### PR TITLE
make RestxAnnotationProcessor reusable for different annotation

### DIFF
--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -22,6 +22,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.*;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -59,7 +60,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
         for (ResourceMethodAnnotation annotation : getResourceMethodAnnotationsInRound(roundEnv)) {
             try {
                 TypeElement typeElem = (TypeElement) annotation.methodElem.getEnclosingElement();
-                RestxResource r = typeElem.getAnnotation(RestxResource.class);
+                ResourceClassDef r = getResourceClassDef(typeElem);
                 if (r == null) {
                     error(
                         String.format("%s rest method found - enclosing class %s must be annotated with @RestxResource",
@@ -85,7 +86,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
 
                 ResourceMethod resourceMethod = new ResourceMethod(
                         resourceClass,
-                        annotation.httpMethod, r.value() + annotation.path,
+                        annotation.httpMethod, r.value + annotation.path,
                         annotation.methodElem.getSimpleName().toString(),
                         annotation.methodElem.getReturnType().toString(),
                         successStatus, logLevel, permission,
@@ -106,6 +107,19 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
             generateFiles(groups, modulesListOriginatingElements);
         }
         return true;
+    }
+
+    protected ResourceClassDef getResourceClassDef(TypeElement typeElem) {
+        RestxResource r = typeElem.getAnnotation(RestxResource.class);
+        ResourceClassDef resourceClassDef = new ResourceClassDef();
+        resourceClassDef.value = r.value();
+        resourceClassDef.priority = r.priority();
+        resourceClassDef.group = r.group();
+        return resourceClassDef;
+    }
+
+    protected Class<? extends Annotation> getRestAnnotationClass() {
+        return RestxResource.class;
     }
 
     private String buildPermission(ResourceMethodAnnotation annotation, TypeElement typeElem) {
@@ -193,21 +207,21 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
         }
     }
 
-    private ResourceGroup getResourceGroup(RestxResource r, Map<String, ResourceGroup> groups) {
-        ResourceGroup group = groups.get(r.group());
+    private ResourceGroup getResourceGroup(ResourceClassDef r, Map<String, ResourceGroup> groups) {
+        ResourceGroup group = groups.get(r.group);
         if (group == null) {
-            groups.put(r.group(), group = new ResourceGroup(r.group()));
+            groups.put(r.group, group = new ResourceGroup(r.group));
         }
         return group;
     }
 
-    private ResourceClass getResourceClass(TypeElement typeElem, RestxResource r, ResourceGroup group, Set<Element> modulesListOriginatingElements) {
+    private ResourceClass getResourceClass(TypeElement typeElem, ResourceClassDef r, ResourceGroup group, Set<Element> modulesListOriginatingElements) {
         String fqcn = typeElem.getQualifiedName().toString();
         ResourceClass resourceClass = group.resourceClasses.get(fqcn);
         if (resourceClass == null) {
             modulesListOriginatingElements.add(typeElem);
             When when = typeElem.getAnnotation(When.class);
-            group.resourceClasses.put(fqcn, resourceClass = new ResourceClass(group, fqcn, r.priority(),
+            group.resourceClasses.put(fqcn, resourceClass = new ResourceClass(group, fqcn, r.priority,
                     when == null ? ""
                             : ("@restx.factory.When(name=\"" + when.name() + "\", value=\"" + when.value() + "\")")));
             resourceClass.originatingElements.add(typeElem);
@@ -371,7 +385,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
 
     private Collection<ResourceMethodAnnotation> getResourceMethodAnnotationsInRound(RoundEnvironment roundEnv) {
         Collection<ResourceMethodAnnotation> methodAnnotations = Lists.newArrayList();
-        for (Element resourceElem : roundEnv.getElementsAnnotatedWith(RestxResource.class)) {
+        for (Element resourceElem : roundEnv.getElementsAnnotatedWith(getRestAnnotationClass())) {
             if (! (resourceElem instanceof TypeElement)) {
                 error(
                     String.format("Only a class can be annotated with @RestxResource. Found %s",
@@ -430,6 +444,12 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
         ResourceGroup(String name) {
             this.name = name;
         }
+    }
+
+    public static class ResourceClassDef {
+        public String value;
+        public String group;
+        public int priority;
     }
 
     private static class ResourceClass {


### PR DESCRIPTION
Now one can extend RestxAnnotationProcessor to define its own processor
recognizing annotations other than RestxResource.

For some need at work, we need to use the restx processor for resources, but our resources are annotated with our own annotation. 
So last Thursday, with Xavier, we did some minor modifications to the AP in order to be able to override the retrieve of data from the annotation.
Some things were missing though. There was a visibility problem with the ResourceClassDef inner class fields and constructor. And the AP was still filtering the RestxResource annotation, by doing this:

``` java
roundEnv.getElementsAnnotatedWith(RestxResource.class)
```

So ResourceClassDef has, from now on, public access, and its fields too.
Another extendable method have been created to get the rest annotation: 

```
protected Class<? extends Annotation> getRestAnnotationClass()
```

With all of this we are able to create a sub-AP defining just this:

``` java
@SupportedAnnotationTypes({
        "our.pkg.OurRestResource"
})
public class OurRestResourceAnnotationProcessor  extends RestxAnnotationProcessor {

    @Override
    protected ResourceClassDef getResourceClassDef(TypeElement typeElem) {
        OurRestResource r = typeElem.getAnnotation(OurRestResource.class);
        ResourceClassDef resourceClassDef = new ResourceClassDef();
        resourceClassDef.value = r.value();
        resourceClassDef.priority = r.priority();
        resourceClassDef.group = r.group();
        return resourceClassDef;
    }

    @Override
    protected Class<? extends Annotation> getRestAnnotationClass() {
        return OurRestResource.class;
    }
}
```

WDYT ?
