### PR TITLE
Implements the @Consumes and @Produces annotations (inspired by JAX-RS) for resource methods

### DIFF
--- a/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
+++ b/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
@@ -38,8 +38,8 @@ public class {{{router}}} extends RestxRouter {
             "{{{routerGroup}}}", "{{{router}}}", new RestxRoute[] {
 {{#routes}}
         new StdEntityRoute<{{{inEntity}}}, {{{outEntity}}}>("{{{routeId}}}",
-                readerRegistry.<{{{inEntity}}}>build({{inEntityType}}, Optional.<String>absent()),
-                writerRegistry.<{{{outEntity}}}>build({{outEntityType}}, Optional.<String>absent()),
+                readerRegistry.<{{{inEntity}}}>build({{inEntityType}}, {{{inContentType}}}),
+                writerRegistry.<{{{outEntity}}}>build({{outEntityType}}, {{{outContentType}}}),
                 new StdRestxRequestMatcher("{{{method}}}", "{{{path}}}"),
                 HttpStatus.{{{successStatusName}}}, RestxLogLevel.{{{logLevelName}}}) {
             @Override

--- a/restx-core/src/main/java/restx/annotations/Consumes.java
+++ b/restx-core/src/main/java/restx/annotations/Consumes.java
@@ -1,0 +1,11 @@
+package restx.annotations;
+
+/**
+ * User: eoriou
+ * Date: 03/12/2013
+ * Time: 17:54
+ */
+public @interface Consumes {
+
+    String value();
+}

--- a/restx-core/src/main/java/restx/annotations/Produces.java
+++ b/restx-core/src/main/java/restx/annotations/Produces.java
@@ -1,0 +1,11 @@
+package restx.annotations;
+
+/**
+ * User: eoriou
+ * Date: 03/12/2013
+ * Time: 17:55
+ */
+public @interface Produces {
+
+    String value();
+}

--- a/restx-samplest/md.restx.json
+++ b/restx-samplest/md.restx.json
@@ -14,7 +14,6 @@
             "io.restx:restx-factory:${restx.version}",
             "io.restx:restx-factory-admin:${restx.version}",
             "io.restx:restx-monitor-admin:${restx.version}",
-            "io.restx:restx-log-admin:${restx.version}",
             "io.restx:restx-servlet:${restx.version}",
             "io.restx:restx-server-simple:${restx.version}",
             "io.restx:restx-apidocs:${restx.version}",

--- a/restx-samplest/module.ivy
+++ b/restx-samplest/module.ivy
@@ -19,7 +19,6 @@
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-factory-admin" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-monitor-admin" rev="latest.integration" conf="default" />
-        <dependency org="io.restx" name="restx-log-admin" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-servlet" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-server-simple" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-apidocs" rev="latest.integration" conf="default" />

--- a/restx-samplest/pom.xml
+++ b/restx-samplest/pom.xml
@@ -52,11 +52,6 @@
         </dependency>
         <dependency>
             <groupId>io.restx</groupId>
-            <artifactId>restx-log-admin</artifactId>
-            <version>${restx.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.restx</groupId>
             <artifactId>restx-servlet</artifactId>
             <version>${restx.version}</version>
         </dependency>

--- a/restx-samplest/src/main/java/samplest/domain/Car.java
+++ b/restx-samplest/src/main/java/samplest/domain/Car.java
@@ -1,0 +1,44 @@
+package samplest.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import samplest.serialization.CustomJacksonSerializer;
+
+/**
+ * User: eoriou
+ * Date: 04/12/2013
+ * Time: 11:16
+ */
+
+@JsonSerialize(using = CustomJacksonSerializer.class)
+public class Car {
+
+    private String brand;
+
+    private String model;
+
+    public Car setBrand(final String brand) {
+        this.brand = brand;
+        return this;
+    }
+
+    public Car setModel(final String model) {
+        this.model = model;
+        return this;
+    }
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    @Override
+    public String toString() {
+        return "Car{" +
+                "brand='" + brand + '\'' +
+                ", model='" + model + '\'' +
+                '}';
+    }
+}

--- a/restx-samplest/src/main/java/samplest/resources/CarsResource.java
+++ b/restx-samplest/src/main/java/samplest/resources/CarsResource.java
@@ -1,0 +1,35 @@
+package samplest.resources;
+
+import com.google.common.collect.Lists;
+import restx.annotations.GET;
+import restx.annotations.Produces;
+import restx.annotations.RestxResource;
+import restx.factory.Component;
+import restx.security.PermitAll;
+import samplest.domain.Car;
+
+import java.util.List;
+
+/**
+ * User: eoriou
+ * Date: 04/12/2013
+ * Time: 11:15
+ */
+
+@RestxResource
+@Component
+public class CarsResource {
+
+    @GET("/cars")
+    @Produces("application/json;view=samplest.serialization.Views$Frontal$Details")
+    @PermitAll
+    public List<Car> getCars() {
+
+        return Lists.newArrayList(
+                new Car().setBrand("Brand1").setModel("Model1"),
+                new Car().setBrand("Brand1").setModel("Model2"),
+                new Car().setBrand("Brand2").setModel("Model1"),
+                new Car().setBrand("Brand3").setModel("Model1")
+        );
+    }
+}

--- a/restx-samplest/src/main/java/samplest/serialization/CustomJacksonSerializer.java
+++ b/restx-samplest/src/main/java/samplest/serialization/CustomJacksonSerializer.java
@@ -1,0 +1,26 @@
+package samplest.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import samplest.domain.Car;
+
+import java.io.IOException;
+
+/**
+ * User: eoriou
+ * Date: 04/12/2013
+ * Time: 14:04
+ */
+public class CustomJacksonSerializer extends JsonSerializer<Car> {
+
+    @Override
+    public void serialize(Car value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+        if (provider.getConfig().getActiveView() == Views.Frontal.Details.class) {
+            jgen.writeString("{'status' : 'ok'}");
+        } else {
+            jgen.writeString("{'status' : 'ko'}");
+        }
+    }
+}

--- a/restx-samplest/src/main/java/samplest/serialization/Views.java
+++ b/restx-samplest/src/main/java/samplest/serialization/Views.java
@@ -1,0 +1,18 @@
+package samplest.serialization;
+
+/**
+ * User: eoriou
+ * Date: 04/12/2013
+ * Time: 11:47
+ */
+public class Views {
+
+    public interface Frontal {
+
+        public interface Details {
+
+        }
+
+    }
+
+}

--- a/restx-samplest/src/test/java/resources/ResourceContentTypeTest.java
+++ b/restx-samplest/src/test/java/resources/ResourceContentTypeTest.java
@@ -1,0 +1,34 @@
+package resources;
+
+import com.github.kevinsawicki.http.HttpRequest;
+import org.junit.Test;
+import restx.server.WebServers;
+import restx.server.simple.simple.SimpleWebServer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * User: eoriou
+ * Date: 04/12/2013
+ * Time: 15:52
+ */
+public class ResourceContentTypeTest {
+
+    @Test
+    public void should_retrieve_well_formed_data() throws Exception {
+
+        SimpleWebServer server = SimpleWebServer.builder()
+                .setRouterPath("/api").setPort(WebServers.findAvailablePort()).build();
+        server.start();
+        try {
+
+            HttpRequest httpRequest = HttpRequest.get(server.baseUrl() + "/api/cars");
+            assertThat(httpRequest.code()).isEqualTo(200);
+            assertThat(httpRequest.body().trim()).isEqualTo(
+                    "[\"{'status' : 'ok'}\",\"{'status' : 'ok'}\",\"{'status' : 'ok'}\",\"{'status' : 'ok'}\"]");
+
+        } finally {
+            server.stop();
+        }
+    }
+}


### PR DESCRIPTION
Both annotations can be used onto resource methods and provide a content-type used during marshalling/unmarshalling. They can also provide a Jackson View (especially for JSON Reader/Writer).
