### PR TITLE
breaking: Introduces FileWatchEventCoalescor

### DIFF
--- a/restx-barbarywatch/src/main/java/restx/common/watch/BarbaryWatchService.java
+++ b/restx-barbarywatch/src/main/java/restx/common/watch/BarbaryWatchService.java
@@ -49,7 +49,7 @@ public class BarbaryWatchService implements WatcherService {
         private final WatchService watcher;
         private final Map<WatchKey, Path> keys;
         private final boolean recursive;
-        private final EventCoalescor<Object> coalescor;
+        private final EventCoalescor<FileWatchEvent> coalescor;
         private final Path root;
         private boolean trace = false;
 
@@ -98,7 +98,7 @@ public class BarbaryWatchService implements WatcherService {
             this.keys = new HashMap<>();
             this.recursive = settings.recurse();
             this.root = dir;
-            this.coalescor = EventCoalescor.generic(eventBus, settings.coalescePeriod());
+            this.coalescor = FileWatchEventCoalescor.create(eventBus, settings.coalescePeriod());
 
             if (recursive) {
                 registerAll(dir);

--- a/restx-barbarywatch/src/main/java/restx/common/watch/BarbaryWatchService.java
+++ b/restx-barbarywatch/src/main/java/restx/common/watch/BarbaryWatchService.java
@@ -49,7 +49,7 @@ public class BarbaryWatchService implements WatcherService {
         private final WatchService watcher;
         private final Map<WatchKey, Path> keys;
         private final boolean recursive;
-        private final EventCoalescor coalescor;
+        private final EventCoalescor<Object> coalescor;
         private final Path root;
         private boolean trace = false;
 
@@ -98,7 +98,7 @@ public class BarbaryWatchService implements WatcherService {
             this.keys = new HashMap<>();
             this.recursive = settings.recurse();
             this.root = dir;
-            this.coalescor = new EventCoalescor(eventBus, settings.coalescePeriod());
+            this.coalescor = EventCoalescor.generic(eventBus, settings.coalescePeriod());
 
             if (recursive) {
                 registerAll(dir);

--- a/restx-common/src/main/java/restx/common/watch/EventCoalescor.java
+++ b/restx-common/src/main/java/restx/common/watch/EventCoalescor.java
@@ -22,39 +22,63 @@ import java.util.concurrent.TimeUnit;
  *     Other similar events occuring within the period are simply not discarded.
  * </p>
  */
-public class EventCoalescor implements Closeable {
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-    private final EventBus eventBus;
-    private final long coalescePeriod;
+public abstract class EventCoalescor<T> implements Closeable {
 
-    private final Set<Object> queue = new LinkedHashSet<>();
+	/**
+	 * Create an instance of an {@link EventCoalescor} which accept all kind of events,
+	 * as it is untyped.
+	 *
+	 * @param eventBus the event bus where to post processed events
+	 * @param coalescePeriod the coalesce period
+	 * @return the generic event coalescor
+	 */
+	public static EventCoalescor<Object> generic(EventBus eventBus, long coalescePeriod) {
+		return new GenericEventCoalescor(eventBus, coalescePeriod);
+	}
 
-    public EventCoalescor(EventBus eventBus, long coalescePeriod) {
+    final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    final EventBus eventBus;
+    final long coalescePeriod;
+
+    EventCoalescor(EventBus eventBus, long coalescePeriod) {
         this.eventBus = eventBus;
         this.coalescePeriod = coalescePeriod;
     }
 
-    public void post(final Object event) {
-        synchronized (queue) {
-            if (queue.add(event)) {
-                executor.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            eventBus.post(event);
-                        } finally {
-                            synchronized (queue) {
-                                queue.remove(event);
-                            }
-                        }
-                    }
-                }, coalescePeriod, TimeUnit.MILLISECONDS);
-            }
-        }
-    }
+	public abstract void post(final T event);
 
     @Override
     public void close() throws IOException {
         executor.shutdownNow();
     }
+
+	/**
+	 * generic coalescor, using untyped events
+	 */
+	private static class GenericEventCoalescor extends EventCoalescor<Object> {
+		private final Set<Object> queue = new LinkedHashSet<>();
+
+		private GenericEventCoalescor(EventBus eventBus, long coalescePeriod) {
+			super(eventBus, coalescePeriod);
+		}
+
+		public void post(final Object event) {
+			synchronized (queue) {
+				if (queue.add(event)) {
+					executor.schedule(new Runnable() {
+						@Override
+						public void run() {
+							try {
+								eventBus.post(event);
+							} finally {
+								synchronized (queue) {
+									queue.remove(event);
+								}
+							}
+						}
+					}, coalescePeriod, TimeUnit.MILLISECONDS);
+				}
+			}
+		}
+	}
 }

--- a/restx-common/src/main/java/restx/common/watch/FileWatchEvent.java
+++ b/restx-common/src/main/java/restx/common/watch/FileWatchEvent.java
@@ -13,6 +13,16 @@ public class FileWatchEvent {
         return new FileWatchEvent(root, normalizePath(root, dir.resolve(normalizePath(dir, path))), kind, count);
     }
 
+    /**
+     * Create a new {@link FileWatchEvent} from a reference, and apply the new specified kind.
+     * @param ref the reference
+     * @param newKind the new kind
+     * @return the created event
+     */
+    public static FileWatchEvent fromWithKind(FileWatchEvent ref, WatchEvent.Kind<?> newKind) {
+        return new FileWatchEvent(ref.dir, ref.path, newKind, ref.count);
+    }
+
     private final Path dir;
     private final Path path;
     private final WatchEvent.Kind<?> kind;

--- a/restx-common/src/main/java/restx/common/watch/FileWatchEventCoalescor.java
+++ b/restx-common/src/main/java/restx/common/watch/FileWatchEventCoalescor.java
@@ -23,9 +23,20 @@ import java.util.concurrent.TimeUnit;
  */
 public class FileWatchEventCoalescor extends EventCoalescor<FileWatchEvent> {
 
+	/**
+	 * Create a new {@link EventCoalescor} to coalesce {@link FileWatchEvent}.
+	 *
+	 * @param eventBus the event bus where to post processed events
+	 * @param coalescePeriod the coalesce period
+	 * @return the generic event coalescor
+	 */
+	public static FileWatchEventCoalescor create(EventBus eventBus, long coalescePeriod) {
+		return new FileWatchEventCoalescor(eventBus, coalescePeriod);
+	}
+
 	private final HashMap<FileWatchEventKey, Deque<EventReference>> queue = new HashMap<>();
 
-	public FileWatchEventCoalescor(EventBus eventBus, long coalescePeriod) {
+	FileWatchEventCoalescor(EventBus eventBus, long coalescePeriod) {
 		super(eventBus, coalescePeriod);
 	}
 

--- a/restx-common/src/main/java/restx/common/watch/FileWatchEventCoalescor.java
+++ b/restx-common/src/main/java/restx/common/watch/FileWatchEventCoalescor.java
@@ -1,0 +1,239 @@
+package restx.common.watch;
+
+import com.google.common.eventbus.EventBus;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Used to coalesce {@link restx.common.watch.FileWatchEvent} in a short period of time.
+ *
+ * <p>
+ * There is some cases where events will be discarded:
+ * <ul>
+ * <li>If the same event is posted multiple times, only the first occurrence will be kept.</li>
+ * <li>If a create event follow a delete event, for a same file, it will be transformed into a modified event.</li>
+ * </ul>
+ *
+ * @author apeyrard
+ */
+public class FileWatchEventCoalescor implements Closeable {
+
+	private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+	private final EventBus eventBus;
+	private final long coalescePeriod;
+
+	private final HashMap<FileWatchEventKey, Deque<EventReference>> queue = new HashMap<>();
+
+	public FileWatchEventCoalescor(EventBus eventBus, long coalescePeriod) {
+		this.eventBus = eventBus;
+		this.coalescePeriod = coalescePeriod;
+	}
+
+	/**
+	 * Posts a {@link restx.common.watch.FileWatchEvent}, the post will be delayed, or even discarded, if
+	 * the event might be merged, with a previous one.
+	 *
+	 * @param event the event to try to post
+	 */
+	public void post(final FileWatchEvent event) {
+		synchronized (queue) {
+			final FileWatchEventKey key = FileWatchEventKey.fromEvent(event);
+
+			Deque<EventReference> fileEvents;
+			if ((fileEvents = queue.get(key)) == null) {
+				// easy case, first event for a file, just queue it and schedule a post
+				fileEvents = new ArrayDeque<>();
+				queue.put(key, fileEvents);
+				EventReference reference = EventReference.of(key, event);
+				fileEvents.add(reference);
+				schedulePost(reference);
+				return;
+			}
+
+			// more complex case, we need to analyze the last saved event for this file
+			EventReference last = fileEvents.getLast();
+			if (!merge(last, event)) {
+				// event has not been merged, so try to add it
+				EventReference reference = EventReference.of(key, event);
+				fileEvents.add(reference);
+				schedulePost(reference);
+			}
+		}
+	}
+
+	/**
+	 * tries to merge the current event into the current one
+	 */
+	private boolean merge(EventReference previous, FileWatchEvent current) {
+		if (!previous.isPresent()) {
+			return false;
+		}
+
+		if (previous.getReference().getKind() == current.getKind()) {
+			return true; // duplicate events, keep only one
+		}
+
+		if (previous.getReference().getKind() == StandardWatchEventKinds.ENTRY_DELETE) {
+			if (current.getKind() == StandardWatchEventKinds.ENTRY_CREATE) {
+				// DELETE, then CREATE, so merge into a MODIFY
+				previous.updateReference(
+						FileWatchEvent.fromWithKind(previous.getReference(), StandardWatchEventKinds.ENTRY_MODIFY));
+				return true;
+			}
+		}
+
+		if (previous.getReference().getKind() == StandardWatchEventKinds.ENTRY_CREATE) {
+			if (current.getKind() == StandardWatchEventKinds.ENTRY_MODIFY) {
+				// skip modify
+				return true;
+			}
+		}
+
+		if (previous.getReference().getKind() == StandardWatchEventKinds.ENTRY_CREATE) {
+			if (current.getKind() == StandardWatchEventKinds.ENTRY_DELETE) {
+				// CREATE then DELETE, so nothing to notify
+				previous.clearReference();
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * postpones the post of the specified event, when it will be time to post,
+	 * the reference might have been cleaned up
+	 *
+	 * (package-private for test purposes)
+	 */
+	void schedulePost(final EventReference event) {
+		executor.schedule(new Runnable() {
+			@Override
+			public void run() {
+				synchronized (queue) {
+					try {
+						if (event.isPresent()) {
+							eventBus.post(event.getReference());
+						}
+					} finally {
+						dequeue(event.getKey(), event);
+					}
+				}
+			}
+		}, coalescePeriod, TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * remove the specified event from the queue
+	 *
+	 * (package-private for test purposes)
+	 */
+	void dequeue(FileWatchEventKey key, EventReference event) {
+		Deque<EventReference> fileEvents;
+		if ((fileEvents = queue.get(key)) != null) {
+			if (fileEvents.remove(event) && fileEvents.isEmpty()) {
+				queue.remove(key); // no more events for this key, remove the stack
+			}
+		}
+	}
+
+	/**
+	 * clear all events
+	 *
+	 * (package-private for test purposes)
+	 */
+	void clear() {
+		synchronized (queue) {
+			queue.clear();
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		executor.shutdownNow();
+	}
+
+	/**
+	 * key used for the storage of an event, composed by file paths, two event with same keys, are for the same physical file
+	 */
+	static class FileWatchEventKey {
+		static FileWatchEventKey fromEvent(FileWatchEvent event) {
+			return new FileWatchEventKey(event.getDir(), event.getPath());
+		}
+
+		private final Path dir;
+		private final Path path;
+
+		private FileWatchEventKey(Path dir, Path path) {
+			this.dir = dir;
+			this.path = path;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (!(o instanceof FileWatchEventKey))
+				return false;
+
+			FileWatchEventKey that = (FileWatchEventKey) o;
+
+			return dir.equals(that.dir) && path.equals(that.path);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = dir.hashCode();
+			result = 31 * result + path.hashCode();
+			return result;
+		}
+	}
+
+	/**
+	 * this is a reference holder, the reference might have been cleaned up, and be null
+	 *
+	 * it also stores the key of the event, in order to avoid key recalculation
+	 */
+	static class EventReference {
+		static EventReference of(FileWatchEventKey key, FileWatchEvent reference) {
+			return new EventReference(key, reference);
+		}
+
+		private final FileWatchEventKey key;
+		private FileWatchEvent reference;
+
+		private EventReference(FileWatchEventKey key, FileWatchEvent reference) {
+			this.key = key;
+			this.reference = reference;
+		}
+
+		public void updateReference(FileWatchEvent newEvent) {
+			reference = newEvent;
+		}
+
+		public void clearReference() {
+			reference = null;
+		}
+
+		public boolean isPresent() {
+			return reference != null;
+		}
+
+		public FileWatchEventKey getKey() {
+			return key;
+		}
+
+		public FileWatchEvent getReference() {
+			return reference;
+		}
+	}
+}

--- a/restx-common/src/main/java/restx/common/watch/FileWatchEventCoalescor.java
+++ b/restx-common/src/main/java/restx/common/watch/FileWatchEventCoalescor.java
@@ -2,15 +2,11 @@ package restx.common.watch;
 
 import com.google.common.eventbus.EventBus;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -25,17 +21,12 @@ import java.util.concurrent.TimeUnit;
  *
  * @author apeyrard
  */
-public class FileWatchEventCoalescor implements Closeable {
-
-	private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-	private final EventBus eventBus;
-	private final long coalescePeriod;
+public class FileWatchEventCoalescor extends EventCoalescor<FileWatchEvent> {
 
 	private final HashMap<FileWatchEventKey, Deque<EventReference>> queue = new HashMap<>();
 
 	public FileWatchEventCoalescor(EventBus eventBus, long coalescePeriod) {
-		this.eventBus = eventBus;
-		this.coalescePeriod = coalescePeriod;
+		super(eventBus, coalescePeriod);
 	}
 
 	/**
@@ -155,11 +146,6 @@ public class FileWatchEventCoalescor implements Closeable {
 		synchronized (queue) {
 			queue.clear();
 		}
-	}
-
-	@Override
-	public void close() throws IOException {
-		executor.shutdownNow();
 	}
 
 	/**

--- a/restx-common/src/main/java/restx/common/watch/StdWatcherService.java
+++ b/restx-common/src/main/java/restx/common/watch/StdWatcherService.java
@@ -44,7 +44,7 @@ public class StdWatcherService implements WatcherService {
         private final WatchService watcher;
         private final Map<WatchKey,Path> keys;
         private final boolean recursive;
-        private final EventCoalescor<Object> coalescor;
+        private final EventCoalescor<FileWatchEvent> coalescor;
         private final Path root;
         private boolean trace = false;
 
@@ -96,7 +96,7 @@ public class StdWatcherService implements WatcherService {
             this.keys = new HashMap<>();
             this.recursive = settings.recurse();
             this.root = dir;
-            this.coalescor = EventCoalescor.generic(eventBus, settings.coalescePeriod());
+            this.coalescor = FileWatchEventCoalescor.create(eventBus, settings.coalescePeriod());
 
             if (recursive) {
                 registerAll(dir);

--- a/restx-common/src/main/java/restx/common/watch/StdWatcherService.java
+++ b/restx-common/src/main/java/restx/common/watch/StdWatcherService.java
@@ -44,7 +44,7 @@ public class StdWatcherService implements WatcherService {
         private final WatchService watcher;
         private final Map<WatchKey,Path> keys;
         private final boolean recursive;
-        private final EventCoalescor coalescor;
+        private final EventCoalescor<Object> coalescor;
         private final Path root;
         private boolean trace = false;
 
@@ -96,7 +96,7 @@ public class StdWatcherService implements WatcherService {
             this.keys = new HashMap<>();
             this.recursive = settings.recurse();
             this.root = dir;
-            this.coalescor = new EventCoalescor(eventBus, settings.coalescePeriod());
+            this.coalescor = EventCoalescor.generic(eventBus, settings.coalescePeriod());
 
             if (recursive) {
                 registerAll(dir);

--- a/restx-common/src/test/java/restx/common/watch/EventCoalescorTest.java
+++ b/restx-common/src/test/java/restx/common/watch/EventCoalescorTest.java
@@ -1,13 +1,14 @@
 package restx.common.watch;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * User: xavierhanin
@@ -27,7 +28,7 @@ public class EventCoalescorTest {
             }
         });
 
-        EventCoalescor coalescor = new EventCoalescor(eventBus, 30);
+        EventCoalescor coalescor = EventCoalescor.generic(eventBus, 30);
 
         coalescor.post("test1");
         coalescor.post("test2");

--- a/restx-common/src/test/java/restx/common/watch/FileWatchEventCoalescorTest.java
+++ b/restx-common/src/test/java/restx/common/watch/FileWatchEventCoalescorTest.java
@@ -1,0 +1,215 @@
+package restx.common.watch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import com.google.common.eventbus.EventBus;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class FileWatchEventCoalescorTest {
+
+	/**
+	 * A utility object for the test, that wrap a {@link FileWatchEventCoalescor}
+	 * and keep reference on events that are scheduled to be posted. It also permits
+	 * to clean the event queue manually.
+	 */
+	static class TestFileWatchEventCoalescor {
+		final List<FileWatchEventCoalescor.EventReference> scheduledEvents = new ArrayList<>();
+
+		FileWatchEventCoalescor coalescor = new FileWatchEventCoalescor(new EventBus(), 50) { // event bus and coalesce time are ignored
+			@Override
+			void schedulePost(EventReference event) {
+				scheduledEvents.add(event);
+			}
+		};
+
+		FileWatchEvent post(String filePath, WatchEvent.Kind<?> kind) {
+			FileWatchEvent event = FileWatchEvent.newInstance(Paths.get("/"), Paths.get("/"), Paths.get(filePath), kind, 1);
+			coalescor.post(event);
+			return event;
+		}
+
+		/*
+			remove noisy event, and return true if it manage to find it
+		 */
+		boolean removeNoise(FileWatchEvent noise) {
+			for (Iterator<FileWatchEventCoalescor.EventReference> it = scheduledEvents.iterator(); it.hasNext(); ) {
+				FileWatchEventCoalescor.EventReference ref = it.next();
+				if (ref.isPresent() && ref.getReference() == noise) {
+					coalescor.dequeue(ref.getKey(), ref);
+					it.remove();
+					return true;
+				}
+			}
+			return false;
+		}
+
+		void clear() {
+			coalescor.clear();
+		}
+	}
+
+	/*
+		No merges here, just very basic events, on separate files
+	 */
+	@Test
+	public void should_send_events() {
+		TestFileWatchEventCoalescor watchEventCoalescor = new TestFileWatchEventCoalescor();
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+		watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_DELETE);
+		watchEventCoalescor.post("tmp/test", StandardWatchEventKinds.ENTRY_MODIFY);
+		watchEventCoalescor.post("tmp/another_file.txt", StandardWatchEventKinds.ENTRY_CREATE);
+
+		assertThat(watchEventCoalescor.scheduledEvents).extracting("reference").extracting("path")
+				.containsOnly(
+						Paths.get("tmp/foo"),
+						Paths.get("tmp/bar"),
+						Paths.get("tmp/test"),
+						Paths.get("tmp/another_file.txt")
+				);
+	}
+
+	@Test
+	public void should_merge_duplicate_events() {
+		TestFileWatchEventCoalescor watchEventCoalescor = new TestFileWatchEventCoalescor();
+		FileWatchEvent noise;
+
+		// try with some create events
+
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+		noise = watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE); // just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+
+		assertThat(watchEventCoalescor.removeNoise(noise)).isTrue();
+
+		assertThat(watchEventCoalescor.scheduledEvents).hasSize(1);
+		FileWatchEvent event = watchEventCoalescor.scheduledEvents.get(0).getReference();
+		assertThat(event.getPath()).isEqualTo(Paths.get("tmp/foo"));
+		assertThat(event.getKind()).isEqualTo(StandardWatchEventKinds.ENTRY_CREATE);
+
+		watchEventCoalescor.clear();
+
+		// try with some delete events
+
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_DELETE);
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_DELETE);
+		noise = watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE); // just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_DELETE);
+
+		assertThat(watchEventCoalescor.removeNoise(noise)).isTrue(); // remove noisy event
+
+		assertThat(watchEventCoalescor.scheduledEvents).hasSize(2);
+		event = watchEventCoalescor.scheduledEvents.get(1).getReference();
+		assertThat(event.getPath()).isEqualTo(Paths.get("tmp/foo"));
+		assertThat(event.getKind()).isEqualTo(StandardWatchEventKinds.ENTRY_DELETE);
+
+		watchEventCoalescor.clear();
+
+		// try with some delete modify
+
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_MODIFY);
+		noise = watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE); // just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_MODIFY);
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_MODIFY);
+
+		assertThat(watchEventCoalescor.removeNoise(noise)).isTrue(); // remove noisy event
+
+		assertThat(watchEventCoalescor.scheduledEvents).hasSize(3);
+		event = watchEventCoalescor.scheduledEvents.get(2).getReference();
+		assertThat(event.getPath()).isEqualTo(Paths.get("tmp/foo"));
+		assertThat(event.getKind()).isEqualTo(StandardWatchEventKinds.ENTRY_MODIFY);
+
+		watchEventCoalescor.clear();
+	}
+	@Test
+	public void should_merge_delete_with_create_events() {
+
+		TestFileWatchEventCoalescor watchEventCoalescor = new TestFileWatchEventCoalescor();
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_DELETE);
+		FileWatchEvent noise = watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE);// just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+
+		assertThat(watchEventCoalescor.removeNoise(noise)).isTrue(); // remove noisy event
+
+		assertThat(watchEventCoalescor.scheduledEvents).hasSize(1);
+		FileWatchEvent event = watchEventCoalescor.scheduledEvents.get(0).getReference();
+		assertThat(event.getPath()).isEqualTo(Paths.get("tmp/foo"));
+		assertThat(event.getKind()).isEqualTo(StandardWatchEventKinds.ENTRY_MODIFY);
+	}
+
+	@Test
+	public void should_merge_create_with_modify_events() {
+		TestFileWatchEventCoalescor watchEventCoalescor = new TestFileWatchEventCoalescor();
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+		FileWatchEvent noise = watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE);// just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_MODIFY);
+
+		assertThat(watchEventCoalescor.removeNoise(noise)).isTrue(); // remove noisy event
+
+		assertThat(watchEventCoalescor.scheduledEvents).hasSize(1);
+		FileWatchEvent event = watchEventCoalescor.scheduledEvents.get(0).getReference();
+		assertThat(event.getPath()).isEqualTo(Paths.get("tmp/foo"));
+		assertThat(event.getKind()).isEqualTo(StandardWatchEventKinds.ENTRY_CREATE);
+	}
+
+	@Test
+	public void should_remove_consecutive_create_and_delete_events() {
+		TestFileWatchEventCoalescor watchEventCoalescor = new TestFileWatchEventCoalescor();
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+		FileWatchEvent noise = watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE);// just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_DELETE);
+
+		assertThat(watchEventCoalescor.removeNoise(noise)).isTrue(); // remove noisy event
+
+		assertThat(watchEventCoalescor.scheduledEvents).hasSize(1);
+		assertThat(watchEventCoalescor.scheduledEvents.get(0).isPresent()).isFalse();
+	}
+
+	@Test
+	public void should_only_merge_consecutive_events_for_a_file() {
+		TestFileWatchEventCoalescor watchEventCoalescor = new TestFileWatchEventCoalescor();
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_MODIFY);
+		FileWatchEvent noise1 = watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE);// just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_DELETE);
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_MODIFY);
+		watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE);// just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+
+		assertThat(watchEventCoalescor.removeNoise(noise1)).isTrue(); // remove noisy event (only one, they have been merged)
+
+		assertThat(watchEventCoalescor.scheduledEvents).hasSize(4); // MODIFY, DELETE, MODIFY, CREATE
+		assertThat(watchEventCoalescor.scheduledEvents).extracting("reference").extracting("kind")
+				.containsExactly(
+						StandardWatchEventKinds.ENTRY_MODIFY,
+						StandardWatchEventKinds.ENTRY_DELETE,
+						StandardWatchEventKinds.ENTRY_MODIFY,
+						StandardWatchEventKinds.ENTRY_CREATE
+				);
+	}
+
+	@Test
+	public void should_merge_classic_idea_on_windows_behavior() {
+		TestFileWatchEventCoalescor watchEventCoalescor = new TestFileWatchEventCoalescor();
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_DELETE);
+		FileWatchEvent noise1 = watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE);// just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_CREATE);
+		watchEventCoalescor.post("tmp/bar", StandardWatchEventKinds.ENTRY_CREATE);// just to add some noise
+		watchEventCoalescor.post("tmp/foo", StandardWatchEventKinds.ENTRY_MODIFY);
+
+		assertThat(watchEventCoalescor.removeNoise(noise1)).isTrue(); // remove noisy event
+
+		assertThat(watchEventCoalescor.scheduledEvents).hasSize(1);
+		FileWatchEvent event = watchEventCoalescor.scheduledEvents.get(0).getReference();
+		assertThat(event.getPath()).isEqualTo(Paths.get("tmp/foo"));
+		assertThat(event.getKind()).isEqualTo(StandardWatchEventKinds.ENTRY_MODIFY);
+	}
+}


### PR DESCRIPTION
This `EventCoalescor` permits to merge events for a same file, not only if the event is the same than the previous one, but also with some rules:
- DELETE + CREATE => MODIFY
- CREATE + MODIFY => CREATE
- CREATE + DELETE => discarded

This new coalescor replace the old `EventCoalescor` in `WatcherService` implementation.

This is a breaking commit due to changes in `EventCoalescor` class, from now on its an abstract class, with a private default implementation, which can be created using the factory method:
```
EventCoalescor.generic(eventBus, period);
``` 