### PR TITLE
Catch Exceptions thrown by a @Provides method and wrap them in ProvisionException

### DIFF
--- a/restx-factory/src/main/java/restx/factory/ProvisionException.java
+++ b/restx-factory/src/main/java/restx/factory/ProvisionException.java
@@ -1,0 +1,9 @@
+package restx.factory;
+
+public class ProvisionException extends Exception {
+	private static final long serialVersionUID = 5152263814913048727L;
+
+	public ProvisionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
+++ b/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
@@ -5,6 +5,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.*;
 import com.google.common.io.CharStreams;
+
 import restx.factory.*;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -15,13 +16,16 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
+
 import java.io.*;
 import java.util.Collections;
 import java.util.List;
@@ -99,6 +103,8 @@ public class FactoryAnnotationProcessor extends AbstractProcessor {
                             exec);
 
                     buildInjectableParams(exec, m.parameters);
+                    
+                    buildCheckedExceptions(exec, m.exceptions);
 
                     module.providerMethods.add(m);
                 }
@@ -218,6 +224,14 @@ public class FactoryAnnotationProcessor extends AbstractProcessor {
         return exec;
     }
 
+    private void buildCheckedExceptions(ExecutableElement executableElement, List<String> exceptions) {
+    	for (TypeMirror e : executableElement.getThrownTypes()) {
+    		// Assuming Exceptions never have type arguments. Qualified names include type arguments.
+    		String exception = ((TypeElement) ((DeclaredType) e).asElement()).getQualifiedName().toString();
+    		exceptions.add(exception);
+    	}
+    }
+    
     private void buildInjectableParams(ExecutableElement executableElement, List<InjectableParameter> parameters) {
         for (VariableElement p : executableElement.getParameters()) {
             parameters.add(new InjectableParameter(
@@ -244,6 +258,7 @@ public class FactoryAnnotationProcessor extends AbstractProcessor {
                     .put("queriesDeclarations", Joiner.on("\n").join(buildQueriesDeclarationsCode(method.parameters)))
                     .put("queries", Joiner.on(",\n").join(buildQueriesNames(method.parameters)))
                     .put("parameters", Joiner.on(",\n").join(buildParamFromSatisfiedBomCode(method.parameters)))
+                    .put("exceptions", Joiner.on("\n").join(method.exceptions))
                     .build());
         }
 
@@ -405,6 +420,7 @@ public class FactoryAnnotationProcessor extends AbstractProcessor {
         final String name;
         final Optional<String> injectionName;
         final List<InjectableParameter> parameters = Lists.newArrayList();
+        final List<String> exceptions = Lists.newArrayList();
 
         ProviderMethod(String type, String name, Optional<String> injectionName, Element originatingElement) {
             this.type = type;

--- a/restx-factory/src/main/resources/restx/factory/processor/ModuleMachine.mustache
+++ b/restx-factory/src/main/resources/restx/factory/processor/ModuleMachine.mustache
@@ -22,10 +22,18 @@ public class {{{machine}}} extends DefaultFactoryMachine {
                 }
 
                 @Override
-                public {{{type}}} doNewComponent(SatisfiedBOM satisfiedBOM) {
-                    return module.{{{name}}}(
-        {{{parameters}}}
-                    );
+                public {{{type}}} doNewComponent(SatisfiedBOM satisfiedBOM) {{#exceptions}} throws ProvisionException {{/exceptions}} {
+	                {{#exceptions}}
+                	try {
+	                {{/exceptions}}
+	                    return module.{{{name}}}(
+	        {{{parameters}}}
+	                    );
+	                {{#exceptions}}
+                    } catch ({{{exceptions}}} e) {
+                    	throw new ProvisionException("Could not create component {{{name}}}", e);
+                    }
+	                {{/exceptions}}
                 }
             },
 {{/engines}}


### PR DESCRIPTION
Regarding issue #35, here's a first attempt into detecting which exceptions are declared by a method that is annotated with `@Provides`.

Two points of interest:
1. Any thrown Exceptions are wrapped in a ProvisionException, but that is not caught yet. I'm not too familiar with the restx codebase to know how to handle them.
2. I've made the assumption that Exceptions do not have type parameters. [`TypeElement#getQualifiedName()`](http://docs.oracle.com/javase/7/docs/api/javax/lang/model/element/TypeElement.html#getQualifiedName%28%29) includes type parameters in its String representation of a thrown Exception.
