### PR TITLE
See #113 - proper use of $artifactId

### DIFF
--- a/restx-build/src/main/resources/restx/build/fragments/maven/war-overlay-resources.xml
+++ b/restx-build/src/main/resources/restx/build/fragments/maven/war-overlay-resources.xml
@@ -6,7 +6,7 @@
                     <overlays>
                         <overlay>
                             <groupId>${project.war.overlay.groupId}</groupId>
-                            <artifactId>${project.war.overlay.groupId}-ui</artifactId>
+                            <artifactId>${project.war.overlay.artifactId}-ui</artifactId>
                             <type>zip</type>
                         </overlay>
                     </overlays>


### PR DESCRIPTION
The property representing the artifact id was not properly used in the generated pom to build the war.

 To test this PR you can do the following in your IDE :

  * make a run configuration with the classpath of `restx-core-shell`
  * export the system property `-Drestx.shell.home=<your workspace location>`
  * run the class `restx.shell.RestxShell`

 Then you will be able to run `app new` and scaffold a new srv/ui layout app (use the latest released version of restx if you want during wizard [0.33.1]).

 If you run a mvn package in the generated app structure, all work as expected.