### PR TITLE
Allowing to configure router path when using RestxSpecTestsRunner

### DIFF
--- a/restx-specs-tests/src/main/java/restx/tests/FindSpecsIn.java
+++ b/restx-specs-tests/src/main/java/restx/tests/FindSpecsIn.java
@@ -9,4 +9,5 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface FindSpecsIn {
     String value();
+    String withRouterPath() default "/api";
 }

--- a/restx-specs-tests/src/main/java/restx/tests/RestxSpecRule.java
+++ b/restx-specs-tests/src/main/java/restx/tests/RestxSpecRule.java
@@ -28,6 +28,13 @@ public class RestxSpecRule extends RestxServerRule {
     }
 
     /**
+     * A shortcut for new RestxSpecRule(routerPath, queryByClass(WebServerSupplier.class), Factory.getInstance())
+     */
+    public RestxSpecRule(String routerPath) {
+        this(routerPath, Factory.getInstance().queryByClass(WebServerSupplier.class).findOne().get().getComponent(), Factory.getInstance());
+    }
+
+    /**
      * A shortcut for new RestxSpecRule("/api", webServerSupplier, Factory.getInstance())
      */
     public RestxSpecRule(WebServerSupplier webServerSupplier) {

--- a/restx-specs-tests/src/main/java/restx/tests/RestxSpecTestsRunner.java
+++ b/restx-specs-tests/src/main/java/restx/tests/RestxSpecTestsRunner.java
@@ -48,7 +48,7 @@ public class RestxSpecTestsRunner extends ParentRunner<RestxSpec> {
         super(testClass);
         FindSpecsIn findSpecsIn = getTestClass().getJavaClass().getAnnotation(FindSpecsIn.class);
         if (findSpecsIn != null) {
-            tests = new RestxSpecTests(new RestxSpecRule(), RestxSpecTests.findSpecsIn(findSpecsIn.value()));
+            tests = new RestxSpecTests(new RestxSpecRule(findSpecsIn.withRouterPath()), RestxSpecTests.findSpecsIn(findSpecsIn.value()));
         } else {
             Object o = getTestClass().getOnlyConstructor().newInstance();
             if (!(o instanceof RestxSpecTests)) {


### PR DESCRIPTION
ATM, if we don't use `/api` as the router path, there isn't any possibility to change this hardcoded value during execution of spec tests.

Workaround here is to pass this router path through `@FindSpecsIn` annotation :

```
@RunWith(RestxSpecTestsRunner.class)
@FindSpecsIn(value="specs", withRouterPath="/")
public class SpecsTests {
}
```
