### PR TITLE
Digits in path params

### DIFF
--- a/restx-core/src/main/java/restx/StdRestxRequestMatcher.java
+++ b/restx-core/src/main/java/restx/StdRestxRequestMatcher.java
@@ -164,11 +164,11 @@ public class StdRestxRequestMatcher implements RestxRequestMatcher {
                     inRegexDef = true;
                     pathParamRegex.append("(");
                 } else {
-                    if (!Character.isLetter(curChar)) {
+                    if (!Character.isLetterOrDigit(curChar)) {
                         //only letters are authorized in path param name
                         throw new IllegalArgumentException(String.format(
                                 "illegal path parameter definition '%s' at offset %d" +
-                                        " - only letters are authorized in path param name",
+                                        " - only letters and digits are authorized in path param name",
                                 pathPatternParser.pathPattern, pathPatternParser.offset));
                     } else {
                         pathParamName.appendCodePoint(curChar);

--- a/restx-core/src/test/java/restx/StdRestxRequestMatcherTest.java
+++ b/restx-core/src/test/java/restx/StdRestxRequestMatcherTest.java
@@ -61,11 +61,11 @@ public class StdRestxRequestMatcherTest {
 
     @Test
     public void should_matcher_with_several_path_params_match_not_match() throws Exception {
-        StdRestxRequestMatcher matcher = new StdRestxRequestMatcher("GET", "/user/{name}/children/{child}");
+        StdRestxRequestMatcher matcher = new StdRestxRequestMatcher("GET", "/user/{name}/children/{child1}/{child2}");
 
-        Optional<? extends RestxRequestMatch> match = matcher.match("GET", "/user/johndoe/children/bobby");
+        Optional<? extends RestxRequestMatch> match = matcher.match("GET", "/user/johndoe/children/bobby/drake");
         assertThat(match.isPresent()).isTrue();
-        assertThat(match.get().getPathParams()).isEqualTo(ImmutableMap.of("name", "johndoe", "child", "bobby"));
+        assertThat(match.get().getPathParams()).isEqualTo(ImmutableMap.of("name", "johndoe", "child1", "bobby", "child2", "drake"));
 
         match = matcher.match("GET", "/user/johndoe");
         assertThat(match.isPresent()).isFalse();


### PR DESCRIPTION
We cannot pass any number as path parameter variable names.

These changes allow it.
