### PR TITLE
Modify jetty max threads

### DIFF
--- a/restx-server-jetty/src/main/java/restx/server/JettyWebServer.java
+++ b/restx-server-jetty/src/main/java/restx/server/JettyWebServer.java
@@ -113,7 +113,7 @@ public class JettyWebServer implements WebServer {
     private ThreadPool createThreadPool() {
         QueuedThreadPool threadPool = new QueuedThreadPool();
         threadPool.setMinThreads(1);
-        threadPool.setMaxThreads(10);
+        threadPool.setMaxThreads(Math.max(10, Runtime.getRuntime().availableProcessors()));
         return threadPool;
     }
 


### PR DESCRIPTION
Hi, 

If you run tests on a server with more than 10 CPUs, jetty blocks. MaxThreads must be at least equal to the number of CPU.

> > starting server
> > 2014-03-28 10:22:40,217 [main            ] [          ] INFO  org.eclipse.jetty.server.Server - jetty-8.1.8.v20121106
> > LoginService=HashLoginService[null] identityService=org.eclipse.jetty.security.DefaultIdentityService@7907f014
> > 2014-03-28 10:22:40,449 [main            ] [          ] INFO  restx.RestxMainRouterFactory - LOADING MAIN ROUTER
> > 2014-03-28 10:22:40,450 [main            ] [          ] INFO  restx.RestxMainRouterFactory -
> > 
> >  -- RESTX >> LOAD ON REQUEST << >> CLEAN << >> TEST MODE <<
> >  -- for admin console,
> >  --   VISIT http://127.0.0.1:43551/api/@/ui/
> >  --
> > 
> > 2014-03-28 10:22:40,547 [main            ] [          ] WARN  o.e.jetty.server.AbstractConnector - insufficient threads configured for SelectChannelConnector@0.0.0.0:43551
> > server started
> > 
> > >> REQUEST
> > GET http://127.0.0.1:43551/api/samples (infinite wait)
