### PR TITLE
Accept name in alternatives, and permits to use Alternative in modules

### DIFF
--- a/restx-common/src/main/java/restx/common/processor/RestxAbstractProcessor.java
+++ b/restx-common/src/main/java/restx/common/processor/RestxAbstractProcessor.java
@@ -51,6 +51,10 @@ public abstract class RestxAbstractProcessor extends AbstractProcessor {
         processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, element);
     }
 
+    protected void warn(String msg, Element element) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, msg, element);
+    }
+
     protected void error(String msg, Element element, AnnotationMirror annotation) {
         processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, element, annotation);
     }

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/AlternativeTest.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/AlternativeTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import java.util.Properties;
 import restx.factory.Factory;
 import restx.factory.Name;
+import restx.factory.alternative.components.TestAlternativesFromModule;
 import restx.factory.alternative.components.TestComponentInterface;
 import restx.factory.alternative.components.TestComponentNamed;
 import restx.factory.alternative.components.TestComponentSimple;
@@ -129,5 +130,53 @@ public class AlternativeTest {
 		factory = Factory.builder().addFromServiceLoader().build();
 		component = factory.getComponent(Name.of(TestComponentsFromModule.SomeOtherInterface.class, "restx.test.component.productionNamed"));
 		assertThat(component.mode()).isEqualTo("dev");
+	}
+
+	/*
+		This test uses an alternative defined in a module.
+	 */
+	@Test
+	public void should_use_alternative_defined_in_modules() {
+		Factory factory = Factory.builder().addFromServiceLoader().build();
+		TestAlternativesFromModule.Calculation component = factory.getComponent(TestAlternativesFromModule.Calculation.class);
+		assertThat(component.calculate(2, 3)).isEqualTo(5);
+
+		System.setProperty("restx.test.alternatives", "true");
+
+		factory = Factory.builder().addFromServiceLoader().build();
+		component = factory.getComponent(TestAlternativesFromModule.Calculation.class);
+		assertThat(component.calculate(2, 3)).isEqualTo(6);
+	}
+
+	/*
+		This test uses an alternative defined in a module, and the referenced component use a Named annotation
+	 */
+	@Test
+	public void should_use_alternative_defined_in_modules_for_named_components() {
+		Factory factory = Factory.builder().addFromServiceLoader().build();
+		TestAlternativesFromModule.Flag component = factory.getComponent(TestAlternativesFromModule.Flag.class);
+		assertThat(component.value()).isEqualTo(true);
+
+		System.setProperty("restx.test.alternatives", "true");
+
+		factory = Factory.builder().addFromServiceLoader().build();
+		component = factory.getComponent(TestAlternativesFromModule.Flag.class);
+		assertThat(component.value()).isEqualTo(false);
+	}
+
+	/*
+		This test defines two alternatives, with different priorities, check that the higher is used.
+	 */
+	@Test
+	public void should_use_alternative_with_higher_priority() {
+		Factory factory = Factory.builder().addFromServiceLoader().build();
+		TestAlternativesFromModule.Priority component = factory.getComponent(TestAlternativesFromModule.Priority.class);
+		assertThat(component.value()).isEqualTo(Integer.MAX_VALUE);
+
+		System.setProperty("restx.test.alternatives", "true");
+
+		factory = Factory.builder().addFromServiceLoader().build();
+		component = factory.getComponent(TestAlternativesFromModule.Priority.class);
+		assertThat(component.value()).isEqualTo(Integer.MIN_VALUE);
 	}
 }

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/AlternativeTest.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/AlternativeTest.java
@@ -1,0 +1,133 @@
+package restx.factory.alternative;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Properties;
+import restx.factory.Factory;
+import restx.factory.Name;
+import restx.factory.alternative.components.TestComponentInterface;
+import restx.factory.alternative.components.TestComponentNamed;
+import restx.factory.alternative.components.TestComponentSimple;
+import restx.factory.alternative.components.TestComponentsFromModule;
+
+/**
+ * Test cases for alternatives.
+ *
+ * @author apeyrard
+ */
+public class AlternativeTest {
+
+	/**
+	 * ElementsFromConfig component can not be build, because of module TestMandatoryDependency
+	 * which use a missing dependency.
+	 */
+	@BeforeClass
+	public static void deactivateElementsFromConfig() {
+		System.setProperty("restx.activation::restx.factory.FactoryMachine::ElementsFromConfig", "false");
+	}
+
+	/**
+	 * Removes all the system properties beginning with "restx.test.", in order to
+	 * start every test methods with a clean state.
+	 */
+	@Before
+	public void resetProperties() {
+		Properties properties = System.getProperties();
+		for (String propertyName : properties.stringPropertyNames()) {
+			if (propertyName.startsWith("restx.test.")) {
+				properties.remove(propertyName);
+			}
+		}
+	}
+
+	/*
+		This test uses the TestComponentSimple, and TestComponentSimpleAlternative. It uses the default alternative
+		mechanism without using Named annotation.
+	 */
+	@Test
+	public void should_use_alternative_for_basic_components() {
+		Factory factory = Factory.builder().addFromServiceLoader().build();
+		TestComponentSimple component = factory.getComponent(TestComponentSimple.class);
+		assertThat(component.greet()).isEqualTo("hello");
+
+		System.setProperty("restx.test.alternatives", "true");
+
+		factory = Factory.builder().addFromServiceLoader().build();
+		component = factory.getComponent(TestComponentSimple.class);
+		assertThat(component.greet()).isEqualTo("bonjour");
+	}
+
+	/*
+		This test uses the TestComponentNamed and TestComponentNamedAlternative, the alternative
+		should be registered under the name defined in the reference component
+	 */
+	@Test
+	public void should_use_alternative_for_named_components() {
+		Factory factory = Factory.builder().addFromServiceLoader().build();
+		TestComponentNamed component = factory.getComponent(Name.of(TestComponentNamed.class, "restx.test.component.speed"));
+		assertThat(component.speed()).isEqualTo("slow");
+
+		System.setProperty("restx.test.alternatives", "true");
+
+		factory = Factory.builder().addFromServiceLoader().build();
+		component = factory.getComponent(Name.of(TestComponentNamed.class, "restx.test.component.speed"));
+		assertThat(component.speed()).isEqualTo("fast");
+	}
+
+	/*
+		This test uses component based on an interface, the alternative reference the interface and force to be registered
+		 with the same name	as the original component.
+	 */
+	@Test
+	public void should_use_alternative_referencing_an_interface() {
+		Factory factory = Factory.builder().addFromServiceLoader().build();
+		TestComponentInterface component = factory.getComponent(Name.of(TestComponentInterface.class, "restx.test.component.name"));
+		assertThat(component.name()).isEqualTo("original");
+
+		System.setProperty("restx.test.alternatives", "true");
+
+		factory = Factory.builder().addFromServiceLoader().build();
+		component = factory.getComponent(Name.of(TestComponentInterface.class, "restx.test.component.name"));
+		assertThat(component.name()).isEqualTo("alternative");
+	}
+
+	/*
+		This test uses a component provided by a module, in order to create an alternative, it has to use the name of the
+		method annotated with @Provides.
+	 */
+	@Test
+	public void should_use_alternative_for_provided_component_using_the_method_as_name() {
+		Factory factory = Factory.builder().addFromServiceLoader().build();
+		TestComponentsFromModule.SomeInterface component = factory.getComponent(TestComponentsFromModule.SomeInterface.class);
+		assertThat(component.mode()).isEqualTo("production");
+
+		System.setProperty("restx.test.alternatives", "true");
+
+		factory = Factory.builder().addFromServiceLoader().build();
+		component = factory.getComponent(TestComponentsFromModule.SomeInterface.class);
+		assertThat(component.mode()).isEqualTo("dev");
+	}
+
+	/*
+		This test uses a named component provided by a module, in order to create an alternative, it has to use the same
+		name as the component.
+	 */
+	@Test
+	public void should_use_alternative_for_provided_named_component_using_same_name() {
+		Factory factory = Factory.builder().addFromServiceLoader().build();
+		TestComponentsFromModule.SomeOtherInterface component = factory.getComponent(
+				Name.of(TestComponentsFromModule.SomeOtherInterface.class, "restx.test.component.productionNamed"));
+		assertThat(component.mode()).isEqualTo("production");
+
+		System.setProperty("restx.test.alternatives", "true");
+
+		factory = Factory.builder().addFromServiceLoader().build();
+		component = factory.getComponent(Name.of(TestComponentsFromModule.SomeOtherInterface.class, "restx.test.component.productionNamed"));
+		assertThat(component.mode()).isEqualTo("dev");
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestAlternativesFromModule.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestAlternativesFromModule.java
@@ -1,0 +1,103 @@
+package restx.factory.alternative.components;
+
+import javax.inject.Named;
+import restx.factory.Alternative;
+import restx.factory.Component;
+import restx.factory.Module;
+import restx.factory.Provides;
+import restx.factory.When;
+
+/**
+ * @author apeyrard
+ */
+@Module
+public class TestAlternativesFromModule {
+
+	public static interface Calculation {
+		int calculate(int a, int b);
+	}
+
+	@Provides
+	public Calculation addition() {
+		return new Calculation() {
+			@Override
+			public int calculate(int a, int b) {
+				return a + b;
+			}
+		};
+	}
+
+	@Alternative(to = Calculation.class, named = "addition")
+	@When(name = "restx.test.alternatives", value = "true")
+	public Calculation multiplication() {
+		return new Calculation() {
+			@Override
+			public int calculate(int a, int b) {
+				return a * b;
+			}
+		};
+	}
+
+	public static interface Flag {
+		boolean value();
+	}
+
+	@Provides
+	@Named("SomeFlag")
+	public Flag alwaysTrue() {
+		return new Flag() {
+			@Override
+			public boolean value() {
+				return true;
+			}
+		};
+	}
+
+	@Alternative(to = Flag.class, named = "SomeFlag")
+	@When(name = "restx.test.alternatives", value = "true")
+	public Flag alwaysFalse() {
+		return new Flag() {
+			@Override
+			public boolean value() {
+				return false;
+			}
+		};
+	}
+
+	public static interface Priority {
+		int value();
+	}
+
+	@Provides
+	public Priority priority() {
+		return new Priority() {
+			@Override
+			public int value() {
+				return Integer.MAX_VALUE;
+			}
+		};
+	}
+
+	@Alternative(to = Priority.class, named = "priority", priority = -2000)
+	@When(name = "restx.test.alternatives", value = "true")
+	public Priority nilPriority() {
+		return new Priority() {
+			@Override
+			public int value() {
+				return 0;
+			}
+		};
+	}
+
+
+	@Alternative(to = Priority.class, named = "priority", priority = -3000)
+	@When(name = "restx.test.alternatives", value = "true")
+	public Priority minPriority() {
+		return new Priority() {
+			@Override
+			public int value() {
+				return Integer.MIN_VALUE;
+			}
+		};
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestBasicComponentFromModuleAlternative.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestBasicComponentFromModuleAlternative.java
@@ -1,0 +1,17 @@
+package restx.factory.alternative.components;
+
+import restx.factory.Alternative;
+import restx.factory.When;
+
+/**
+ * @author apeyrard
+ */
+@Alternative(to = TestComponentsFromModule.SomeInterface.class, named = "production")
+@When(name = "restx.test.alternatives", value = "true")
+public class TestBasicComponentFromModuleAlternative implements TestComponentsFromModule.SomeInterface {
+
+	@Override
+	public String mode() {
+		return "dev";
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentFromInterface.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentFromInterface.java
@@ -1,0 +1,19 @@
+package restx.factory.alternative.components;
+
+import javax.inject.Named;
+import restx.factory.Component;
+
+/**
+ * Component based on an interface
+ *
+ * @author apeyrard
+ */
+@Component
+@Named("restx.test.component.name")
+public class TestComponentFromInterface implements TestComponentInterface {
+
+	@Override
+	public String name() {
+		return "original";
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentFromInterfaceAlternative.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentFromInterfaceAlternative.java
@@ -1,0 +1,19 @@
+package restx.factory.alternative.components;
+
+import restx.factory.Alternative;
+import restx.factory.When;
+
+/**
+ * Create an alternative for a component, without knowing its implementation, just the interface.
+ *
+ * @author apeyrard
+ */
+@Alternative(to = TestComponentInterface.class, named = "restx.test.component.name")
+@When(name = "restx.test.alternatives", value = "true")
+public class TestComponentFromInterfaceAlternative implements TestComponentInterface {
+
+	@Override
+	public String name() {
+		return "alternative";
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentInterface.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentInterface.java
@@ -1,0 +1,10 @@
+package restx.factory.alternative.components;
+
+/**
+ * Just a basic interface, to be used in components.
+ *
+ * @author apeyrard
+ */
+public interface TestComponentInterface {
+	String name();
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentNamed.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentNamed.java
@@ -1,0 +1,18 @@
+package restx.factory.alternative.components;
+
+import javax.inject.Named;
+import restx.factory.Component;
+
+/**
+ * A component using a {@link Named} annotation.
+ *
+ * @author apeyrard
+ */
+@Component
+@Named("restx.test.component.speed")
+public class TestComponentNamed {
+
+	public String speed() {
+		return "slow";
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentNamedAlternative.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentNamedAlternative.java
@@ -1,0 +1,17 @@
+package restx.factory.alternative.components;
+
+import restx.factory.Alternative;
+import restx.factory.When;
+
+/**
+ * @author apeyrard
+ */
+@Alternative(to = TestComponentNamed.class)
+@When(name = "restx.test.alternatives", value = "true")
+public class TestComponentNamedAlternative extends TestComponentNamed {
+
+	@Override
+	public String speed() {
+		return "fast";
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentSimple.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentSimple.java
@@ -1,0 +1,17 @@
+package restx.factory.alternative.components;
+
+import javax.inject.Named;
+import restx.factory.Component;
+
+/**
+ * Simple component, without {@link Named} annotation, nor interface implementation.
+ *
+ * @author apeyrard
+ */
+@Component
+public class TestComponentSimple {
+
+	public String greet() {
+		return "hello";
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentSimpleAlternative.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentSimpleAlternative.java
@@ -1,0 +1,19 @@
+package restx.factory.alternative.components;
+
+import restx.factory.Alternative;
+import restx.factory.When;
+
+/**
+ * Create an alternative for component {@link TestComponentSimple}.
+ *
+ * @author apeyrard
+ */
+@Alternative(to = TestComponentSimple.class)
+@When(name = "restx.test.alternatives", value = "true")
+public class TestComponentSimpleAlternative extends TestComponentSimple {
+
+	@Override
+	public String greet() {
+		return "bonjour";
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentsFromModule.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestComponentsFromModule.java
@@ -1,0 +1,43 @@
+package restx.factory.alternative.components;
+
+import javax.inject.Named;
+import restx.factory.Module;
+import restx.factory.Provides;
+
+/**
+ * This module permits to define some components used during alternatives tests.
+ *
+ * @author apeyrard
+ */
+@Module
+public class TestComponentsFromModule {
+
+	public static interface SomeInterface {
+		String mode();
+	}
+
+	@Provides
+	public SomeInterface production() {
+		return new SomeInterface() {
+			@Override
+			public String mode() {
+				return "production";
+			}
+		};
+	}
+
+	public static interface SomeOtherInterface {
+		String mode();
+	}
+
+	@Provides
+	@Named("restx.test.component.productionNamed")
+	public SomeOtherInterface productionNamed() {
+		return new SomeOtherInterface() {
+			@Override
+			public String mode() {
+				return "production";
+			}
+		};
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestNamedComponentFromModuleAlternative.java
+++ b/restx-factory-testing/src/test/java/restx/factory/alternative/components/TestNamedComponentFromModuleAlternative.java
@@ -1,0 +1,17 @@
+package restx.factory.alternative.components;
+
+import restx.factory.Alternative;
+import restx.factory.When;
+
+/**
+ * @author apeyrard
+ */
+@Alternative(to = TestComponentsFromModule.SomeOtherInterface.class, named = "restx.test.component.productionNamed")
+@When(name = "restx.test.alternatives", value = "true")
+public class TestNamedComponentFromModuleAlternative implements TestComponentsFromModule.SomeOtherInterface {
+
+	@Override
+	public String mode() {
+		return "dev";
+	}
+}

--- a/restx-factory/src/main/java/restx/factory/Alternative.java
+++ b/restx-factory/src/main/java/restx/factory/Alternative.java
@@ -2,8 +2,14 @@ package restx.factory;
 
 /**
  * Marks a class as an alternative implementation, to be used under certain conditions only.
+ *
+ * The {@link Name} used for the alternative is composed by:
+ * - The class defined by {@link #to()}
+ * - The name defined by {@link #named()} if defined, or the name of the component referenced by {@link #to()} if one is defined,
+ * or the simple name of the class defined by {@link #to()}.
  */
 public @interface Alternative {
     int priority() default -1000;
     Class<?> to();
+    String named() default "";
 }

--- a/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
+++ b/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
@@ -7,7 +7,6 @@ import com.google.common.io.CharStreams;
 import com.samskivert.mustache.Template;
 import restx.common.processor.RestxAbstractProcessor;
 import restx.factory.*;
-import restx.factory.Name;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -85,24 +84,61 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
 
                 ModuleClass module = new ModuleClass(typeElem.getQualifiedName().toString(), typeElem, mod.priority());
                 for (Element element : typeElem.getEnclosedElements()) {
+                    // look for Provides or Alternative elements
                     Provides provides = element.getAnnotation(Provides.class);
+                    Alternative alternative = element.getAnnotation(Alternative.class);
                     if (element instanceof ExecutableElement
-                            && element.getKind() == ElementKind.METHOD
-                            && provides != null) {
-                        ExecutableElement exec = (ExecutableElement) element;
+                            && element.getKind() == ElementKind.METHOD) {
+                        if (provides != null) {
+                            ExecutableElement exec = (ExecutableElement) element;
 
-                        ProviderMethod m = new ProviderMethod(
-                                exec.getReturnType().toString(),
-                                exec.getSimpleName().toString(),
-                                provides.priority() == 0 ? mod.priority() : provides.priority(),
-                                getInjectionName(exec.getAnnotation(Named.class)),
-                                exec);
+                            ProviderMethod m = new ProviderMethod(
+                                    exec.getReturnType().toString(),
+                                    exec.getSimpleName().toString(),
+                                    provides.priority() == 0 ? mod.priority() : provides.priority(),
+                                    getInjectionName(exec.getAnnotation(Named.class)),
+                                    exec);
 
-                        buildInjectableParams(exec, m.parameters);
+                            buildInjectableParams(exec, m.parameters);
 
-                        buildCheckedExceptions(exec, m.exceptions);
+                            buildCheckedExceptions(exec, m.exceptions);
 
-                        module.providerMethods.add(m);
+                            module.providerMethods.add(m);
+                        } else if (alternative != null) {
+                            ExecutableElement exec = (ExecutableElement) element;
+
+                            When when = exec.getAnnotation(When.class);
+                            if (when == null) {
+                                error("an Alternative MUST be annotated with @When to tell when it must be activated", exec);
+                                continue;
+                            }
+
+                            TypeElement alternativeTo = null;
+                            if (alternative != null) {
+                                try {
+                                    alternative.to();
+                                } catch (MirroredTypeException mte) {
+                                    alternativeTo = asTypeElement(mte.getTypeMirror());
+                                }
+                            }
+
+                            AlternativeMethod m = new AlternativeMethod(
+                                    exec.getReturnType().toString(),
+                                    alternativeTo.getQualifiedName().toString(),
+                                    alternativeTo.getSimpleName().toString(),
+                                    exec.getSimpleName().toString(),
+                                    alternative.priority(),
+                                    !alternative.named().isEmpty() ? Optional.of(alternative.named()) : Optional.<String>absent(),
+                                    when.name(),
+                                    when.value(),
+                                    exec);
+
+                            buildInjectableParams(exec, m.parameters);
+
+                            buildCheckedExceptions(exec, m.exceptions);
+
+                            module.alternativeMethods.add(m);
+                        }
                     }
                 }
 
@@ -166,6 +202,11 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
     private void processAlternatives(RoundEnvironment roundEnv) throws IOException {
         for (Element elem : roundEnv.getElementsAnnotatedWith(Alternative.class)) {
             try {
+                if (elem instanceof ExecutableElement && elem.getKind() == ElementKind.METHOD) {
+                    // skip this annotation, if it is in a module, it will been managed by processModules
+                    continue;
+                }
+
                 if (!(elem instanceof TypeElement)) {
                     error("annotating element " + elem + " of type " + elem.getKind().name()
                                     + " with @Alternative is not supported", elem);
@@ -274,6 +315,7 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
 
     private void generateMachineFile(ModuleClass moduleClass) throws IOException {
         List<ImmutableMap<String, Object>> engines = Lists.newArrayList();
+        List<ImmutableMap<String, Object>> alternativesEngines = Lists.newArrayList();
 
         for (ProviderMethod method : moduleClass.providerMethods) {
             engines.add(ImmutableMap.<String, Object>builder()
@@ -289,6 +331,23 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
                     .build());
         }
 
+        for (AlternativeMethod method : moduleClass.alternativeMethods) {
+            alternativesEngines.add(ImmutableMap.<String, Object>builder()
+                    .put("componentType", method.componentType)
+                    .put("alternativeToComponentType", method.alternativeType)
+                    .put("alternativeToComponentName", method.injectionName.or(method.alternativeName))
+                    .put("alternativeToComponentSimpleName", method.alternativeName)
+                    .put("whenName", method.whenName)
+                    .put("whenValue", method.whenValue)
+                    .put("priority", method.priority)
+                    .put("queriesDeclarations", Joiner.on("\n").join(buildQueriesDeclarationsCode(method.parameters)))
+                    .put("methodName", method.methodName)
+                    .put("queries", Joiner.on(",\n").join(buildQueriesNames(method.parameters)))
+                    .put("parameters", Joiner.on(",\n").join(buildParamFromSatisfiedBomCode(method.parameters)))
+                    .put("exceptions", method.exceptions.isEmpty() ? false : Joiner.on("|").join(method.exceptions))
+                    .build());
+        }
+
         ImmutableMap<String, Object> ctx = ImmutableMap.<String, Object>builder()
                 .put("package", moduleClass.pack)
                 .put("machine", moduleClass.name + "FactoryMachine")
@@ -296,12 +355,12 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
                 .put("moduleType", moduleClass.name)
                 .put("priority", moduleClass.priority)
                 .put("engines", engines)
+                .put("alternativesEngines", alternativesEngines)
                 .build();
 
         generateJavaClass(moduleClass.fqcn + "FactoryMachine", moduleMachineTpl, ctx,
                 Collections.singleton(moduleClass.originatingElement));
     }
-
 
     private void generateMachineFile(ComponentClass componentClass, ComponentClass alternativeTo, When when) throws IOException {
         ImmutableMap<String, String> ctx = ImmutableMap.<String, String>builder()
@@ -521,6 +580,7 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
         final String fqcn;
 
         final List<ProviderMethod> providerMethods = Lists.newArrayList();
+        final List<AlternativeMethod> alternativeMethods = Lists.newArrayList();
         final Element originatingElement;
         final String pack;
         final String name;
@@ -549,6 +609,34 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
             this.name = name;
             this.priority = priority;
             this.injectionName = injectionName;
+            this.originatingElement = originatingElement;
+        }
+    }
+
+    private static class AlternativeMethod {
+        final Element originatingElement;
+        final String componentType;
+        final String alternativeType;
+        final String alternativeName;
+        final String methodName;
+        final int priority;
+        final Optional<String> injectionName;
+        final String whenName;
+        final String whenValue;
+        final List<InjectableParameter> parameters = Lists.newArrayList();
+        final List<String> exceptions = Lists.newArrayList();
+
+        AlternativeMethod(String componentType, String alternativeType,
+                String alternativeName, String methodName, int priority, Optional<String> injectionName,
+                String whenName, String whenValue, Element originatingElement) {
+            this.componentType = componentType;
+            this.alternativeType = alternativeType;
+            this.alternativeName = alternativeName;
+            this.methodName = methodName;
+            this.priority = priority;
+            this.injectionName = injectionName;
+            this.whenName = whenName;
+            this.whenValue = whenValue;
             this.originatingElement = originatingElement;
         }
     }

--- a/restx-factory/src/main/resources/restx/factory/processor/ModuleMachine.mustache
+++ b/restx-factory/src/main/resources/restx/factory/processor/ModuleMachine.mustache
@@ -37,6 +37,55 @@ public class {{machine}} extends DefaultFactoryMachine {
                 }
             },
 {{/engines}}
+
+{{#alternativesEngines}}
+            new StdMachineEngine<FactoryMachine>(
+                    Name.of(FactoryMachine.class, "{{methodName}}{{alternativeToComponentSimpleName}}Alternative"), 0, BoundlessComponentBox.FACTORY) {
+                private Factory.Query<String> query = Factory.Query.byName(Name.of(String.class, "{{whenName}}")).optional();
+
+                @Override
+                protected FactoryMachine doNewComponent(SatisfiedBOM satisfiedBOM) {
+                    if (satisfiedBOM.getOne(query).isPresent()
+                            && satisfiedBOM.getOne(query).get().getComponent().equals("{{whenValue}}")) {
+                        return new SingleNameFactoryMachine<{{alternativeToComponentType}}>({{priority}},
+                                        new StdMachineEngine<{{alternativeToComponentType}}>(
+                                                Name.of({{alternativeToComponentType}}.class, "{{alternativeToComponentName}}"),
+                                                {{priority}}, BoundlessComponentBox.FACTORY) {
+                                            {{queriesDeclarations}}
+
+                                            @Override
+                                            public BillOfMaterials getBillOfMaterial() {
+                                                return new BillOfMaterials(ImmutableSet.<Factory.Query<?>>of(
+                                                    {{queries}}
+                                                ));
+                                            }
+
+                                            @Override
+                                            protected {{alternativeToComponentType}} doNewComponent(SatisfiedBOM satisfiedBOM) {
+                                                {{#exceptions}}
+                                                try {
+                                                {{/exceptions}}
+                                                    return module.{{methodName}}(
+                                                {{parameters}}
+                                                    );
+                                                {{#exceptions}}
+                                                } catch ({{exceptions}} e) {
+                                                    throw new ProvisionException("Could not create component {{alternativeToComponentName}}", e);
+                                                }
+                                                {{/exceptions}}
+                                            }
+                                        });
+                    } else {
+                        return NoopFactoryMachine.INSTANCE;
+                    }
+                }
+
+                @Override
+                public BillOfMaterials getBillOfMaterial() {
+                    return BillOfMaterials.of(query);
+                }
+            },
+{{/alternativesEngines}}
         });
-}
+    }
 }


### PR DESCRIPTION
Alternatives were using the name of the referenced component, so it was not possible to create an alternative for a component provided by a module. 
From now on Alternative annotation allow to force a name by defining a value to the optional parameter "named".
Another modification is the capability for Alternative to be used in modules. So from now on we can directly annotate modules methods to create alternatives. 