### PR TITLE
TypeReference and utility methods

### DIFF
--- a/restx-common/src/main/java/restx/common/TypeReference.java
+++ b/restx-common/src/main/java/restx/common/TypeReference.java
@@ -1,0 +1,38 @@
+package restx.common;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * This abstract class is used to extract generic types.
+ * <p>
+ * The {@code type} attribute hold the {@link Type} of &lt;T&gt;
+ * <p>
+ * For example if this class is used like this:
+ * <pre>
+ *     Type listStringType = new TypeReference&lt;List&lt;String&gt;&gt;() {}.getType();
+ * </pre>
+ * The {@code listStringType} will reference the type {@code List<String>}.
+ * <p>
+ * The idea is based on Gafter's blog post: <a href="http://gafter.blogspot.fr/2006/12/super-type-tokens.html?m=1">
+ *     http://gafter.blogspot.fr/2006/12/super-type-tokens.html?m=1</a>
+ *
+ *
+ * @author apeyrard
+ */
+public abstract class TypeReference<T> {
+	private final Type type;
+
+	@SuppressWarnings("unchecked")
+	protected TypeReference() {
+		Type superClass = getClass().getGenericSuperclass();
+		if (superClass instanceof Class<?>) {
+			throw new IllegalArgumentException("TypeReference must be constructed with type information.");
+		}
+		this.type = ((ParameterizedType) superClass).getActualTypeArguments()[0];
+	}
+
+	public Type getType() { return type; }
+}
+
+

--- a/restx-common/src/main/java/restx/common/Types.java
+++ b/restx-common/src/main/java/restx/common/Types.java
@@ -1,7 +1,11 @@
 package restx.common;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 import java.lang.Class;
 import java.lang.reflect.Array;
