### PR TITLE
adds a closeable extension to MongoClient (fixes #193)

### DIFF
--- a/restx-jongo/src/main/java/restx/mongo/CloseableMongoClient.java
+++ b/restx-jongo/src/main/java/restx/mongo/CloseableMongoClient.java
@@ -1,0 +1,69 @@
+package restx.mongo;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+
+import java.net.UnknownHostException;
+import java.util.List;
+
+/**
+ * Simple extension of the MongoClient in order to add the {@link AutoCloseable} type.
+ *
+ * @author apeyrard
+ */
+public class CloseableMongoClient extends MongoClient implements AutoCloseable {
+
+	public CloseableMongoClient() throws UnknownHostException {
+	}
+
+	public CloseableMongoClient(String host) throws UnknownHostException {
+		super(host);
+	}
+
+	public CloseableMongoClient(String host, MongoClientOptions options) throws UnknownHostException {
+		super(host, options);
+	}
+
+	public CloseableMongoClient(String host, int port) throws UnknownHostException {
+		super(host, port);
+	}
+
+	public CloseableMongoClient(ServerAddress addr) {
+		super(addr);
+	}
+
+	public CloseableMongoClient(ServerAddress addr, List<MongoCredential> credentialsList) {
+		super(addr, credentialsList);
+	}
+
+	public CloseableMongoClient(ServerAddress addr, MongoClientOptions options) {
+		super(addr, options);
+	}
+
+	public CloseableMongoClient(ServerAddress addr, List<MongoCredential> credentialsList, MongoClientOptions options) {
+		super(addr, credentialsList, options);
+	}
+
+	public CloseableMongoClient(List<ServerAddress> seeds) {
+		super(seeds);
+	}
+
+	public CloseableMongoClient(List<ServerAddress> seeds, List<MongoCredential> credentialsList) {
+		super(seeds, credentialsList);
+	}
+
+	public CloseableMongoClient(List<ServerAddress> seeds, MongoClientOptions options) {
+		super(seeds, options);
+	}
+
+	public CloseableMongoClient(List<ServerAddress> seeds, List<MongoCredential> credentialsList, MongoClientOptions options) {
+		super(seeds, credentialsList, options);
+	}
+
+	public CloseableMongoClient(MongoClientURI uri) throws UnknownHostException {
+		super(uri);
+	}
+}

--- a/restx-jongo/src/main/java/restx/mongo/MongoModule.java
+++ b/restx-jongo/src/main/java/restx/mongo/MongoModule.java
@@ -27,7 +27,7 @@ public class MongoModule {
     @Provides @Named(MONGO_CLIENT_NAME)
     public MongoClient mongoClient(MongoSettings settings) {
         try {
-            return new MongoClient(new MongoClientURI(settings.uri()));
+            return new CloseableMongoClient(new MongoClientURI(settings.uri()));
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
`MongoClient` provides a close method but does not implement the `AutoCloseable`
interface. And the restx factory during its 'close' process is calling `close`
methods on every components implementing the `AutoCloseable` interface.

So the solution for this problem is to override `MongoClient` in order to implement
the `AutoCloseable` interface.