### PR TITLE
@ValidatedFor annotation support for validation groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ Main modules:
 - `restx-factory-testing`: A module dedicated to test `restx-factory` features involving annotation processing.
 - `restx-classloader`: Hot reload / hot compile support
 - `restx-build`: The very simple tool which generates POM / Ivy files from `md.restx.json` files
-- `restx-core`: Core module, includes the REST framework, base security, JSON support, Validation, ...
+- `restx-core`: Core module, includes the REST framework, base security, JSON support, ...
 - `restx-core-annotation-processor`: Annotation processing to generate routers based on RESTX core annotations. Needed at build time only.
 - `restx-security-basic`: A basic implementation of security, still enough in many cases.
 - `restx-specs-tests`: Enables using RESTX specs as JUnit tests.
 - `restx-specs-server`: Enables using RESTX specs as HTTP mocks.
 - `restx-i18n`: I18n Support
+- `restx-validation`: Bean validation support (based on `hibernate-validator` implementation) for POJOs BODY parameters & query parameters
 
 Admin console modules:
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
         <module>restx-shell-manager</module>
         <module>restx-build-shell</module>
         <module>restx-specs-shell</module>
+        <module>restx-validation</module>
     </modules>
 
 

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/Annotations.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/Annotations.java
@@ -1,0 +1,38 @@
+package restx.annotations;
+
+import com.sun.tools.javac.code.Attribute;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author fcamblor
+ */
+public class Annotations {
+    public static String[] getAnnotationClassValuesAsFQCN(VariableElement p, Class annotationClazz, String methodName) {
+        List<? extends AnnotationMirror> annotationMirrors = p.getAnnotationMirrors();
+        for(AnnotationMirror annotationMirror : annotationMirrors){
+            if(annotationMirror.getAnnotationType().toString().equals(annotationClazz.getCanonicalName())){
+                for(Map.Entry<? extends ExecutableElement,? extends AnnotationValue> entry : annotationMirror.getElementValues().entrySet()){
+                    if(entry.getKey().getSimpleName().contentEquals(methodName)){
+                        Attribute.Array array = (Attribute.Array) entry.getValue();
+
+                        List<String> fqcns = new ArrayList<>();
+                        for(Attribute attribute : array.getValue()) {
+                            DeclaredType type = (DeclaredType) attribute.getValue();
+                            fqcns.add(type.toString());
+                        }
+                        return fqcns.toArray(new String[fqcns.size()]);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -176,7 +176,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
 
             String[] validationGroups = new String[0];
             if(validatedFor != null) {
-                validationGroups = Collections2.transform(Arrays.asList(validatedFor.value()), FQN_EXTRACTOR).toArray(new String[0]);
+                validationGroups = Annotations.getAnnotationClassValuesAsFQCN(p, ValidatedFor.class, "value");
             }
 
             resourceMethod.parameters.add(new ResourceMethodParameter(

--- a/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
+++ b/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
@@ -32,7 +32,7 @@ public class {{router}} extends RestxRouter {
                     final EntityRequestBodyReaderRegistry readerRegistry,
                     final EntityResponseWriterRegistry writerRegistry,
                     final MainStringConverter converter,
-                    final Validator validator,
+                    final Optional<Validator> validator,
                     final RestxSecurityManager securityManager) {
         super(
             "{{routerGroup}}", "{{router}}", new RestxRoute[] {

--- a/restx-core/pom.xml
+++ b/restx-core/pom.xml
@@ -25,7 +25,7 @@
         <joda-time.version>2.3</joda-time.version>
         <jackson.version>2.3.3</jackson.version>
         <snakeyaml.version>1.13</snakeyaml.version>
-        <hibernate-validator.version>5.0.1.Final</hibernate-validator.version>
+        <validation-api.version>1.1.0.Final</validation-api.version>
         <reflections.version>0.9.9-RC1</reflections.version>
         <javax.inject.version>1</javax.inject.version>
         <junit.version>4.11</junit.version>
@@ -94,9 +94,9 @@
             <version>${slf4j-api.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate-validator.version}</version>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>${validation-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/restx-core/src/main/java/restx/validation/ValidatedFor.java
+++ b/restx-core/src/main/java/restx/validation/ValidatedFor.java
@@ -1,0 +1,13 @@
+package restx.validation;
+
+import java.lang.annotation.*;
+
+/**
+ * @author fcamblor
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ValidatedFor {
+    Class[] value();
+}

--- a/restx-core/src/main/java/restx/validation/Validations.java
+++ b/restx-core/src/main/java/restx/validation/Validations.java
@@ -5,6 +5,7 @@ import com.google.common.base.Optional;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
+import javax.validation.groups.Default;
 import java.util.Set;
 
 /**
@@ -13,9 +14,13 @@ import java.util.Set;
  * Time: 9:57 PM
  */
 public class Validations {
-    public static <T> T checkValid(Optional<Validator> validator, T o) {
+    public static <T> T checkValid(Optional<Validator> validator, T o, Class... groups) {
         if(validator.isPresent()) {
-            Set<ConstraintViolation<T>> violations = validator.get().validate(o);
+            if(groups == null || groups.length==0) {
+                groups = new Class[]{ Default.class };
+            }
+
+            Set<ConstraintViolation<T>> violations = validator.get().validate(o, groups);
             if (!violations.isEmpty()) {
                 throw new IllegalArgumentException(Joiner.on(", ").join(violations));
             }

--- a/restx-core/src/main/java/restx/validation/Validations.java
+++ b/restx-core/src/main/java/restx/validation/Validations.java
@@ -14,6 +14,15 @@ import java.util.Set;
  * Time: 9:57 PM
  */
 public class Validations {
+
+    /**
+     * @deprecated Kept for backward compat. Use checkValid(Optional&lt;Validator&gt;, T, Class...) instead
+     */
+    @Deprecated
+    public static <T> T checkValid(Validator validator, T o) {
+        return checkValid(Optional.of(validator), o);
+    }
+
     public static <T> T checkValid(Optional<Validator> validator, T o, Class... groups) {
         if(validator.isPresent()) {
             if(groups == null || groups.length==0) {

--- a/restx-core/src/main/java/restx/validation/Validations.java
+++ b/restx-core/src/main/java/restx/validation/Validations.java
@@ -1,6 +1,7 @@
 package restx.validation;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
@@ -12,11 +13,14 @@ import java.util.Set;
  * Time: 9:57 PM
  */
 public class Validations {
-    public static <T> T checkValid(Validator validator, T o) {
-        Set<ConstraintViolation<T>> violations = validator.validate(o);
-        if (!violations.isEmpty()) {
-            throw new IllegalArgumentException(Joiner.on(", ").join(violations));
+    public static <T> T checkValid(Optional<Validator> validator, T o) {
+        if(validator.isPresent()) {
+            Set<ConstraintViolation<T>> violations = validator.get().validate(o);
+            if (!violations.isEmpty()) {
+                throw new IllegalArgumentException(Joiner.on(", ").join(violations));
+            }
         }
+
         return o;
     }
 }

--- a/restx-core/src/main/java/restx/validation/stereotypes/FormValidations.java
+++ b/restx-core/src/main/java/restx/validation/stereotypes/FormValidations.java
@@ -6,6 +6,9 @@ import javax.validation.groups.Default;
  * @author fcamblor
  */
 public interface FormValidations {
+    public static final String DefaultFQN = "javax.validation.groups.Default";
+    public static final String CreateFQN = "restx.validation.stereotypes.FormValidations.Create";
     public static interface Create extends Default{}
+    public static final String UpdateFQN = "restx.validation.stereotypes.FormValidations.Update";
     public static interface Update extends Default{}
 }

--- a/restx-core/src/main/java/restx/validation/stereotypes/FormValidations.java
+++ b/restx-core/src/main/java/restx/validation/stereotypes/FormValidations.java
@@ -1,0 +1,11 @@
+package restx.validation.stereotypes;
+
+import javax.validation.groups.Default;
+
+/**
+ * @author fcamblor
+ */
+public interface FormValidations {
+    public static interface Create extends Default{}
+    public static interface Update extends Default{}
+}

--- a/restx-samplest/pom.xml
+++ b/restx-samplest/pom.xml
@@ -133,6 +133,20 @@
                     <additionalparam>-restx-target-dir ${project.basedir}/target/classes</additionalparam>
                 </configuration>
             </plugin>
+            <!-- Uncomment to debug annotation processing on samplest...
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <verbose>true</verbose>
+                    <fork>true</fork>
+                    <compilerArgs>
+                        <arg>-J-Xdebug</arg>
+                        <arg>-J-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            -->
         </plugins>
     </build>
 </project>

--- a/restx-samplest/pom.xml
+++ b/restx-samplest/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
         <dependency>
             <groupId>io.restx</groupId>
+            <artifactId>restx-validation</artifactId>
+            <version>${restx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.restx</groupId>
             <artifactId>restx-core-annotation-processor</artifactId>
             <version>${restx.version}</version>
         </dependency>

--- a/restx-samplest/src/main/java/samplest/validation/POJO.java
+++ b/restx-samplest/src/main/java/samplest/validation/POJO.java
@@ -1,0 +1,52 @@
+package samplest.validation;
+
+import org.hibernate.validator.constraints.Email;
+import restx.validation.stereotypes.FormValidations;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class POJO {
+    @NotNull(groups={FormValidations.Update.class})
+    Long id;
+    @NotNull
+    @Size(min=10, groups={ValidationResource.MyCustomValidationGroup.class})
+    String name;
+    @Valid
+    SubPOJO subPOJO;
+    @Email
+    String email;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public SubPOJO getSubPOJO() {
+        return subPOJO;
+    }
+
+    public void setSubPOJO(SubPOJO subPOJO) {
+        this.subPOJO = subPOJO;
+    }
+}

--- a/restx-samplest/src/main/java/samplest/validation/SubPOJO.java
+++ b/restx-samplest/src/main/java/samplest/validation/SubPOJO.java
@@ -1,0 +1,16 @@
+package samplest.validation;
+
+import javax.validation.constraints.Size;
+
+public class SubPOJO {
+    @Size(min=10)
+    String label;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+}

--- a/restx-samplest/src/main/java/samplest/validation/ValidationResource.java
+++ b/restx-samplest/src/main/java/samplest/validation/ValidationResource.java
@@ -1,0 +1,41 @@
+package samplest.validation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import restx.annotations.POST;
+import restx.annotations.PUT;
+import restx.annotations.Param;
+import restx.annotations.RestxResource;
+import restx.factory.Component;
+import restx.security.PermitAll;
+import restx.validation.ValidatedFor;
+import restx.validation.stereotypes.FormValidations;
+
+/**
+ * @author fcamblor
+ */
+@RestxResource @Component
+public class ValidationResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ValidationResource.class);
+
+    public static interface MyCustomValidationGroup{}
+
+    @PermitAll
+    @POST("/valid/pojos")
+    public void createPOJOWithoutAnnotation(POJO myPojo) {
+        LOG.info("Pojo {} {} created !", myPojo.getName(), myPojo.getSubPOJO().getLabel());
+    }
+
+    @PermitAll
+    @POST("/valid/pojos2")
+    public void createPOJOWithAnnotation(@ValidatedFor(FormValidations.Create.class) POJO myPojo) {
+        LOG.info("Pojo {} {} created !", myPojo.getName(), myPojo.getSubPOJO().getLabel());
+    }
+
+    @PermitAll
+    @PUT("/valid/pojos/{id}")
+    public void createPOJOWithoutAnnotation(Long id, @ValidatedFor({MyCustomValidationGroup.class, FormValidations.Update.class}) POJO myPojo) {
+        LOG.info("Pojo {} {} updated !", myPojo.getName(), myPojo.getSubPOJO().getLabel());
+    }
+}

--- a/restx-samplest/src/main/resources/specs/core/Hello_msg_20140427_170121.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/core/Hello_msg_20140427_170121.spec.yaml
@@ -1,0 +1,11 @@
+title: Hello msg 20140427 170121
+given:
+  - time: 2014-04-27T17:01:21.795+02:00
+wts:
+  - when: |
+       GET core/hellomsg?who=xavier
+       Cookie: RestxSession={"_expires":"2014-05-27T17:01:21.795+02:00","principal":"admin","sessionKey":"81b92e9b-49eb-4c54-9c78-79a4a79feae5"}; RestxSessionSignature=g3KnRfPE2SAaoXbR3Iq7XHv5L3M=
+    then: |
+        {
+          "msg" : "hello xavier"
+        }

--- a/restx-samplest/src/main/resources/specs/validation/createPOJO_ko.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/validation/createPOJO_ko.spec.yaml
@@ -1,0 +1,34 @@
+title: Create Validation POJO - KO
+given:
+  - time: 2014-12-24T17:01:21.795+02:00
+wts:
+  - when: |
+       POST valid/pojos
+       {"email": "toto@acme.com", "subPOJO": { "label": "a very long label" }}
+    then: |
+       400
+  - when: |
+       POST valid/pojos
+       {"name": "blah", "email": "toto", "subPOJO": { "label": "a very long label" }}
+    then: |
+       400
+  - when: |
+       POST valid/pojos
+       {"name": "blah", "email": "toto@acme.com", "subPOJO": { "label": "a label" }}
+    then: |
+       400
+  - when: |
+       POST valid/pojos2
+       {"email": "toto@acme.com", "subPOJO": { "label": "a very long label" }}
+    then: |
+       400
+  - when: |
+       POST valid/pojos2
+       {"name": "blah", "email": "toto", "subPOJO": { "label": "a very long label" }}
+    then: |
+       400
+  - when: |
+       POST valid/pojos2
+       {"name": "blah", "email": "toto@acme.com", "subPOJO": { "label": "a label" }}
+    then: |
+       400

--- a/restx-samplest/src/main/resources/specs/validation/createPOJO_ok.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/validation/createPOJO_ok.spec.yaml
@@ -1,0 +1,14 @@
+title: Create Validation POJO - OK
+given:
+  - time: 2014-12-24T17:01:21.795+02:00
+wts:
+  - when: |
+       POST valid/pojos
+       {"name": "blah", "email": "toto@acme.com", "subPOJO": { "label": "a very long label" }}
+    then: |
+       204
+  - when: |
+       POST valid/pojos2
+       {"name": "blah", "email": "toto@acme.com", "subPOJO": { "label": "a very long label" }}
+    then: |
+       204

--- a/restx-samplest/src/main/resources/specs/validation/updatePOJO_ko.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/validation/updatePOJO_ko.spec.yaml
@@ -1,0 +1,24 @@
+title: Update Validation POJO - KO
+given:
+  - time: 2014-12-24T17:01:21.795+02:00
+wts:
+  - when: |
+       PUT valid/pojos/123
+       {"name": "a very long name", "email": "toto@acme.com", "subPOJO": { "label": "a very long label" }}
+    then: |
+       400
+  - when: |
+       PUT valid/pojos/123
+       {"id": 123, "name": "a name", "email": "toto@acme.com", "subPOJO": { "label": "a very long label" }}
+    then: |
+       400
+  - when: |
+       PUT valid/pojos/123
+       {"id": 123, "name": "a very long name", "email": "toto", "subPOJO": { "label": "a very long label" }}
+    then: |
+       400
+  - when: |
+       PUT valid/pojos/123
+       {"id": 123, "name": "a very long name", "email": "toto@acme.com", "subPOJO": { "label": "a label" }}
+    then: |
+       400

--- a/restx-samplest/src/main/resources/specs/validation/updatePOJO_ok.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/validation/updatePOJO_ok.spec.yaml
@@ -1,0 +1,9 @@
+title: Create Validation POJO - OK
+given:
+  - time: 2014-12-24T17:01:21.795+02:00
+wts:
+  - when: |
+       PUT valid/pojos/123
+       {"id": 123, "name": "a very long name", "email": "toto@acme.com", "subPOJO": { "label": "a very long label" }}
+    then: |
+       204

--- a/restx-samplest/src/test/java/samplest/validation/ValidationResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/validation/ValidationResourceTest.java
@@ -1,0 +1,13 @@
+package samplest.validation;
+
+import org.junit.runner.RunWith;
+import restx.tests.FindSpecsIn;
+import restx.tests.RestxSpecTestsRunner;
+
+/**
+ * @author fcamblor
+ */
+@RunWith(RestxSpecTestsRunner.class)
+@FindSpecsIn("specs/validation")
+public class ValidationResourceTest {
+}

--- a/restx-validation/md.restx.json
+++ b/restx-validation/md.restx.json
@@ -1,0 +1,19 @@
+{
+    "parent": "io.restx:restx-parent:${restx.version}",
+    "module": "io.restx:restx-validation:${restx.version}",
+
+    "properties": {
+        "@files": ["../restx.build.properties.json"]
+    },
+
+    "dependencies": {
+        "compile": [
+            "io.restx:restx-factory:${restx.version}",
+            "org.hibernate:hibernate-validator:${hibernate-validator.version}",
+            "javax.el:el-api:${el.api.version}"
+        ],
+        "runtime": [
+            "org.glassfish.web:el-impl:${el.api.version}"
+        ]
+    }
+}

--- a/restx-validation/module.ivy
+++ b/restx-validation/module.ivy
@@ -1,0 +1,22 @@
+<ivy-module version="2.0" xmlns:ea="http://www.easyant.org">
+    <info organisation="io.restx" module="restx-validation" revision="0.34" status="integration">
+        <ea:build organisation="org.apache.easyant.buildtypes" module="build-std-java" revision="0.9"
+            compile.java.source.version="1.7"
+            compile.java.target.version="1.7"
+        />
+    </info>
+    <configurations>
+        <conf name="default"/>
+        <conf name="runtime"/>
+        <conf name="test"/>
+    </configurations>
+    <publications>
+        <artifact type="jar"/>
+    </publications>
+    <dependencies>
+        <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
+        <dependency org="org.hibernate" name="hibernate-validator" rev="5.0.1.Final" conf="default" />
+        <dependency org="javax.el" name="el-api" rev="2.2" conf="default" />
+        <dependency org="org.glassfish.web" name="el-impl" rev="2.2" conf="runtime->default" />
+    </dependencies>
+</ivy-module>

--- a/restx-validation/pom.xml
+++ b/restx-validation/pom.xml
@@ -20,6 +20,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <maven.compiler.source>1.7</maven.compiler.source>
         <hibernate-validator.version>5.0.1.Final</hibernate-validator.version>
+        <el.api.version>2.2</el.api.version>
     </properties>
 
     <dependencies>
@@ -32,6 +33,22 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate-validator.version}</version>
+            <!--
+            Using compile scope here, and not runtime, because we may need to use some
+             hibernate-validator specific annotations (like @Email)
+            -->
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>el-api</artifactId>
+            <version>${el.api.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.web</groupId>
+          <artifactId>el-impl</artifactId>
+          <version>${el.api.version}</version>
+          <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/restx-validation/pom.xml
+++ b/restx-validation/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.restx</groupId>
+        <artifactId>restx-parent</artifactId>
+        <version>0.34-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.restx</groupId>
+    <artifactId>restx-validation</artifactId>
+    <version>0.34-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>restx-validation</name>
+
+    <properties>
+        <restx.version>0.34-SNAPSHOT</restx.version>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <hibernate-validator.version>5.0.1.Final</hibernate-validator.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.restx</groupId>
+            <artifactId>restx-factory</artifactId>
+            <version>${restx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/restx-validation/src/main/java/restx/validation/ValidatorFactory.java
+++ b/restx-validation/src/main/java/restx/validation/ValidatorFactory.java
@@ -16,7 +16,7 @@ import javax.validation.Validator;
  */
 @Module
 public class ValidatorFactory {
-    public static final String VALIDATOR_NAME = "validator";
+    public static final String VALIDATOR_NAME = "hibernate.validator";
     public static final Name<Validator> VALIDATOR = Name.of(Validator.class, VALIDATOR_NAME);
 
     @Provides @Named(VALIDATOR_NAME)

--- a/restx-validation/src/main/java/restx/validation/ValidatorFactory.java
+++ b/restx-validation/src/main/java/restx/validation/ValidatorFactory.java
@@ -1,6 +1,7 @@
 package restx.validation;
 
 import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
 import restx.factory.Module;
 import restx.factory.Name;
 import restx.factory.Provides;
@@ -17,11 +18,21 @@ import javax.validation.Validator;
 @Module
 public class ValidatorFactory {
     public static final String VALIDATOR_NAME = "hibernate.validator";
+    public static final String IGNORE_XML_CONFIGURATION_NAME = "hibernate.validator.ignore.xml.configuration";
     public static final Name<Validator> VALIDATOR = Name.of(Validator.class, VALIDATOR_NAME);
 
     @Provides @Named(VALIDATOR_NAME)
-    public Validator validator() {
-        return Validation.byProvider(HibernateValidator.class).configure()
-                        .ignoreXmlConfiguration().buildValidatorFactory().getValidator();
+    public Validator validator(@Named(IGNORE_XML_CONFIGURATION_NAME) Boolean ignoreXmlConfiguration) {
+        HibernateValidatorConfiguration config = Validation.byProvider(HibernateValidator.class).configure();
+        if(ignoreXmlConfiguration) {
+            config.ignoreXmlConfiguration();
+        }
+        return config.buildValidatorFactory().getValidator();
+    }
+
+    // Perf improvement to greatly fasten startup time
+    @Provides @Named(IGNORE_XML_CONFIGURATION_NAME)
+    public Boolean ignoreXmlConfigurationFlag(){
+        return Boolean.TRUE;
     }
 }

--- a/restx-validation/src/main/java/restx/validation/ValidatorFactory.java
+++ b/restx-validation/src/main/java/restx/validation/ValidatorFactory.java
@@ -1,7 +1,9 @@
 package restx.validation;
 
 import org.hibernate.validator.HibernateValidator;
-import restx.factory.*;
+import restx.factory.Module;
+import restx.factory.Name;
+import restx.factory.Provides;
 
 import javax.inject.Named;
 import javax.validation.Validation;

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -16,6 +16,7 @@
     "snakeyaml.version": "1.13",
 
     "hibernate-validator.version": "5.0.1.Final",
+    "el.api.version": "2.2",
 
     "reflections.version": "0.9.9-RC1",
     "janino.version": "2.6.1",


### PR DESCRIPTION
Proposal to support bean validation groups during validation.

I'm not really satisfied by the current implementation and would like to open the discussion about it.

At first, I was planning to implement usage below :
```
    @PermitAll
    @POST("/valid/pojos")
    public void createPOJOWithoutAnnotation(POJO myPojo) { // No @ValidatedFor annotation => Default validation group will be implicitly used here, keeping backward compat behaviour
        LOG.info("Pojo {} {} created !", myPojo.getName(), myPojo.getSubPOJO().getLabel());
    }

    @PermitAll
    @POST("/valid/pojos2")
    public void createPOJOWithAnnotation(@ValidatedFor(FormValidations.Create.class) POJO myPojo) { // Here, defining we want to activate the Create validation group mode on validation
        LOG.info("Pojo {} {} created !", myPojo.getName(), myPojo.getSubPOJO().getLabel());
    }

    @PermitAll
    @PUT("/valid/pojos/{id}")
    public void createPOJOWithoutAnnotation(Long id, @ValidatedFor({MyCustomValidationGroup.class, FormValidations.Update.class}) POJO myPojo) { // Multiple validation groups can be provided, following bean validation's Validator API
        LOG.info("Pojo {} {} updated !", myPojo.getName(), myPojo.getSubPOJO().getLabel());
    }
```
with group declaration :
```
public interface FormValidations {
    public static interface Create extends Default{}
    public static interface Update extends Default{}
}

public class ValidationResource {
// ...
    public static interface MyCustomValidationGroup{}
// ...
}
```

But I faced some issues at annotation processing time when retrieving `@ValidatedFor.value()` classes : didn't completely understood why, but some classes (either in `restx-core` or in `samplest`) were not accessible.
You can see some testing I made in commit 7f88a79573d00d5d28c796d238aaf0dfdde1fdcf (from branch [validations-validatedfor-with-class](https://github.com/fcamblor/restx/commits/validations-validatedfor-with-class), some github comments describe what's going weird)

Thus, I had to fallback from `Class[]` to `String[]` in order to directly provide validation group FQN used for source generation.
Which makes declaration look like :
```
    @PermitAll
    @POST("/valid/pojos")
    public void createPOJOWithoutAnnotation(POJO myPojo) {
        LOG.info("Pojo {} {} created !", myPojo.getName(), myPojo.getSubPOJO().getLabel());
    }

    @PermitAll
    @POST("/valid/pojos2")
    public void createPOJOWithAnnotation(@ValidatedFor(FormValidations.CreateFQN) POJO myPojo) {
        LOG.info("Pojo {} {} created !", myPojo.getName(), myPojo.getSubPOJO().getLabel());
    }

    @PermitAll
    @PUT("/valid/pojos/{id}")
    public void createPOJOWithoutAnnotation(Long id, @ValidatedFor({MyCustomValidationGroupFQN, FormValidations.UpdateFQN}) POJO myPojo) {
        LOG.info("Pojo {} {} updated !", myPojo.getName(), myPojo.getSubPOJO().getLabel());
    }
```
and group declaration :
```
public interface FormValidations {
    public static final String DefaultFQN = "javax.validation.groups.Default";
    public static final String CreateFQN = "restx.validation.stereotypes.FormValidations.Create";
    public static interface Create extends Default{}
    public static final String UpdateFQN = "restx.validation.stereotypes.FormValidations.Update";
    public static interface Update extends Default{}
}

public class ValidationResource {
// ...
    public static interface MyCustomValidationGroup{}
    public static final String MyCustomValidationGroupFQN = "samplest.validation.ValidationResource.MyCustomValidationGroup";
// ...
}
```

If you see any workaround for this issue, I'm opened to discuss it.

Another way would be to rely on reflection but I know this is something we should avoid, especially for such trivial things.