@@ -10,6 +14,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.Map;
 
 /**
  * Date: 23/10/13
@@ -30,7 +35,7 @@ public class Types {
 
             @Override
             public Type getOwnerType() {
-                return null;
+                return rawType.getEnclosingClass();
             }
         };
     }
@@ -73,5 +78,145 @@ public class Types {
 
 		throw new IllegalArgumentException(
 				format("Unhandled type %s, unable to extract its raw type.", type));
+	}
+
+	/**
+	 * This method acts like the {@link Class#isAssignableFrom(Class)} but with {@link Type}.
+	 *
+	 * <p>
+	 * {@code true} meant that {@code t1} is assignable from {@code t2},
+	 * in other words, t1 is a super type of t2.
+	 *
+	 * @param t1 the first type
+	 * @param t2 the second type
+	 * @return true if t1 is assignable from t2, false otherwise
+	 */
+	public static boolean isAssignableFrom(Type t1, Type t2) {
+		checkNotNull(t1);
+		checkNotNull(t2);
+
+		if (t1.equals(t2)) {
+			// easy case, types are equals
+			return true;
+		}
+
+		if (t1 instanceof Class<?>) {
+			/*
+				first type is a reifiable class, so any raw type, generic or not,
+				which is assignable by the raw type of t1 means that t1 is assignable from t2
+				and the reverse is also true
+			 */
+			return ((Class<?>) t1).isAssignableFrom(getRawType(t2));
+		}
+
+		if (t1 instanceof ParameterizedType) {
+			Class<?> rawTypeT1 = getRawType(t1);
+			Class<?> rawTypeT2 = getRawType(t2);
+
+			if (!rawTypeT1.isAssignableFrom(rawTypeT2) || rawTypeT1.equals(rawTypeT2)) {
+				/*
+					don't need to go further and to check generics, raw type of first type is not assignable
+					from second one, or raw types are equals but type aren't, so has one can not reference
+					a same type having a different generic type than his, it also means that t1 is not
+					assignable from t2
+				 */
+				return false;
+			}
+
+			if (t2 instanceof Class<?>) {
+				/*
+					we need to launch a recursive analysis on generic super type, and generic interfaces, because
+					t2 is a reifiable class, so there is no way that t1 can be directly assigned from t2,
+					so it has to be one of the sub-types of t2
+				 */
+
+				Type genericSuperclass = ((Class) t2).getGenericSuperclass();
+				if (genericSuperclass != null) {
+					if (isAssignableFrom(t1, genericSuperclass)) {
+						return true;
+					}
+				}
+				Type[] genericInterfaces = ((Class) t2).getGenericInterfaces();
+				for (Type genericInterface : genericInterfaces) {
+					if (isAssignableFrom(t1, genericInterface)) {
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			if (t2 instanceof ParameterizedType) {
+				/*
+					Extract generics type, and variables of the class, in order to know the concrete type of each variables
+				 */
+				Type[] actualTypeArguments = ((ParameterizedType) t2).getActualTypeArguments();
+				TypeVariable<? extends Class<?>>[] typeParameters = rawTypeT2.getTypeParameters();
+				Map<TypeVariable<? extends Class<?>>, Type> typesMap = Maps.newHashMapWithExpectedSize(typeParameters.length);
+				for (int i = 0; i < typeParameters.length; i++) {
+					typesMap.put(typeParameters[i], actualTypeArguments[i]);
+				}
+
+				/*
+					Try with the superclass, and fill variable with concrete types
+				 */
+				Type genericSuperclass = rawTypeT2.getGenericSuperclass();
+				if (genericSuperclass != null) {
+					if (genericSuperclass instanceof Class<?>) {
+						if (isAssignableFrom(t1, genericSuperclass)) {
+							return true;
+						}
+					} else if (genericSuperclass instanceof ParameterizedType) {
+						/*
+							We need to replace type parameters with concrete types
+						 */
+						ParameterizedType genericSuperclassParameterized = (ParameterizedType) genericSuperclass;
+						Type[] genericSuperclassActualTypeArguments = genericSuperclassParameterized.getActualTypeArguments();
+						for (int i = 0; i < genericSuperclassActualTypeArguments.length; i++) {
+							if (genericSuperclassActualTypeArguments[i] instanceof TypeVariable) {
+								genericSuperclassActualTypeArguments[i] = typesMap.get(genericSuperclassActualTypeArguments[i]);
+							}
+						}
+						Type genericSuperclassRawType = genericSuperclassParameterized.getRawType();
+						if (isAssignableFrom(t1, Types.newParameterizedType((Class<?>) genericSuperclassRawType,
+								genericSuperclassActualTypeArguments))) {
+							return true;
+						}
+					}
+				}
+
+				/*
+					Try the same thing with interfaces
+				 */
+				Type[] genericInterfaces = rawTypeT2.getGenericInterfaces();
+				for (Type genericInterface : genericInterfaces) {
+					if (genericInterface instanceof Class<?>) {
+						if (isAssignableFrom(t1, genericInterface)) {
+							return true;
+						}
+					} else if (genericInterface instanceof ParameterizedType) {
+						/*
+							We need to replace type parameters with concrete types
+						 */
+						ParameterizedType genericInterfaceParameterized = (ParameterizedType) genericInterface;
+						Type[] genericInterfaceActualTypeArguments = genericInterfaceParameterized.getActualTypeArguments();
+						for (int i = 0; i < genericInterfaceActualTypeArguments.length; i++) {
+							if (genericInterfaceActualTypeArguments[i] instanceof TypeVariable) {
+								genericInterfaceActualTypeArguments[i] = typesMap.get(genericInterfaceActualTypeArguments[i]);
+							}
+						}
+						Type genericInterfaceRawType = genericInterfaceParameterized.getRawType();
+						if (isAssignableFrom(t1, Types.newParameterizedType((Class<?>) genericInterfaceRawType,
+								genericInterfaceActualTypeArguments))) {
+							return true;
+						}
+					}
+				}
+
+				return false;
+
+			}
+		}
+		return false;
 	}
 }

--- a/restx-common/src/main/java/restx/common/Types.java
+++ b/restx-common/src/main/java/restx/common/Types.java
@@ -1,8 +1,15 @@
 package restx.common;
 
+import static java.lang.String.format;
+
+
 import java.lang.Class;
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
 
 /**
  * Date: 23/10/13
@@ -27,4 +34,44 @@ public class Types {
             }
         };
     }
+
+	/**
+	 * Gets the raw type of the specified type.
+	 *
+	 * <p>
+	 * As defined by <a href="http://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html">
+	 *     http://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html</a>
+	 * The raw type is the name of a generic class or interface without any type arguments.
+	 * <p>
+	 * This method know only how to extract raw type of {@link Class}, {@link ParameterizedType} and {@link GenericArrayType}.
+	 * Calling this method with an instance of {@link TypeVariable} or {@link WildcardType} will throw an
+	 * {@link IllegalArgumentException}.
+	 *
+	 * @param type the type
+	 * @return the raw type corresponding to the specified type
+	 * @throws IllegalArgumentException if the method is called with a type not being an instance of {@link Class},
+	 * {@link ParameterizedType} or {@link GenericArrayType}.
+	 */
+	public static Class<?> getRawType(Type type) {
+		if (type instanceof Class<?>) {
+			return (Class<?>) type;
+		}
+
+		if (type instanceof ParameterizedType) {
+			Type rawType = ((ParameterizedType) type).getRawType();
+			if (rawType instanceof Class<?>) {
+				return (Class<?>) rawType;
+			}
+			throw new IllegalStateException(
+					format("getRawType of the parameterized type %s did not return a class, but %s", type, rawType));
+		}
+
+		if (type instanceof GenericArrayType) {
+			Type componentType = ((GenericArrayType) type).getGenericComponentType();
+			return Array.newInstance(getRawType(componentType), 0).getClass();
+		}
+
+		throw new IllegalArgumentException(
+				format("Unhandled type %s, unable to extract its raw type.", type));
+	}
 }

--- a/restx-common/src/test/java/restx/common/TypesTest.java
+++ b/restx-common/src/test/java/restx/common/TypesTest.java
@@ -1,0 +1,41 @@
+package restx.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test cases for {@link Types} methods.
+ */
+public class TypesTest {
+
+	@Rule
+	public JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+	@Test
+	public void getRawType_should_return_the_class_of_non_parametrized_types() {
+		softly.assertThat(Types.getRawType(Integer.class)).isEqualTo(Integer.class);
+		softly.assertThat(Types.getRawType(String.class)).isEqualTo(String.class);
+		softly.assertThat(Types.getRawType(int.class)).isEqualTo(int.class);
+	}
+
+	@Test
+	public void getRawType_should_return_the_reified_class_of_parametrized_types() {
+		softly.assertThat(Types.getRawType(new TypeReference<List<String>>() {}.getType()))
+				.isEqualTo(List.class);
+		softly.assertThat(Types.getRawType(new TypeReference<Map<String, Integer>>() {}.getType()))
+				.isEqualTo(Map.class);
+	}
+
+	@Test
+	public void getRawType_should_return_the_class_of_array_types() throws NoSuchMethodException {
+		softly.assertThat(Types.getRawType(new TypeReference<List<String>[]>() {}.getType()))
+				.isEqualTo(List[].class);
+	}
+}

--- a/restx-common/src/test/java/restx/common/TypesTest.java
+++ b/restx-common/src/test/java/restx/common/TypesTest.java
@@ -221,72 +221,72 @@ public class TypesTest {
 
 	@Test
 	public void isAssignableFrom_should_work_with_fixed_generic_interface_implementation() {
-		// GenericInterface and TypedImpl
+		// GenericInterface and StringTypedImpl
 
 		softly.assertThat(isAssignableFrom(
 				new TypeReference<GenericInterface<String>>() {}.getType(),
-				TypedImpl.class
+				StringTypedImpl.class
 		)).isTrue();
 
 		softly.assertThat(isAssignableFrom(
 				new TypeReference<GenericInterface<Integer>>() {}.getType(),
-				TypedImpl.class
+				StringTypedImpl.class
 		)).isFalse();
 
-		// GenericInterface and MoreTypedImpl
+		// GenericInterface and MoreStringTypedImpl
 
 		softly.assertThat(isAssignableFrom(
 				new TypeReference<GenericInterface<String>>() {}.getType(),
-				MoreTypedImpl.class
+				MoreStringTypedImpl.class
 		)).isTrue();
 
 		softly.assertThat(isAssignableFrom(
 				new TypeReference<GenericInterface<Integer>>() {}.getType(),
-				MoreTypedImpl.class
+				MoreStringTypedImpl.class
 		)).isFalse();
 
 		softly.assertThat(isAssignableFrom(
-				TypedImpl.class,
-				MoreTypedImpl.class
+				StringTypedImpl.class,
+				MoreStringTypedImpl.class
 		)).isTrue();
 
-		// GenericInterface and GenericTypedImpl
+		// GenericInterface and GenericStringTypedImpl
 
 		softly.assertThat(isAssignableFrom(
 				new TypeReference<GenericInterface<String>>() {}.getType(),
-				new TypeReference<GenericTypedImpl<Integer>>() {}.getType()
+				new TypeReference<GenericStringTypedImpl<Integer>>() {}.getType()
 		)).isTrue();
 
 		softly.assertThat(isAssignableFrom(
 				new TypeReference<GenericInterface<Integer>>() {}.getType(),
-				new TypeReference<GenericTypedImpl<Integer>>() {}.getType()
+				new TypeReference<GenericStringTypedImpl<Integer>>() {}.getType()
 		)).isFalse();
 
-		// GenericInterface, GenericTypedImpl and MoreGenericTypedImpl
+		// GenericInterface, GenericStringTypedImpl and MoreIntegerGenericStringTypedImpl
 
 		softly.assertThat(isAssignableFrom(
 				new TypeReference<GenericInterface<String>>() {}.getType(),
-				new TypeReference<MoreGenericTypedImpl<Integer>>() {}.getType()
+				new TypeReference<MoreIntegerGenericStringTypedImpl<Integer>>() {}.getType()
 		)).isTrue();
 
 		softly.assertThat(isAssignableFrom(
 				new TypeReference<GenericInterface<Integer>>() {}.getType(),
-				new TypeReference<MoreGenericTypedImpl<Integer>>() {}.getType()
+				new TypeReference<MoreIntegerGenericStringTypedImpl<Integer>>() {}.getType()
 		)).isFalse();
 
 		softly.assertThat(isAssignableFrom(
-				new TypeReference<GenericTypedImpl<Integer>>() {}.getType(),
-				new TypeReference<MoreGenericTypedImpl<Integer>>() {}.getType()
+				new TypeReference<GenericStringTypedImpl<Integer>>() {}.getType(),
+				new TypeReference<MoreIntegerGenericStringTypedImpl<Integer>>() {}.getType()
 		)).isTrue();
 
 		softly.assertThat(isAssignableFrom(
-				new TypeReference<GenericTypedImpl<Integer>>() {}.getType(),
-				new TypeReference<MoreGenericTypedImpl<Double>>() {}.getType()
+				new TypeReference<GenericStringTypedImpl<Integer>>() {}.getType(),
+				new TypeReference<MoreIntegerGenericStringTypedImpl<Double>>() {}.getType()
 		)).isTrue();
 
 		softly.assertThat(isAssignableFrom(
-				new TypeReference<GenericTypedImpl<String>>() {}.getType(),
-				new TypeReference<MoreGenericTypedImpl<Double>>() {}.getType()
+				new TypeReference<GenericStringTypedImpl<String>>() {}.getType(),
+				new TypeReference<MoreIntegerGenericStringTypedImpl<Double>>() {}.getType()
 		)).isFalse();
 	}
 
@@ -354,15 +354,15 @@ public class TypesTest {
 
 	public static class MoreUnTypedImpl<T> extends UnTypedImpl<T> {}
 
-	public static class TypedImpl implements GenericInterface<String> {}
+	public static class StringTypedImpl implements GenericInterface<String> {}
 
-	public static class MoreTypedImpl extends TypedImpl {}
-
-	@SuppressWarnings("unused")
-	public static class GenericTypedImpl<T> implements GenericInterface<String> {}
+	public static class MoreStringTypedImpl extends StringTypedImpl {}
 
 	@SuppressWarnings("unused")
-	public static class MoreGenericTypedImpl<T> extends GenericTypedImpl<Integer> {}
+	public static class GenericStringTypedImpl<T> implements GenericInterface<String> {}
+
+	@SuppressWarnings("unused")
+	public static class MoreIntegerGenericStringTypedImpl<T> extends GenericStringTypedImpl<Integer> {}
 
 	@SuppressWarnings("unused")
 	public static class SomethingMap<A, B> implements GenericInterface<A> {}

--- a/restx-common/src/test/java/restx/common/TypesTest.java
+++ b/restx-common/src/test/java/restx/common/TypesTest.java
@@ -1,12 +1,14 @@
 package restx.common;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static restx.common.Types.isAssignableFrom;
 
 
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -38,4 +40,222 @@ public class TypesTest {
 		softly.assertThat(Types.getRawType(new TypeReference<List<String>[]>() {}.getType()))
 				.isEqualTo(List[].class);
 	}
+
+	@Test
+	public void isAssignableFrom_should_return_true_if_types_are_equals() {
+		softly.assertThat(isAssignableFrom(String.class, String.class)).isTrue();
+		softly.assertThat(isAssignableFrom(int.class, int.class)).isTrue();
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<List<String>>() {}.getType(),
+				new TypeReference<List<String>>() {}.getType())
+		).isTrue();
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<List<String>[]>() {}.getType(),
+				new TypeReference<List<String>[]>() {}.getType())
+		).isTrue();
+
+		softly.assertThat(isAssignableFrom(String.class, Number.class)).isFalse();
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<List<String>>() {}.getType(),
+				new TypeReference<Map<String, Integer>>() {}.getType())
+		).isFalse();
+	}
+
+	@Test
+	public void isAssignableFrom_should_return_true_if_first_type_is_a_super_type_of_second_type() {
+		softly.assertThat(isAssignableFrom(CharSequence.class, String.class));
+
+		Type list = List.class;
+		Type listOfString = new TypeReference<List<String>>() {}.getType();
+		Type arrayListOfString = new TypeReference<ArrayList<String>>() {}.getType();
+
+		softly.assertThat(isAssignableFrom(list, listOfString)).isTrue();
+		softly.assertThat(isAssignableFrom(list, arrayListOfString)).isTrue();
+		softly.assertThat(isAssignableFrom(listOfString, arrayListOfString)).isTrue();
+
+		softly.assertThat(isAssignableFrom(listOfString, list)).isFalse();
+		softly.assertThat(isAssignableFrom(arrayListOfString, listOfString)).isFalse();
+
+		softly.assertThat(isAssignableFrom(String.class, CharSequence.class)).isFalse();
+
+
+		// now lets play with some more complex cases
+
+		// UnTypedImpl
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<UnTypedImpl<String>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<UnTypedImpl<Integer>>() {}.getType()
+		)).isFalse();
+
+		// MoreUnTypedImpl
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<MoreUnTypedImpl<String>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<MoreUnTypedImpl<Integer>>() {}.getType()
+		)).isFalse();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<UnTypedImpl<String>>() {}.getType(),
+				new TypeReference<MoreUnTypedImpl<String>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<UnTypedImpl<String>>() {}.getType(),
+				new TypeReference<MoreUnTypedImpl<Integer>>() {}.getType()
+		)).isFalse();
+
+		// TypedImpl
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				TypedImpl.class
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<Integer>>() {}.getType(),
+				TypedImpl.class
+		)).isFalse();
+
+		// MoreTypedImpl
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				MoreTypedImpl.class
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<Integer>>() {}.getType(),
+				MoreTypedImpl.class
+		)).isFalse();
+
+		softly.assertThat(isAssignableFrom(
+				TypedImpl.class,
+				MoreTypedImpl.class
+		)).isTrue();
+
+		// GenericTypedImpl
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<GenericTypedImpl<Integer>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<Integer>>() {}.getType(),
+				new TypeReference<GenericTypedImpl<Integer>>() {}.getType()
+		)).isFalse();
+
+		// MoreGenericTypedImpl
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<MoreGenericTypedImpl<Integer>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<Integer>>() {}.getType(),
+				new TypeReference<MoreGenericTypedImpl<Integer>>() {}.getType()
+		)).isFalse();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericTypedImpl<Integer>>() {}.getType(),
+				new TypeReference<MoreGenericTypedImpl<Integer>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericTypedImpl<Integer>>() {}.getType(),
+				new TypeReference<MoreGenericTypedImpl<Double>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericTypedImpl<String>>() {}.getType(),
+				new TypeReference<MoreGenericTypedImpl<Double>>() {}.getType()
+		)).isFalse();
+
+		// SomethingMap and SuperMap
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<Double>>() {}.getType(),
+				new TypeReference<SomethingMap<Double, Integer>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<SomethingMap<String, Integer>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<SomethingMap<Number, Integer>>() {}.getType()
+		)).isFalse();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<Double>>() {}.getType(),
+				new TypeReference<SuperMap<Integer, Double>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<SuperMap<Integer, String>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<String>>() {}.getType(),
+				new TypeReference<SuperMap<Integer, Number>>() {}.getType()
+		)).isFalse();
+
+		// FixedSomethingMap and FixedSuperMap
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<Double>>() {}.getType(),
+				new TypeReference<FixedSuperMap<Integer, Long>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<Double>>() {}.getType(),
+				new TypeReference<FixedSuperMap<Number, Double>>() {}.getType()
+		)).isTrue();
+
+		softly.assertThat(isAssignableFrom(
+				new TypeReference<GenericInterface<Integer>>() {}.getType(),
+				new TypeReference<FixedSuperMap<Number, Double>>() {}.getType()
+		)).isFalse();
+	}
+
+	/*
+		some classes and interfaces used in isAssignableFrom test cases
+	 */
+
+	public static interface GenericInterface<T> {}
+
+	public static class UnTypedImpl<T> implements GenericInterface<T> {}
+
+	public static class MoreUnTypedImpl<T> extends UnTypedImpl<T> {}
+
+	public static class TypedImpl implements GenericInterface<String> {}
+
+	public static class MoreTypedImpl extends TypedImpl {}
+
+	public static class GenericTypedImpl<T> implements GenericInterface<String> {}
+
+	public static class MoreGenericTypedImpl<T> extends GenericTypedImpl<Integer> {}
+
+	public static class SomethingMap<A, B> implements GenericInterface<A> {}
+
+	public static class SuperMap<A,B> extends SomethingMap<B, String> {}
+
+	public static class FixedSomethingMap<A, B> implements GenericInterface<Double> {}
+
+	public static class FixedSuperMap<A,B> extends FixedSomethingMap<B, String> {}
 }


### PR DESCRIPTION
This PR introduces `TypeReference` an abstract class permitting to construct `ParameterizedType` like that:
```java
new TypeReference<List<String>>() {}.getType();
```

In `Types` class two new methods have been implemented:
- `getRawType` permit to extract a `Class` which is the raw type of a `Type`.
- `isAssignableFrom` permit to know if a type is assignable from another type, like `Class.isAssignableFrom` is doing with classes. 
