### PR TITLE
Better cold classes management

### DIFF
--- a/restx-classloader/pom.xml
+++ b/restx-classloader/pom.xml
@@ -73,6 +73,13 @@
     </dependencies>
     <build>
         <plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<compilerArgument>-proc:none</compilerArgument>
+				</configuration>
+			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/restx-classloader/src/main/java/restx/classloader/Cold.java
+++ b/restx-classloader/src/main/java/restx/classloader/Cold.java
@@ -1,0 +1,21 @@
+package restx.classloader;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation permits to declare a class as cold.
+ *
+ * Once annotated a class will not be hot-reloaded.
+ *
+ * @author apeyrard
+ */
+@Target(TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Cold {
+
+}

--- a/restx-classloader/src/main/java/restx/classloader/ColdClasses.java
+++ b/restx-classloader/src/main/java/restx/classloader/ColdClasses.java
@@ -26,7 +26,7 @@ public class ColdClasses {
 	/**
 	 * Extracts the cold classes from a string containing a list of cold classes.
 	 * <p>
-	 * The {@code coldClasses} parameter contains a list of fqcn separated by ':' character.
+	 * The {@code coldClasses} parameter contains a list of fqcn separated by ',' character.
 	 *
 	 * @param classLoader the classloader to load cold classes
 	 * @param coldClasses all cold classes in a string
@@ -34,7 +34,7 @@ public class ColdClasses {
 	 */
 	public static ImmutableSet<Class<?>> extractFromString(ClassLoader classLoader, String coldClasses) {
 		ImmutableSet.Builder<Class<?>> classes = ImmutableSet.builder();
-		for (String fqcn : Splitter.on(':').split(coldClasses)) {
+		for (String fqcn : Splitter.on(',').trimResults().split(coldClasses)) {
 			try {
 				classes.add(classLoader.loadClass(fqcn));
 			} catch (ClassNotFoundException e) {

--- a/restx-classloader/src/main/java/restx/classloader/ColdClasses.java
+++ b/restx-classloader/src/main/java/restx/classloader/ColdClasses.java
@@ -1,0 +1,38 @@
+package restx.classloader;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper methods to manage cold classes.
+ *
+ * @author apeyrard
+ */
+public class ColdClasses {
+	private static final Logger logger = LoggerFactory.getLogger(ColdClasses.class);
+
+	private ColdClasses() {}
+
+	/**
+	 * Extracts the cold classes from a string containing a list of cold classes.
+	 * <p>
+	 * The {@code coldClasses} parameter contains a list of fqcn separated by ':' character.
+	 *
+	 * @param classLoader the classloader to load cold classes
+	 * @param coldClasses all cold classes in a string
+	 * @return a set of cold classes
+	 */
+	public static ImmutableSet<Class<?>> extractFromString(ClassLoader classLoader, String coldClasses) {
+		ImmutableSet.Builder<Class<?>> classes = ImmutableSet.builder();
+		for (String fqcn : Splitter.on(':').split(coldClasses)) {
+			try {
+				classes.add(classLoader.loadClass(fqcn));
+			} catch (ClassNotFoundException e) {
+				logger.warn("invalid cold class {}: unable to find it from supplied classloader", fqcn);
+			}
+		}
+		return classes.build();
+	}
+}

--- a/restx-classloader/src/main/java/restx/classloader/processor/ColdClassesAnnotationProcessor.java
+++ b/restx-classloader/src/main/java/restx/classloader/processor/ColdClassesAnnotationProcessor.java
@@ -1,0 +1,93 @@
+package restx.classloader.processor;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
+import com.google.common.io.CharStreams;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Set;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import restx.classloader.Cold;
+import restx.classloader.ColdClasses;
+import restx.common.processor.RestxAbstractProcessor;
+
+/**
+ * Annotation processor for the cold classes.
+ *
+ * @author apeyrard
+ */
+@SupportedAnnotationTypes({
+		"restx.classloader.Cold",
+})
+@SupportedOptions({ "debug" })
+public class ColdClassesAnnotationProcessor extends RestxAbstractProcessor {
+	private final ColdClassesAnnotationProcessor.ColdClassesDeclaration coldClassesDeclaration;
+
+	public ColdClassesAnnotationProcessor() {
+		this.coldClassesDeclaration = new ColdClassesDeclaration();
+	}
+
+	@Override
+	protected boolean processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws Exception {
+		coldClassesDeclaration.processing();
+		if (roundEnv.processingOver()) {
+			coldClassesDeclaration.generate();
+		} else {
+			processColdClasses(roundEnv);
+		}
+
+		return true;
+	}
+
+	private void processColdClasses(RoundEnvironment roundEnv) {
+		for (Element annotation : roundEnv.getElementsAnnotatedWith(Cold.class)) {
+			if (!(annotation instanceof TypeElement)) {
+				error("annotating element " + annotation + " of type " + annotation.getKind().name()
+						+ " with @Cold is not supported", annotation);
+				continue;
+			}
+			TypeElement typeElem = (TypeElement) annotation;
+			coldClassesDeclaration.declareColdClass(typeElem.getQualifiedName().toString());
+		}
+	}
+
+	private class ColdClassesDeclaration extends ResourceDeclaration {
+		private final Set<String> coldClasses = Sets.newHashSet();
+
+		protected ColdClassesDeclaration() {
+			super(ColdClasses.COLD_CLASSES_FILE_PATH);
+		}
+
+		void declareColdClass(String coldClass) {
+			coldClasses.add(coldClass);
+		}
+
+		@Override
+		protected boolean requireGeneration() {
+			return coldClasses.size() > 0;
+		}
+
+		@Override
+		protected void clearContent() {
+			coldClasses.clear();
+		}
+
+		@Override
+		protected void writeContent(Writer writer) throws IOException {
+			writer.write(Joiner.on('\n').join(Ordering.natural().sortedCopy(coldClasses)));
+			writer.write('\n');
+		}
+
+		@Override
+		protected void readContent(Reader reader) throws IOException {
+			coldClasses.addAll(CharStreams.readLines(reader));
+		}
+	}
+}

--- a/restx-classloader/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/restx-classloader/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+restx.classloader.processor.ColdClassesAnnotationProcessor

--- a/restx-common/src/main/java/restx/common/MoreClasses.java
+++ b/restx-common/src/main/java/restx/common/MoreClasses.java
@@ -1,0 +1,43 @@
+package restx.common;
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+/**
+ * Provides static utility methods to deal with {@link Class}
+ *
+ * @author apeyrard
+ */
+public class MoreClasses {
+	private MoreClasses() {}
+
+	/**
+	 * Gets all inherited classes for a specified class (in a flat structure). Its super classes, and its interfaces.
+	 *
+	 * This process is recursive, if class A inherit from B which also inherit from C and D, the result will
+	 * be (B, C, D).
+	 *
+	 * @param clazz the clazz to analyse
+	 * @return the list of inherited classes
+	 */
+	public static Set<Class> getInheritedClasses(Class clazz) {
+		Set<Class> inheritedClasses = Sets.newHashSet();
+
+		// add super class, and add recursively their inherited classes
+		Class superClass = clazz.getSuperclass();
+		if (superClass != null) {
+			inheritedClasses.add(superClass);
+			inheritedClasses.addAll(getInheritedClasses(superClass));
+		}
+
+		// add all interfaces, and recursively add their inherited classes
+		Class[] interfaces = clazz.getInterfaces();
+		for (Class anInterface : interfaces) {
+			inheritedClasses.add(anInterface);
+			inheritedClasses.addAll(getInheritedClasses(anInterface));
+		}
+
+		return inheritedClasses;
+	}
+}

--- a/restx-common/src/test/java/restx/common/MoreClassesTest.java
+++ b/restx-common/src/test/java/restx/common/MoreClassesTest.java
@@ -1,0 +1,86 @@
+package restx.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static restx.common.MoreClasses.getInheritedClasses;
+
+
+import org.junit.Test;
+
+import java.io.Closeable;
+import java.io.Externalizable;
+import java.io.FileOutputStream;
+import java.io.Flushable;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.RandomAccess;
+
+/**
+ * Test cases for {@link MoreClasses}
+ *
+ * @author apeyrard
+ */
+public class MoreClassesTest {
+
+	@Test
+	public void should_not_find_inherited_classes_for_primitive_types() {
+		assertThat(getInheritedClasses(void.class)).isEmpty();
+		assertThat(getInheritedClasses(int.class)).isEmpty();
+		assertThat(getInheritedClasses(double.class)).isEmpty();
+	}
+
+	public static class DummyClass { }
+
+	@Test
+	public void should_at_least_find_Object_class_for_classes_without_explicit_inheritance() {
+		assertThat(getInheritedClasses(DummyClass.class)).containsExactly(Object.class);
+	}
+
+	@Test
+	public void should_work_for_interfaces() {
+		assertThat(getInheritedClasses(Externalizable.class)).containsExactly(Serializable.class);
+	}
+
+	@Test
+	public void should_find_inherited_interfaces() {
+		assertThat(getInheritedClasses(Number.class)).containsOnly(Serializable.class, Object.class);
+		assertThat(getInheritedClasses(AbstractCollection.class)).containsOnly(Collection.class, Iterable.class, Object.class);
+	}
+
+	public static class A { }
+	public static class B extends A { }
+	public static class C extends B { }
+
+	@Test
+	public void should_find_inherited_super_classes() {
+		assertThat(getInheritedClasses(B.class)).containsOnly(A.class, Object.class);
+		assertThat(getInheritedClasses(C.class)).containsOnly(B.class, A.class, Object.class);
+	}
+
+	@Test
+	public void should_find_superclasses_and_interfaces() {
+		assertThat(getInheritedClasses(ArrayList.class)).containsOnly(
+				AbstractList.class,
+				AbstractCollection.class,
+				Object.class,
+				List.class,
+				Collection.class,
+				Iterable.class,
+				Serializable.class,
+				RandomAccess.class,
+				Cloneable.class
+		);
+
+		assertThat(getInheritedClasses(FileOutputStream.class)).containsOnly(
+				OutputStream.class,
+				Object.class,
+				Closeable.class,
+				AutoCloseable.class,
+				Flushable.class
+		);
+	}
+}

--- a/restx-core/src/main/java/restx/AppSettings.java
+++ b/restx-core/src/main/java/restx/AppSettings.java
@@ -43,4 +43,7 @@ public interface AppSettings {
 
     @SettingsKey(key = "restx.factory.load")
     Optional<String> factoryLoadMode();
+
+	@SettingsKey(key = "restx.cold.classes")
+	Optional<String> coldClasses();
 }

--- a/restx-core/src/main/java/restx/AppSettingsConfig.java
+++ b/restx-core/src/main/java/restx/AppSettingsConfig.java
@@ -75,4 +75,10 @@ public class AppSettingsConfig implements AppSettings {
         return Optional.fromNullable(Strings.emptyToNull(
                 config.getString("restx.factory.load").or("")));
     }
+
+	@Override
+	public Optional<String> coldClasses() {
+		return Optional.fromNullable(Strings.emptyToNull(
+				config.getString("restx.cold.classes").or("")));
+	}
 }

--- a/restx-core/src/main/java/restx/RestxMainRouterFactory.java
+++ b/restx-core/src/main/java/restx/RestxMainRouterFactory.java
@@ -736,6 +736,13 @@ public class RestxMainRouterFactory {
 						}
 				).or(ImmutableSet.<Class<?>>of()));
 
+				// and finally try to get some cold classes from resources files
+				try {
+					coldClasses.addAll(ColdClasses.extractFromResources(mainFactoryClassLoader));
+				} catch (IOException e) {
+					logger.warn("Unable to extract cold classes from resources, due to {}", e.getMessage());
+				}
+
 				logger.debug("cold classes: {}", coldClasses);
 
                 return ImmutableSet.copyOf(coldClasses);

--- a/restx-core/src/main/java/restx/RestxMainRouterFactory.java
+++ b/restx-core/src/main/java/restx/RestxMainRouterFactory.java
@@ -14,6 +14,8 @@ import com.google.common.eventbus.Subscribe;
 import com.google.common.net.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import restx.classloader.ColdClasses;
 import restx.classloader.CompilationFinishedEvent;
 import restx.classloader.CompilationManager;
 import restx.classloader.CompilationSettings;
@@ -729,15 +731,7 @@ public class RestxMainRouterFactory {
 						new Function<String, ImmutableSet<Class<?>>>() {
 							@Override
 							public ImmutableSet<Class<?>> apply(String input) {
-								ImmutableSet.Builder<Class<?>> classes = ImmutableSet.builder();
-								for (String fqcn : Splitter.on(':').split(input)) {
-									try {
-										classes.add(mainFactoryClassLoader.loadClass(fqcn));
-									} catch (ClassNotFoundException e) {
-										logger.warn("invalid cold class {}: unable to find it from main classloader", fqcn);
-									}
-								}
-								return classes.build();
+								return ColdClasses.extractFromString(mainFactoryClassLoader, input);
 							}
 						}
 				).or(ImmutableSet.<Class<?>>of()));

--- a/restx-core/src/main/java/restx/RestxMainRouterFactory.java
+++ b/restx-core/src/main/java/restx/RestxMainRouterFactory.java
@@ -16,6 +16,7 @@ import restx.classloader.CompilationFinishedEvent;
 import restx.classloader.CompilationManager;
 import restx.classloader.CompilationSettings;
 import restx.classloader.HotReloadingClassLoader;
+import restx.common.MoreClasses;
 import restx.common.RestxConfig;
 import restx.common.metrics.api.MetricRegistry;
 import restx.factory.Factory;
@@ -695,13 +696,16 @@ public class RestxMainRouterFactory {
                 for (Name<?> name : factory.getWarehouse().listNames()) {
                     Optional<?> c = factory.queryByName(name).findOneAsComponent();
                     if (c.isPresent()) {
-                        coldClasses.add(c.get().getClass());
-                    } else {
+						coldClasses.add(c.get().getClass()); // add the component's class
+						coldClasses.addAll(MoreClasses.getInheritedClasses(c.get().getClass())); // add all inherited classes
+					} else {
                         logger.debug(
                                 "invalid cold class {}: found in factory warehouse but not available as component." +
                                 " Ignored.", name);
                     }
                 }
+
+				logger.debug("cold classes: {}", coldClasses);
 
                 return ImmutableSet.copyOf(coldClasses);
             }


### PR DESCRIPTION
This PR permits to manage several new things about cold classes.

- It permits to add inherited classes of cold components (components being loaded in the main factory, such as `AutoStartable` ones) in cold classes list.
- It adds a way to declare cold classes using a property: `restx.cold.classes`. The property value is a list of fqcn separated by `:`.
- It adds a way to declare cold classes using a resource file: `META-INF/cold-classes.list`. Resources will be loaded from the classloader, and every classes listed will be added to the cold classes list. The file must contains a list of fqcn, one per line.
- It provides a way to fulfil the resource file using an annotation: `@Cold`. So every classes annotated with `@Cold` will be added to the resource file (thanks to a new annotation processor).