### PR TITLE
Introduced CurrentLocaleResolver component

### DIFF
--- a/restx-i18n/src/main/java/restx/i18n/CurrentLocaleResolver.java
+++ b/restx-i18n/src/main/java/restx/i18n/CurrentLocaleResolver.java
@@ -1,0 +1,13 @@
+package restx.i18n;
+
+import restx.RestxRequest;
+import restx.StdRequest;
+
+import java.util.Locale;
+
+/**
+ * @author fcamblor
+ */
+public interface CurrentLocaleResolver {
+    Locale guessLocale(RestxRequest request);
+}

--- a/restx-i18n/src/main/java/restx/i18n/I18nModule.java
+++ b/restx-i18n/src/main/java/restx/i18n/I18nModule.java
@@ -2,6 +2,7 @@ package restx.i18n;
 
 import restx.AppSettings;
 import restx.RestxContext;
+import restx.RestxRequest;
 import restx.factory.Module;
 import restx.factory.Provides;
 
@@ -23,6 +24,16 @@ public class I18nModule {
         } else {
             return new DefaultMutableMessages("labels", StandardCharsets.UTF_8);
         }
+    }
+
+    @Provides @Named("CurrentLocaleResolver")
+    public CurrentLocaleResolver currentLocaleResolver(){
+        return new CurrentLocaleResolver() {
+            @Override
+            public Locale guessLocale(RestxRequest request) {
+                return request.getLocale();
+            }
+        };
     }
 
     @Provides @Named("ROOT")


### PR DESCRIPTION
This component allows to provide an extension point to guess default current locale in `MessagesRouter`

It may be useful if, for instance, `request.getLocale()` is not *always* the good implementation to guess current user's locale (for instance if the user's locale is part of the user's data)