### PR TITLE
Delegate the cookie signing to a Signer component.

### DIFF
--- a/restx-core/src/main/java/restx/security/DefaultCookieSigner.java
+++ b/restx-core/src/main/java/restx/security/DefaultCookieSigner.java
@@ -1,0 +1,33 @@
+package restx.security;
+
+import javax.inject.Named;
+
+import com.google.common.base.Optional;
+
+import restx.common.Crypto;
+import restx.factory.Component;
+
+/**
+ * Default cookie signer, using HMAC-SHA1 algorithm to sign the cookie.
+ *
+ * @author apeyrard
+ */
+@Component
+@Named(RestxSessionCookieFilter.COOKIE_SIGNER_NAME)
+public class DefaultCookieSigner implements Signer {
+	private final SignatureKey signatureKey;
+
+	public DefaultCookieSigner(Optional<SignatureKey> signatureKey) {
+		this.signatureKey = signatureKey.or(SignatureKey.DEFAULT);
+	}
+
+	@Override
+	public String sign(String cookie) {
+		return Crypto.sign(cookie, signatureKey.getKey());
+	}
+
+	@Override
+	public boolean verify(String cookie, String signedCookie) {
+		return sign(cookie).equals(signedCookie);
+	}
+}

--- a/restx-core/src/main/java/restx/security/Signer.java
+++ b/restx-core/src/main/java/restx/security/Signer.java
@@ -1,0 +1,24 @@
+package restx.security;
+
+/**
+ * Permits to sign and verify messages.
+ *
+ * @author apeyrard
+ */
+public interface Signer {
+
+	/**
+	 * Sign the specified message.
+	 * @param message The message to sign.
+	 * @return The signed message.
+	 */
+	String sign(String message);
+
+	/**
+	 * Verify if the specified message correspond to the signed one.
+	 * @param message The message to verify.
+	 * @param signedMessage The signed message.
+	 * @return True if the message is corresponding to the signed message, false otherwise.
+	 */
+	boolean verify(String message, String signedMessage);
+}

--- a/restx-core/src/main/java/restx/specs/WhenRestxSessionHeaderLoader.java
+++ b/restx-core/src/main/java/restx/specs/WhenRestxSessionHeaderLoader.java
@@ -1,12 +1,11 @@
 package restx.specs;
 
-import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import restx.security.SignatureKey;
-import restx.common.Crypto;
+
 import restx.factory.Component;
 import restx.security.RestxSessionCookieDescriptor;
+import restx.security.Signer;
 
 /**
  * @author fcamblor
@@ -17,11 +16,11 @@ public class WhenRestxSessionHeaderLoader implements RestxSpecLoader.WhenHeaderL
     private static final Logger logger = LoggerFactory.getLogger(WhenRestxSessionHeaderLoader.class);
 
     private final RestxSessionCookieDescriptor restxSessionCookieDescriptor;
-    private final SignatureKey signature;
+    private final Signer signer;
 
-    public WhenRestxSessionHeaderLoader(RestxSessionCookieDescriptor restxSessionCookieDescriptor, Optional<SignatureKey> signature) {
+    public WhenRestxSessionHeaderLoader(RestxSessionCookieDescriptor restxSessionCookieDescriptor, Signer signer) {
         this.restxSessionCookieDescriptor = restxSessionCookieDescriptor;
-        this.signature = signature.or(SignatureKey.DEFAULT);
+        this.signer = signer;
     }
 
     @Override
@@ -39,6 +38,6 @@ public class WhenRestxSessionHeaderLoader implements RestxSpecLoader.WhenHeaderL
         }
 
         whenHttpRequestBuilder.addCookie(restxSessionCookieDescriptor.getCookieName(), sessionContent);
-        whenHttpRequestBuilder.addCookie(restxSessionCookieDescriptor.getCookieSignatureName(), Crypto.sign(sessionContent, signature.getKey()));
+        whenHttpRequestBuilder.addCookie(restxSessionCookieDescriptor.getCookieSignatureName(), signer.sign(sessionContent));
     }
 }

--- a/restx-specs-tests/src/main/java/restx/tests/HttpTestClient.java
+++ b/restx-specs-tests/src/main/java/restx/tests/HttpTestClient.java
@@ -1,18 +1,18 @@
 package restx.tests;
 
-import com.github.kevinsawicki.http.HttpRequest;
-import com.google.common.collect.ImmutableMap;
-import org.joda.time.DateTime;
-import restx.RestxMainRouterFactory;
-import restx.common.Crypto;
-import restx.common.UUIDGenerator;
-import restx.factory.Factory;
-import restx.security.RestxSessionCookieDescriptor;
-import restx.security.SignatureKey;
+import static restx.RestxMainRouterFactory.Blade;
 
 import java.util.Map;
 
-import static restx.RestxMainRouterFactory.Blade;
+import org.joda.time.DateTime;
+
+import com.github.kevinsawicki.http.HttpRequest;
+import com.google.common.collect.ImmutableMap;
+
+import restx.common.UUIDGenerator;
+import restx.factory.Factory;
+import restx.security.RestxSessionCookieDescriptor;
+import restx.security.Signer;
 
 /**
  * HttpTestClient is a helper to create com.github.kevinsawicki.http.HttpRequest
@@ -43,7 +43,7 @@ public class HttpTestClient {
     public HttpTestClient authenticatedAs(String principal) {
         Factory factory = Factory.newInstance();
         RestxSessionCookieDescriptor restxSessionCookieDescriptor = factory.getComponent(RestxSessionCookieDescriptor.class);
-        SignatureKey signature = factory.queryByClass(SignatureKey.class).findOneAsComponent().or(SignatureKey.DEFAULT);
+        Signer signer = factory.queryByClass(Signer.class).findOneAsComponent().get();
 
         ImmutableMap.Builder<String, String> cookiesBuilder = ImmutableMap.<String, String>builder().putAll(cookies);
         String uuid = factory.getComponent(UUIDGenerator.class).doGenerate();
@@ -51,7 +51,7 @@ public class HttpTestClient {
         String sessionContent = String.format(
                 "{\"_expires\":\"%s\",\"principal\":\"%s\",\"sessionKey\":\"%s\"}", expires, principal, uuid);
         cookiesBuilder.put(restxSessionCookieDescriptor.getCookieName(), sessionContent);
-        cookiesBuilder.put(restxSessionCookieDescriptor.getCookieSignatureName(), Crypto.sign(sessionContent, signature.getKey()));
+        cookiesBuilder.put(restxSessionCookieDescriptor.getCookieSignatureName(), signer.sign(sessionContent));
 
         return new HttpTestClient(baseUrl, principal, cookiesBuilder.build());
     }


### PR DESCRIPTION
Add a new concept of "signer" in order to delegate the process of cookie signing, and cookie signature check.

The cookie filter will no more do this work, but delegates signing and signature verification to its injected signer.

Create a DefaultCookieSigner component which use the existing SignatureKey in order to stay compatible with previous releases.
The DefaultCookieSigner get the signature key by dependency injection and use the HMAC-SHA1 algorithm (defined in Crypto class) to sign the cookie.

I wasn't sure about the fact of giving a name to the injected Signer in RestxSessionCookieFilter. But as I think an application might have multiple signers, I defined it.
For the same reason the signature injected in DefaultCookieSigner might be named too ?!
