### PR TITLE
CompilationManager becames Closeable

### DIFF
--- a/restx-barbarywatch/src/main/java/restx/common/watch/BarbaryWatchService.java
+++ b/restx-barbarywatch/src/main/java/restx/common/watch/BarbaryWatchService.java
@@ -189,6 +189,7 @@ public class BarbaryWatchService implements WatcherService {
         @Override
         public void close() throws IOException {
             watcher.close();
+            coalescor.close();
         }
     }
 

--- a/restx-common/src/main/java/restx/common/MoreFiles.java
+++ b/restx-common/src/main/java/restx/common/MoreFiles.java
@@ -6,6 +6,7 @@ import com.google.common.io.ByteStreams;
 import restx.common.watch.WatcherServiceLoader;
 import restx.common.watch.WatcherSettings;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -69,9 +70,9 @@ public class MoreFiles {
         }
     }
 
-    public static void watch(Path dir, EventBus eventBus,
+    public static Closeable watch(Path dir, EventBus eventBus,
                              ExecutorService executor, WatcherSettings watcherSettings) {
-        WatcherServiceLoader.getWatcherService().watch(eventBus, executor, dir, watcherSettings);
+        return WatcherServiceLoader.getWatcherService().watch(eventBus, executor, dir, watcherSettings);
     }
 
     public static void copyDir(final Path sourceDir, final Path targetDir) throws IOException {

--- a/restx-common/src/main/java/restx/common/watch/EventCoalescor.java
+++ b/restx-common/src/main/java/restx/common/watch/EventCoalescor.java
@@ -2,6 +2,8 @@ package restx.common.watch;
 
 import com.google.common.eventbus.EventBus;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -20,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  *     Other similar events occuring within the period are simply not discarded.
  * </p>
  */
-public class EventCoalescor {
+public class EventCoalescor implements Closeable {
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private final EventBus eventBus;
     private final long coalescePeriod;
@@ -49,5 +51,10 @@ public class EventCoalescor {
                 }, coalescePeriod, TimeUnit.MILLISECONDS);
             }
         }
+    }
+
+    @Override
+    public void close() throws IOException {
+        executor.shutdownNow();
     }
 }

--- a/restx-common/src/main/java/restx/common/watch/StdWatcherService.java
+++ b/restx-common/src/main/java/restx/common/watch/StdWatcherService.java
@@ -171,6 +171,7 @@ public class StdWatcherService implements WatcherService {
         @Override
         public void close() throws IOException {
             watcher.close();
+            coalescor.close();
         }
     }
 }


### PR DESCRIPTION
Executors used by CompilationManager, WatcherService and
EventCoalescor were not closed, so the JVM could not stop
properly.
So from no on, EventCoalescor implements Closeable, so do the
CompilationManager. And they shutdown their executors in their
'close' methods.