### PR TITLE
Allow to set a value prepended to all metrics names which are sent to graphite

### DIFF
--- a/restx-monitor-admin/src/main/java/restx/monitor/GraphiteSettings.java
+++ b/restx-monitor-admin/src/main/java/restx/monitor/GraphiteSettings.java
@@ -20,4 +20,7 @@ public interface GraphiteSettings {
     Optional<Integer> getFrequency();
     @SettingsKey(key = "graphite.reporter.frequency.unit", doc = "the unit in which frequency is expressed", defaultValue = "MINUTES")
     Optional<String> getFrequencyUnit();
+
+    @SettingsKey(key = "graphite.prefix", doc = "the value prepended to all metrics names which are sent to graphite")
+    Optional<String> getPrefix();
 }

--- a/restx-monitor-admin/src/main/java/restx/monitor/MetricsConfiguration.java
+++ b/restx-monitor-admin/src/main/java/restx/monitor/MetricsConfiguration.java
@@ -80,7 +80,16 @@ public class MetricsConfiguration implements AutoStartable {
             InetSocketAddress address = new InetSocketAddress(
                     graphiteSettings.getGraphiteHost().get(), graphiteSettings.getGraphitePort().or(2003));
             logger.info("Initializing Metrics Graphite reporting to {}", address);
-            GraphiteReporter graphiteReporter = GraphiteReporter.forRegistry(metrics)
+
+            GraphiteReporter.Builder builder = GraphiteReporter.forRegistry(metrics);
+
+            if (graphiteSettings.getPrefix().isPresent()) {
+                String prefix = graphiteSettings.getPrefix().get();
+                builder.prefixedWith(prefix);
+                logger.info("Metrics Graphite prefix is set to '{}'", prefix);
+            }
+
+            GraphiteReporter graphiteReporter = builder
                     .convertRatesTo(TimeUnit.SECONDS)
                     .convertDurationsTo(TimeUnit.MILLISECONDS)
                     .build(new Graphite(address));


### PR DESCRIPTION
In case there is more than one instance of restx in the same environnement, it could be interesting to set a value prepended to metrics names in order to distinguish them on graphite reporting (the hostname for instance).
