### PR TITLE
Remove jetty stuff from packaging

### DIFF
--- a/restx-build/src/main/java/restx/build/GAV.java
+++ b/restx-build/src/main/java/restx/build/GAV.java
@@ -6,19 +6,25 @@ package restx.build;
  * Time: 2:21 PM
  */
 public class GAV {
+    private static final String OPTIONAL_SUFFIX = "!optional";
     public static GAV parse(String gav) {
         String[] parts = gav.split(":");
         if (parts.length < 3 || parts.length > 5) {
             throw new IllegalArgumentException("can't parse '" + gav + "' as a module coordinates (GAV). " +
                     "It must have at least 3 parts separated by columns. (4th and 5th are optional and correspond to artifact type and classifier)");
         }
+        boolean optional = false;
+        if(parts[parts.length-1].endsWith(OPTIONAL_SUFFIX)) {
+            optional = true;
+            parts[parts.length-1] = parts[parts.length-1].substring(0, parts[parts.length-1].length()-OPTIONAL_SUFFIX.length());
+        }
         if(parts.length == 3) {
-            return new GAV(parts[0], parts[1], parts[2]);
+            return new GAV(parts[0], parts[1], parts[2], optional);
         }
         if(parts.length == 4) {
-        	return new GAV(parts[0], parts[1], parts[2], parts[3]);
+        	return new GAV(parts[0], parts[1], parts[2], parts[3], optional);
         }
-    	return new GAV(parts[0], parts[1], parts[2], parts[3], parts[4]);
+    	return new GAV(parts[0], parts[1], parts[2], parts[3], parts[4], optional);
     }
 
     private final String groupId;
@@ -26,21 +32,23 @@ public class GAV {
     private final String version;
     private final String type;
     private final String classifier;
+    private final boolean optional;
 
-    public GAV(String groupId, String artifactId, String version) {
-        this(groupId, artifactId, version, null, null);
+    public GAV(String groupId, String artifactId, String version, final boolean optional) {
+        this(groupId, artifactId, version, null, null, optional);
     }
 
-    public GAV(String groupId, String artifactId, String version, String type) {
-        this(groupId, artifactId, version, type, null);
+    public GAV(String groupId, String artifactId, String version, String type, final boolean optional) {
+        this(groupId, artifactId, version, type, null, optional);
     }
     
-    public GAV(final String groupId, final String artifactId, final String version, final String type, final String classifier) {
+    public GAV(final String groupId, final String artifactId, final String version, final String type, final String classifier, final boolean optional) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
         this.type = type;
         this.classifier = classifier;
+        this.optional = optional;
     }
 
     public String getGroupId() {
@@ -62,7 +70,11 @@ public class GAV {
     public String getClassifier() {
     	return classifier;
     }
-    
+
+    public boolean isOptional() {
+        return optional;
+    }
+
     @Override
     public String toString() {
         return groupId + ":" + artifactId + ":" + version;
@@ -74,12 +86,13 @@ public class GAV {
      * through GAV.parse()
      */
     public String toParseableString(){
+        String suffix = optional?OPTIONAL_SUFFIX:"";
         if (type == null){
-            return groupId + ":" + artifactId + ":" + version;
+            return groupId + ":" + artifactId + ":" + version + suffix;
         }
         if(classifier == null) {
-            return groupId + ":" + artifactId + ":" + version + ":" + type;
+            return groupId + ":" + artifactId + ":" + version + ":" + type + suffix;
         }
-        return groupId + ":" + artifactId + ":" + version + ":" + type + ":" + classifier;
+        return groupId + ":" + artifactId + ":" + version + ":" + type + ":" + classifier + suffix;
     }
 }

--- a/restx-build/src/main/java/restx/build/GAV.java
+++ b/restx-build/src/main/java/restx/build/GAV.java
@@ -65,9 +65,21 @@ public class GAV {
     
     @Override
     public String toString() {
+        return groupId + ":" + artifactId + ":" + version;
+    }
+
+    /**
+     * toString() will only generate simple GAV whereas toParseableString()
+     * should generate a String that should return the same GAV content when parsed
+     * through GAV.parse()
+     */
+    public String toParseableString(){
         if (type == null){
             return groupId + ":" + artifactId + ":" + version;
         }
-        return groupId + ":" + artifactId + ":" + version + ":" + type;
+        if(classifier == null) {
+            return groupId + ":" + artifactId + ":" + version + ":" + type;
+        }
+        return groupId + ":" + artifactId + ":" + version + ":" + type + ":" + classifier;
     }
 }

--- a/restx-build/src/main/java/restx/build/MavenSupport.java
+++ b/restx-build/src/main/java/restx/build/MavenSupport.java
@@ -79,7 +79,7 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
                     String.valueOf(jsonObject.get("version")),
                     typeKey==null?null:jsonObject.has(typeKey)?jsonObject.getString(typeKey):null,
                     jsonObject.has("classifier")?jsonObject.getString("classifier"):null,
-                    false);
+                    jsonObject.has("optional")?jsonObject.getBoolean("optional"):false);
         }
     }
     static class Generator {
@@ -178,7 +178,10 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
             }
             if(gav.getClassifier() != null) {
                 writeXmlTag(w, indent, "classifier", gav.getClassifier());
-            }            
+            }
+            if(gav.isOptional()) {
+                writeXmlTag(w, indent, "optional", Boolean.TRUE.toString());
+            }
         }
 
         private void writeXmlTag(Writer w, String indent, String tag, String val) throws IOException {

--- a/restx-build/src/main/java/restx/build/MavenSupport.java
+++ b/restx-build/src/main/java/restx/build/MavenSupport.java
@@ -78,7 +78,8 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
                     jsonObject.getString("artifactId"),
                     String.valueOf(jsonObject.get("version")),
                     typeKey==null?null:jsonObject.has(typeKey)?jsonObject.getString(typeKey):null,
-                    jsonObject.has("classifier")?jsonObject.getString("classifier"):null);
+                    jsonObject.has("classifier")?jsonObject.getString("classifier"):null,
+                    false);
         }
     }
     static class Generator {

--- a/restx-build/src/main/java/restx/build/RestxJsonSupport.java
+++ b/restx-build/src/main/java/restx/build/RestxJsonSupport.java
@@ -25,9 +25,9 @@ public class RestxJsonSupport implements RestxBuild.Parser, RestxBuild.Generator
             w.write("{\n");
 
             if (md.getParent() != null) {
-                w.write(String.format("    \"parent\": \"%s\",\n", md.getParent()));
+                w.write(String.format("    \"parent\": \"%s\",\n", md.getParent().toParseableString()));
             }
-            w.write(String.format("    \"module\": \"%s\",\n", md.getGav()));
+            w.write(String.format("    \"module\": \"%s\",\n", md.getGav().toString()));
             if (!"jar".equals(md.getPackaging())) {
                 w.write(String.format("    \"packaging\": \"%s\",\n", md.getPackaging()));
             }
@@ -52,7 +52,7 @@ public class RestxJsonSupport implements RestxBuild.Parser, RestxBuild.Generator
                 w.write(String.format("        \"%s\": [\n", scope));
                 for (Iterator<ModuleDependency> itDeps = md.getDependencies(scope).iterator(); itDeps.hasNext(); ) {
                     ModuleDependency dependency = itDeps.next();
-                    w.write(String.format("            \"%s\"", dependency.getGav()));
+                    w.write(String.format("            \"%s\"", dependency.getGav().toParseableString()));
                     if (itDeps.hasNext()) {
                         w.write(",");
                     }

--- a/restx-build/src/test/java/restx/build/GAVTest.java
+++ b/restx-build/src/test/java/restx/build/GAVTest.java
@@ -18,11 +18,17 @@ public class GAVTest {
     }
 
     @Test
+    public void should_parse_classifier_artifact(){
+        shouldBeConsistent("restx:restx-ui:0.2:zip:jdk8");
+        shouldBeConsistent("restx:restx-ui:0.2:jar:jdk8");
+    }
+
+    @Test
     public void should_parse_artifact_with_type() throws Exception {
         shouldBeConsistent("restx:restx-ui:0.2:zip");
     }
 
     private void shouldBeConsistent(String gav) {
-        assertThat(GAV.parse(gav).toString()).isEqualTo(gav);
+        assertThat(GAV.parse(gav).toParseableString()).isEqualTo(gav);
     }
 }

--- a/restx-build/src/test/java/restx/build/GAVTest.java
+++ b/restx-build/src/test/java/restx/build/GAVTest.java
@@ -24,6 +24,13 @@ public class GAVTest {
     }
 
     @Test
+    public void should_parse_optional_artifact(){
+        shouldBeConsistent("restx:restx-ui:0.2!optional");
+        shouldBeConsistent("restx:restx-ui:0.2:zip!optional");
+        shouldBeConsistent("restx:restx-ui:0.2:jar:jdk8!optional");
+    }
+
+    @Test
     public void should_parse_artifact_with_type() throws Exception {
         shouldBeConsistent("restx:restx-ui:0.2:zip");
     }

--- a/restx-build/src/test/java/restx/build/RestxBuildTest.java
+++ b/restx-build/src/test/java/restx/build/RestxBuildTest.java
@@ -86,6 +86,15 @@ public class RestxBuildTest {
         shouldGenerate(json, "Module8.restx.json", maven, "Module8.pom.xml");
     }
 
+    @Test
+    public void should_generate_pom_with_optional_dependency() throws Exception {
+        shouldGenerate(json, "Module9.restx.json", maven, "Module9.pom.xml");
+    }
+
+    @Test
+    public void should_parse_simple_pom_with_optional_dependency() throws Exception {
+        shouldGenerate(maven, "Module9.pom.xml", json, "Module9.restx.json");
+    }
 
     private void shouldGenerate(RestxBuild.Parser parser, String module, RestxBuild.Generator generator, String expected) throws IOException {
         URL resource = getClass().getResource(module);

--- a/restx-build/src/test/resources/restx/build/Module9.pom.xml
+++ b/restx-build/src/test/resources/restx/build/Module9.pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>example-parent</artifactId>
+        <version>0.8</version>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>example-common</artifactId>
+    <version>0.2-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>example-common</name>
+
+    <properties>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <joda-time.version>2.0</joda-time.version>
+        <junit.version>4.11</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>14.0-rc2</version>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${joda-time.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+            <version>0.8.10</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert-core</artifactId>
+            <version>2.0M8</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/restx-build/src/test/resources/restx/build/Module9.restx.json
+++ b/restx-build/src/test/resources/restx/build/Module9.restx.json
@@ -1,0 +1,22 @@
+{
+    "parent": "com.example:example-parent:0.8",
+    "module": "com.example:example-common:0.2-SNAPSHOT",
+
+    "properties": {
+        "java.version": "1.7",
+        "joda-time.version": "2.0",
+        "junit.version": "4.11"
+    },
+
+    "dependencies": {
+        "compile": [
+            "com.google.guava:guava:14.0-rc2",
+            "joda-time:joda-time:${joda-time.version}",
+            "com.github.spullara.mustache.java:compiler:0.8.10!optional"
+        ],
+        "test": [
+            "junit:junit:${junit.version}",
+            "org.easytesting:fest-assert-core:2.0M8"
+        ]
+    }
+}

--- a/restx-core-shell/src/main/resources/templates/srv/main/_md.restx.json
+++ b/restx-core-shell/src/main/resources/templates/srv/main/_md.restx.json
@@ -33,7 +33,8 @@
 {{#includeStatsModule}}
             "io.restx:restx-stats-admin:${restx.version}",
 {{/includeStatsModule}}
-            "io.restx:restx-server-jetty:${restx.version}",
+            "io.restx:restx-servlet:${restx.version}",
+            "io.restx:restx-server-jetty:${restx.version}!optional",
             "io.restx:restx-apidocs:${restx.version}",
             "io.restx:restx-specs-admin:${restx.version}",
             "io.restx:restx-admin:${restx.version}",


### PR DESCRIPTION
This PR fixes #220 

It introduces the possibility to define an `optional` dependency in `md.restx.json` file by using the `!optional` dependency suffix
Note that `optional` dependencies equivalent doesn't seem to exist in ivy (or at least, I don't have enough knowledge to be able to reproduce this behaviour), thus, I didn't implemented anything to convert this info to ivy module file.
