### PR TITLE
Syntax error in generated FactoryMachine when method throws several exception

### DIFF
--- a/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
+++ b/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
@@ -317,7 +317,7 @@ public class FactoryAnnotationProcessor extends AbstractProcessor {
                     .put("queriesDeclarations", Joiner.on("\n").join(buildQueriesDeclarationsCode(method.parameters)))
                     .put("queries", Joiner.on(",\n").join(buildQueriesNames(method.parameters)))
                     .put("parameters", Joiner.on(",\n").join(buildParamFromSatisfiedBomCode(method.parameters)))
-                    .put("exceptions", method.exceptions.isEmpty() ? false : Joiner.on("\n").join(method.exceptions))
+                    .put("exceptions", method.exceptions.isEmpty() ? false : Joiner.on(",\n").join(method.exceptions))
                     .build());
         }
 


### PR DESCRIPTION
I have a module (for the test actually but I assume it'll probably be the same with the real one) which has a method throwing exceptions:

```
@Provides
public ChallengeManager getChallengeManager() throws
                 ChallengeNotFoundException, ParticipationDeniedException {
```

 When building the project I get a syntax error in MockedGuiceModuleFactoryMachine.java:

```
                } catch (net.ggtools.shifumi.domain.ChallengeNotFoundException
net.ggtools.shifumi.domain.ParticipationDeniedException e) {
```

There is no issue if the method only throws one exception.
