### PR TITLE
Added grunt test to build.sh

### DIFF
--- a/restx-core-shell/src/main/resources/templates/root/grunt-bower/ui/build.bat
+++ b/restx-core-shell/src/main/resources/templates/root/grunt-bower/ui/build.bat
@@ -2,4 +2,5 @@ REM This script is used to build the front app and put it in the dist directory.
 
 npm install
 bower install
+grunt test
 grunt build

--- a/restx-core-shell/src/main/resources/templates/root/grunt-bower/ui/build.sh
+++ b/restx-core-shell/src/main/resources/templates/root/grunt-bower/ui/build.sh
@@ -4,4 +4,5 @@
 
 npm install
 bower install
+grunt test
 grunt build


### PR DESCRIPTION
When using grunt bower template, added a `grunt test` step to consolidate build of the ui part.
When used with angular-bootstrap-grunt-bower#1 it allows proper test results report handling for the CI server.