### PR TITLE
Add a request body input handler for String bodies (text/plain).

### DIFF
--- a/restx-core/pom.xml
+++ b/restx-core/pom.xml
@@ -120,5 +120,10 @@
             <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/restx-core/src/main/java/restx/entity/TextContentTypeModule.java
+++ b/restx-core/src/main/java/restx/entity/TextContentTypeModule.java
@@ -1,6 +1,7 @@
 package restx.entity;
 
 import com.google.common.base.Optional;
+import org.apache.commons.io.IOUtils;
 import restx.RestxContext;
 import restx.RestxRequest;
 import restx.RestxResponse;
@@ -33,6 +34,39 @@ public class TextContentTypeModule {
                 } else {
                     return Optional.absent();
                 }
+            }
+        };
+    }
+
+    @Provides
+    public EntityRequestBodyReaderFactory testEntityRequestBodyReaderFactory() {
+        return new EntityRequestBodyReaderFactory() {
+            @Override
+            public Optional<? extends EntityRequestBodyReader> mayBuildFor(Type valueType, String contentType) {
+                if (!contentType.toLowerCase(Locale.ENGLISH).startsWith("text/plain")) {
+                    return Optional.absent();
+                }
+
+                return Optional.of(
+                    new EntityRequestBodyReader<String>() {
+
+                        @Override
+                        public Type getType() {
+                            return String.class;
+                        }
+
+                        @Override
+                        public String readBody(RestxRequest req, RestxContext ctx) throws IOException {
+                            String body;
+                            try {
+                                body = IOUtils.toString(req.getContentStream(), "UTF8");
+                            } finally {
+                                IOUtils.closeQuietly(req.getContentStream());
+                            }
+                            return body;
+                        }
+                    }
+                );
             }
         };
     }


### PR DESCRIPTION
The code base has a String output mapper but doesn't have a String input mapper - which prevents String bodies from being submitted. This patch seeks to address that. Could you please consider merging? Thanks, Joe