### PR TITLE
Allow to force injection type for components

### DIFF
--- a/restx-factory-testing/src/test/java/restx/factory/FactoryTest.java
+++ b/restx-factory-testing/src/test/java/restx/factory/FactoryTest.java
@@ -95,4 +95,16 @@ public class FactoryTest {
 
         assertThat(factory.queryByClass(A.class).findOne().isPresent()).isTrue();
     }
+
+    @Test
+    public void should_permit_to_force_component_produced_class() {
+        Factory factory = Factory.builder().addFromServiceLoader().build();
+
+        TestGreeting component = factory.getComponent(TestGreeting.class);
+        assertThat(component.greet()).isEqualTo("hello");
+
+        Optional<NamedComponent<TestGreeting>> one = factory.queryByClass(TestGreeting.class).findOne();
+        assertThat(one.isPresent());
+        assertThat(one.get().getName().getClazz()).isEqualTo(TestGreeting.class);
+    }
 }

--- a/restx-factory-testing/src/test/java/restx/factory/TestComponentForcedClass.java
+++ b/restx-factory-testing/src/test/java/restx/factory/TestComponentForcedClass.java
@@ -1,0 +1,12 @@
+package restx.factory;
+
+/**
+ * @author apeyrard
+ */
+@Component(asClass = TestGreeting.class)
+public class TestComponentForcedClass implements TestGreeting {
+	@Override
+	public String greet() {
+		return "hello";
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/TestGreeting.java
+++ b/restx-factory-testing/src/test/java/restx/factory/TestGreeting.java
@@ -1,0 +1,8 @@
+package restx.factory;
+
+/**
+ * @author apeyrard
+ */
+public interface TestGreeting {
+	String greet();
+}

--- a/restx-factory-testing/src/test/java/restx/factory/conditional/ConditionalTest.java
+++ b/restx-factory-testing/src/test/java/restx/factory/conditional/ConditionalTest.java
@@ -13,9 +13,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Comparator;
 import java.util.Set;
 import restx.factory.Factory;
 import restx.factory.Name;
+import restx.factory.NamedComponent;
+import restx.factory.TestGreeting;
 import restx.factory.conditional.components.TestConditionalComponent;
 import restx.factory.conditional.components.TestInterfaces;
 import restx.factory.conditional.components.TestModuleWithConditional;
@@ -123,5 +126,15 @@ public class ConditionalTest {
 		factory = Factory.newInstance();
 		conditional = factory.queryByName(Name.of(TestConditionalComponent.class, "conditional")).findOneAsComponent();
 		assertThat(conditional.isPresent()).isTrue();
+	}
+
+	@Test
+	public void should_use_asClass_parameter_for_conditional_components() {
+		overrideComponents().set("allow.comparator", "true");
+
+		Factory factory = Factory.newInstance();
+		Optional<NamedComponent<Comparator>> one = factory.queryByClass(Comparator.class).findOne();
+		assertThat(one.isPresent());
+		assertThat(one.get().getName().getClazz()).isEqualTo(Comparator.class);
 	}
 }

--- a/restx-factory-testing/src/test/java/restx/factory/conditional/components/TestConditionalAsClass.java
+++ b/restx-factory-testing/src/test/java/restx/factory/conditional/components/TestConditionalAsClass.java
@@ -1,0 +1,20 @@
+package restx.factory.conditional.components;
+
+/**
+ * @author apeyrard
+ */
+
+import java.util.Comparator;
+import javax.inject.Named;
+import restx.factory.Component;
+import restx.factory.When;
+
+@Component(asClass = Comparator.class)
+@Named("test.comparator")
+@When(name = "allow.comparator", value = "true")
+public class TestConditionalAsClass implements Comparator {
+	@Override
+	public int compare(Object o1, Object o2) {
+		return 0;
+	}
+}

--- a/restx-factory/src/main/java/restx/factory/Component.java
+++ b/restx-factory/src/main/java/restx/factory/Component.java
@@ -10,7 +10,7 @@ public @interface Component {
 
     /**
      * @return the class to use for the name of this component,
-     * if not defined the annotated class will be used
+     * if not defined, the annotated class will be used
      */
-    Class<?> asClass() default Component.class; // trick to mark default value, as null is not permitted
+    Class<?> asClass() default void.class; // trick to mark default value, as null is not permitted
 }

--- a/restx-factory/src/main/java/restx/factory/Component.java
+++ b/restx-factory/src/main/java/restx/factory/Component.java
@@ -7,4 +7,10 @@ package restx.factory;
  */
 public @interface Component {
     int priority() default 0;
+
+    /**
+     * @return the class to use for the name of this component,
+     * if not defined the annotated class will be used
+     */
+    Class<?> asClass() default Component.class; // trick to mark default value, as null is not permitted
 }

--- a/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
+++ b/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
@@ -247,7 +247,7 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
                 } catch (MirroredTypeException mte) {
                     asClass = asTypeElement(mte.getTypeMirror());
                 }
-                if (asClass.getQualifiedName().toString().equals(Component.class.getName())) {
+                if (asClass == null) {
                     // no class as been forced, so use the annotated class
                     asClass = component;
                 }

--- a/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
+++ b/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
@@ -464,7 +464,7 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
                 .put("machine", componentClass.name + "FactoryMachine")
                 .put("imports", ImmutableList.of(componentClass.fqcn))
                 .put("componentType", componentClass.name)
-                .put("componentInjectionType", componentClass.name)
+                .put("componentInjectionType", componentClass.producedName)
                 .put("priority", String.valueOf(componentClass.priority))
                 .put("whenName", when.name())
                 .put("whenValue", when.value())

--- a/restx-factory/src/main/resources/restx/factory/processor/ComponentMachine.mustache
+++ b/restx-factory/src/main/resources/restx/factory/processor/ComponentMachine.mustache
@@ -5,11 +5,11 @@ import restx.factory.*;
 import {{componentFqcn}};
 
 @Machine
-public class {{machine}} extends SingleNameFactoryMachine<{{componentType}}> {
-    public static final Name<{{componentType}}> NAME = Name.of({{componentType}}.class, "{{componentInjectionName}}");
+public class {{machine}} extends SingleNameFactoryMachine<{{componentProducedType}}> {
+    public static final Name<{{componentProducedType}}> NAME = Name.of({{componentProducedType}}.class, "{{componentInjectionName}}");
 
     public {{machine}}() {
-        super({{priority}}, new StdMachineEngine<{{componentType}}>(NAME, {{priority}}, BoundlessComponentBox.FACTORY) {
+        super({{priority}}, new StdMachineEngine<{{componentProducedType}}>(NAME, {{priority}}, BoundlessComponentBox.FACTORY) {
 {{queriesDeclarations}}
 
             @Override
@@ -20,7 +20,7 @@ public class {{machine}} extends SingleNameFactoryMachine<{{componentType}}> {
             }
 
             @Override
-            protected {{componentType}} doNewComponent(SatisfiedBOM satisfiedBOM) {
+            protected {{componentProducedType}} doNewComponent(SatisfiedBOM satisfiedBOM) {
                 return new {{componentType}}(
 {{parameters}}
                 );


### PR DESCRIPTION
As discussed in #155.

Currently when defining a class annotated with @Component the class used in the Name is the component class. So if we want to register it with another class, typically an implemented interface or an inherited class, we have to use a Module and a "provides" method.

This PR allow to use the optional parameter `asClass` in `@Component` annotation to define the injection class that will be used for the component.