### PR TITLE
Minor improvements on the admin-ui login page.

### DIFF
--- a/restx-admin/src/main/resources/restx/admin/js/login.js
+++ b/restx-admin/src/main/resources/restx/admin/js/login.js
@@ -5,8 +5,8 @@ angular.module('admin').factory('baseUri', function() {
 });
 
 angular.module('admin').controller('LoginController', function($scope, baseUri, $http) {
-    $scope.authenticate = function(username, password) {
-        $http.post(baseUri + '/sessions', {principal: {name: username, passwordHash: SparkMD5.hash(password)}})
+    $scope.authenticate = function() {
+        $http.post(baseUri + '/sessions', {principal: {name: $scope.username, passwordHash: SparkMD5.hash($scope.password)}})
             .success(function(data, status, headers, config) {
                 console.log('authenticated', data, status);
                 window.location = $.querystring('backTo') || (baseUri + '/@/ui/');
@@ -15,4 +15,19 @@ angular.module('admin').controller('LoginController', function($scope, baseUri, 
                 alertify.success("Authentication error, please try again.");
             });;
     }
+});
+
+angular.module('admin').directive('formAutofillFix', function($timeout) {
+    return function(scope, elem, attrs) {
+        // Fix autofill issues where Angular doesn't know about autofilled inputs
+        if(attrs.ngSubmit) {
+            $timeout(function() {
+                elem.unbind('submit').submit(function(e) {
+                    e.preventDefault();
+                    elem.find('input, textarea, select').trigger('input').trigger('change').trigger('keydown');
+                    scope.$apply(attrs.ngSubmit);
+                });
+            });
+        }
+    };
 });

--- a/restx-admin/src/main/resources/restx/admin/login.html
+++ b/restx-admin/src/main/resources/restx/admin/login.html
@@ -15,7 +15,7 @@
     <div class="container">
         <div class="row">
             <div class="span12">
-                <form class="form-horizontal" action='' method="POST">
+                <form ng-submit="authenticate()" class="form-horizontal" action='' method="POST" form-autofill-fix>
                   <fieldset>
                     <div id="legend">
                       <legend class="">Login to RESTX Admin console</legend>
@@ -24,7 +24,7 @@
                       <!-- Username -->
                       <label class="control-label"  for="username">Username</label>
                       <div class="controls">
-                        <input type="text" id="username" name="username" placeholder="" class="input-xlarge" ng-model="username">
+                        <input type="text" id="username" name="username" placeholder="" class="input-xlarge" ng-model="username" autofocus>
                       </div>
                     </div>
 
@@ -40,7 +40,7 @@
                     <div class="control-group">
                       <!-- Button -->
                       <div class="controls">
-                        <button class="btn btn-success" ng-click="authenticate(username, password)">Login</button>
+                        <button class="btn btn-success" type="submit">Login</button>
                       </div>
                     </div>
                   </fieldset>


### PR DESCRIPTION
- Correct the bug with browser autofill (This bug is due to a known bug of angularjs https://github.com/angular/angular.js/issues/1460, but as the correction is a little bit too much code to add, I prefer a less verbose solution found there: http://victorblog.com/2014/01/12/fixing-autocomplete-autofill-on-angularjs-form-submit/).
- Default focus on the username input (using the html5 attribute autofocus).
- Change login button type to "submit" in order to be able to validate the form with the enter key.

(I didn't knew if I needed to add an issue, and submit the PR for the related issue ?!)
