### PR TITLE
[breaking] Variabilized security roles

### DIFF
--- a/restx-admin/src/main/java/restx/admin/AdminModule.java
+++ b/restx-admin/src/main/java/restx/admin/AdminModule.java
@@ -86,7 +86,7 @@ public class AdminModule {
                                 public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
                                     final RestxSession current = RestxSession.current();
                                     if (current.getPrincipal().isPresent() &&
-                                            Permissions.hasRole(RESTX_ADMIN_ROLE).has(current.getPrincipal().get(), req).isPresent()) {
+                                            Permissions.hasRole(RESTX_ADMIN_ROLE).has(current.getPrincipal().get(), req, match).isPresent()) {
                                         ctx.nextHandlerMatch().handle(req, resp, ctx);
                                     } else {
                                         throw new WebException(HttpStatus.UNAUTHORIZED);

--- a/restx-admin/src/main/java/restx/admin/AdminModule.java
+++ b/restx-admin/src/main/java/restx/admin/AdminModule.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.Hashing;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.regex.Pattern;
 import restx.RestxContext;
 import restx.RestxFilter;
@@ -86,7 +87,7 @@ public class AdminModule {
                                 public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
                                     final RestxSession current = RestxSession.current();
                                     if (current.getPrincipal().isPresent() &&
-                                            Permissions.hasRole(RESTX_ADMIN_ROLE).has(current.getPrincipal().get(), req, match).isPresent()) {
+                                            Permissions.hasRole(RESTX_ADMIN_ROLE).has(current.getPrincipal().get(), Collections.<String, String>emptyMap()).isPresent()) {
                                         ctx.nextHandlerMatch().handle(req, resp, ctx);
                                     } else {
                                         throw new WebException(HttpStatus.UNAUTHORIZED);

--- a/restx-admin/src/main/java/restx/admin/AdminModule.java
+++ b/restx-admin/src/main/java/restx/admin/AdminModule.java
@@ -73,7 +73,7 @@ public class AdminModule {
     }
 
     @Provides
-    public RestxFilter adminRoleFilter() {
+    public RestxFilter adminRoleFilter(final PermissionFactory permissionFactory) {
         return new RestxFilter() {
             final Pattern privatePath = Pattern.compile("^/@/(?!(ui|webjars)/).*$");
 
@@ -87,7 +87,7 @@ public class AdminModule {
                                 public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
                                     final RestxSession current = RestxSession.current();
                                     if (current.getPrincipal().isPresent() &&
-                                            Permissions.hasRole(RESTX_ADMIN_ROLE).has(current.getPrincipal().get(), Collections.<String, String>emptyMap()).isPresent()) {
+                                            permissionFactory.hasRole(RESTX_ADMIN_ROLE).has(current.getPrincipal().get(), Collections.<String, String>emptyMap()).isPresent()) {
                                         ctx.nextHandlerMatch().handle(req, resp, ctx);
                                     } else {
                                         throw new WebException(HttpStatus.UNAUTHORIZED);

--- a/restx-admin/src/main/java/restx/exceptions/ErrorDescriptorsRoute.java
+++ b/restx-admin/src/main/java/restx/exceptions/ErrorDescriptorsRoute.java
@@ -50,7 +50,7 @@ public class ErrorDescriptorsRoute extends StdJsonProducerEntityRoute {
 
     @Override
     protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object i) throws IOException {
-        securityManager.check(restxRequest, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(restxRequest, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
         return Optional.of(errorDescriptors.values());
     }
 }

--- a/restx-admin/src/main/java/restx/exceptions/ErrorDescriptorsRoute.java
+++ b/restx-admin/src/main/java/restx/exceptions/ErrorDescriptorsRoute.java
@@ -1,8 +1,5 @@
 package restx.exceptions;
 
-import static restx.security.Permissions.hasRole;
-
-
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableCollection;
@@ -15,6 +12,7 @@ import restx.admin.AdminModule;
 import restx.factory.Component;
 import restx.jackson.FrontObjectMapperFactory;
 import restx.jackson.StdJsonProducerEntityRoute;
+import restx.security.PermissionFactory;
 import restx.security.RestxSecurityManager;
 
 import javax.inject.Named;
@@ -31,12 +29,15 @@ public class ErrorDescriptorsRoute extends StdJsonProducerEntityRoute {
 
     private final ImmutableMap<String, ErrorDescriptor> errorDescriptors;
     private final RestxSecurityManager securityManager;
+    private PermissionFactory permissionFactory;
 
     public ErrorDescriptorsRoute(Iterable<ErrorDescriptor> errorDescriptors,
                                  @Named(FrontObjectMapperFactory.WRITER_NAME) ObjectWriter objectWriter,
-                                 RestxSecurityManager securityManager) {
+                                 RestxSecurityManager securityManager,
+                                 PermissionFactory permissionFactory) {
 
         super("ErrorDescriptorsRoute", ImmutableCollection.class, objectWriter, new StdRestxRequestMatcher("GET", "/@/errors/descriptors"));
+        this.permissionFactory = permissionFactory;
         Map<String, ErrorDescriptor> map = Maps.newLinkedHashMap();
         for (ErrorDescriptor errorDescriptor : errorDescriptors) {
             if (map.containsKey(errorDescriptor.getErrorCode())) {
@@ -50,7 +51,7 @@ public class ErrorDescriptorsRoute extends StdJsonProducerEntityRoute {
 
     @Override
     protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object i) throws IOException {
-        securityManager.check(restxRequest, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(restxRequest, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
         return Optional.of(errorDescriptors.values());
     }
 }

--- a/restx-admin/src/main/java/restx/exceptions/ErrorDescriptorsRoute.java
+++ b/restx-admin/src/main/java/restx/exceptions/ErrorDescriptorsRoute.java
@@ -34,10 +34,9 @@ public class ErrorDescriptorsRoute extends StdJsonProducerEntityRoute {
     public ErrorDescriptorsRoute(Iterable<ErrorDescriptor> errorDescriptors,
                                  @Named(FrontObjectMapperFactory.WRITER_NAME) ObjectWriter objectWriter,
                                  RestxSecurityManager securityManager,
-                                 PermissionFactory permissionFactory) {
-
-        super("ErrorDescriptorsRoute", ImmutableCollection.class, objectWriter, new StdRestxRequestMatcher("GET", "/@/errors/descriptors"));
-        this.permissionFactory = permissionFactory;
+                                 PermissionFactory permissionFactory
+    ) {
+        super("ErrorDescriptorsRoute", ImmutableCollection.class, objectWriter, new StdRestxRequestMatcher("GET", "/@/errors/descriptors"), permissionFactory);
         Map<String, ErrorDescriptor> map = Maps.newLinkedHashMap();
         for (ErrorDescriptor errorDescriptor : errorDescriptors) {
             if (map.containsKey(errorDescriptor.getErrorCode())) {

--- a/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
+++ b/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
@@ -50,7 +50,7 @@ public class ApiDeclarationRoute extends StdJsonProducerEntityRoute {
     @Inject
     public ApiDeclarationRoute(@Named(FrontObjectMapperFactory.WRITER_NAME) ObjectWriter writer,
                                Factory factory, RestxSecurityManager securityManager, PermissionFactory permissionFactory) {
-        super("ApiDeclarationRoute", Map.class, writer, new StdRestxRequestMatcher("GET", "/@/api-docs/{router}"));
+        super("ApiDeclarationRoute", Map.class, writer, new StdRestxRequestMatcher("GET", "/@/api-docs/{router}"), permissionFactory);
         this.factory = factory;
         this.securityManager = securityManager;
         this.permissionFactory = permissionFactory;

--- a/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
+++ b/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
@@ -56,7 +56,7 @@ public class ApiDeclarationRoute extends StdJsonProducerEntityRoute {
 
     @Override
     protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object body) throws IOException {
-        securityManager.check(restxRequest, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(restxRequest, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
         String routerName = match.getPathParam("router");
         Optional<NamedComponent<RestxRouter>> router = getRouterByName(factory, routerName);
 

--- a/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
+++ b/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
@@ -13,6 +13,7 @@ import restx.factory.Name;
 import restx.factory.NamedComponent;
 import restx.jackson.FrontObjectMapperFactory;
 import restx.jackson.StdJsonProducerEntityRoute;
+import restx.security.PermissionFactory;
 import restx.security.RestxSecurityManager;
 
 import javax.inject.Inject;
@@ -21,7 +22,6 @@ import java.io.IOException;
 import java.util.*;
 
 import static restx.apidocs.ApiDocsIndexRoute.getRouterApiPath;
-import static restx.security.Permissions.hasRole;
 
 /**
  * Serves the swagger api declaration of one router, which looks like that:
@@ -45,18 +45,20 @@ import static restx.security.Permissions.hasRole;
 public class ApiDeclarationRoute extends StdJsonProducerEntityRoute {
     private final Factory factory;
     private final RestxSecurityManager securityManager;
+    private PermissionFactory permissionFactory;
 
     @Inject
     public ApiDeclarationRoute(@Named(FrontObjectMapperFactory.WRITER_NAME) ObjectWriter writer,
-            Factory factory, RestxSecurityManager securityManager) {
+                               Factory factory, RestxSecurityManager securityManager, PermissionFactory permissionFactory) {
         super("ApiDeclarationRoute", Map.class, writer, new StdRestxRequestMatcher("GET", "/@/api-docs/{router}"));
         this.factory = factory;
         this.securityManager = securityManager;
+        this.permissionFactory = permissionFactory;
     }
 
     @Override
     protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object body) throws IOException {
-        securityManager.check(restxRequest, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(restxRequest, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
         String routerName = match.getPathParam("router");
         Optional<NamedComponent<RestxRouter>> router = getRouterByName(factory, routerName);
 

--- a/restx-apidocs/src/main/java/restx/apidocs/ApiDocsIndexRoute.java
+++ b/restx-apidocs/src/main/java/restx/apidocs/ApiDocsIndexRoute.java
@@ -14,6 +14,7 @@ import restx.jackson.FrontObjectMapperFactory;
 import restx.jackson.StdJsonProducerEntityRoute;
 import restx.security.PermissionFactory;
 import restx.security.RestxSecurityManager;
+import restx.security.PermissionFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -44,23 +45,20 @@ import java.util.Set;
 public class ApiDocsIndexRoute extends StdJsonProducerEntityRoute {
     private final Factory factory;
     private final RestxSecurityManager securityManager;
-    private PermissionFactory permissionFactory;
 
     @Inject
     public ApiDocsIndexRoute(@Named(FrontObjectMapperFactory.WRITER_NAME) ObjectWriter writer,
                              Factory factory,
                              RestxSecurityManager securityManager,
                              PermissionFactory permissionFactory) {
-
-        super("ApiDocsIndexRoute", Map.class, writer, new StdRestxRequestMatcher("GET", "/@/api-docs"));
+        super("ApiDocsIndexRoute", Map.class, writer, new StdRestxRequestMatcher("GET", "/@/api-docs"), permissionFactory);
         this.factory = factory;
         this.securityManager = securityManager;
-        this.permissionFactory = permissionFactory;
     }
 
     @Override
     protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object i) throws IOException {
-        securityManager.check(restxRequest, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(restxRequest, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
         return Optional.of(ImmutableMap.builder()
                 .put("apiVersion", "0.1") // TODO
                 .put("swaggerVersion", "1.1")

--- a/restx-apidocs/src/main/java/restx/apidocs/ApiDocsIndexRoute.java
+++ b/restx-apidocs/src/main/java/restx/apidocs/ApiDocsIndexRoute.java
@@ -1,8 +1,5 @@
 package restx.apidocs;
 
-import static restx.security.Permissions.hasRole;
-
-
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Optional;
@@ -15,6 +12,7 @@ import restx.factory.Factory;
 import restx.factory.NamedComponent;
 import restx.jackson.FrontObjectMapperFactory;
 import restx.jackson.StdJsonProducerEntityRoute;
+import restx.security.PermissionFactory;
 import restx.security.RestxSecurityManager;
 
 import javax.inject.Inject;
@@ -46,20 +44,23 @@ import java.util.Set;
 public class ApiDocsIndexRoute extends StdJsonProducerEntityRoute {
     private final Factory factory;
     private final RestxSecurityManager securityManager;
+    private PermissionFactory permissionFactory;
 
     @Inject
     public ApiDocsIndexRoute(@Named(FrontObjectMapperFactory.WRITER_NAME) ObjectWriter writer,
                              Factory factory,
-                             RestxSecurityManager securityManager) {
+                             RestxSecurityManager securityManager,
+                             PermissionFactory permissionFactory) {
 
         super("ApiDocsIndexRoute", Map.class, writer, new StdRestxRequestMatcher("GET", "/@/api-docs"));
         this.factory = factory;
         this.securityManager = securityManager;
+        this.permissionFactory = permissionFactory;
     }
 
     @Override
     protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object i) throws IOException {
-        securityManager.check(restxRequest, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(restxRequest, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
         return Optional.of(ImmutableMap.builder()
                 .put("apiVersion", "0.1") // TODO
                 .put("swaggerVersion", "1.1")

--- a/restx-apidocs/src/main/java/restx/apidocs/ApiDocsIndexRoute.java
+++ b/restx-apidocs/src/main/java/restx/apidocs/ApiDocsIndexRoute.java
@@ -59,7 +59,7 @@ public class ApiDocsIndexRoute extends StdJsonProducerEntityRoute {
 
     @Override
     protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object i) throws IOException {
-        securityManager.check(restxRequest, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(restxRequest, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
         return Optional.of(ImmutableMap.builder()
                 .put("apiVersion", "0.1") // TODO
                 .put("swaggerVersion", "1.1")

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -300,7 +300,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
                     .put("method", resourceMethod.httpMethod)
                     .put("path", resourceMethod.path.replace("\\", "\\\\"))
                     .put("resource", resourceClass.name)
-                    .put("securityCheck", "securityManager.check(request, " + resourceMethod.permission + ");")
+                    .put("securityCheck", "securityManager.check(request, match, " + resourceMethod.permission + ");")
                     .put("call", call)
                     .put("responseClass", toTypeDescription(resourceMethod.returnType))
                     .put("sourceLocation", resourceMethod.sourceLocation)

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -36,7 +36,7 @@ import static restx.annotations.processor.TypeHelper.getTypeExpressionFor;
 })
 @SupportedOptions({ "debug" })
 public class RestxAnnotationProcessor extends RestxAbstractProcessor {
-    private static final Pattern ROLE_PARAM_INTERPOLATOR_REGEX = Pattern.compile("\\{([^}]+)\\}");
+    private static final Pattern ROLE_PARAM_INTERPOLATOR_REGEX = Pattern.compile("\\{(.+?)\\}");
 
     final Template routerTpl;
 

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -112,32 +112,32 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
         String permission;
         PermitAll permitAll = annotation.methodElem.getAnnotation(PermitAll.class);
         if (permitAll != null) {
-            permission = "pf.open()";
+            permission = "open()";
         } else {
             RolesAllowed rolesAllowed = annotation.methodElem.getAnnotation(RolesAllowed.class);
             if (rolesAllowed != null) {
                 List<String> roles = new ArrayList<>();
                 for (String role : rolesAllowed.value()) {
                     for(String wildcardedRole : generateWildcardRolesFor(role)){
-                        roles.add("pf.hasRole(\"" + wildcardedRole + "\")");
+                        roles.add("hasRole(\"" + wildcardedRole + "\")");
                     }
                 }
                 switch (roles.size()) {
                     case 0:
-                        permission = "pf.isAuthenticated()";
+                        permission = "isAuthenticated()";
                         break;
                     case 1:
                         permission = roles.get(0);
                         break;
                     default:
-                        permission = "pf.anyOf(" + Joiner.on(", ").join(roles) + ")";
+                        permission = "anyOf(" + Joiner.on(", ").join(roles) + ")";
                 }
             } else {
                 permitAll = typeElem.getAnnotation(PermitAll.class);
                 if (permitAll != null) {
-                    permission = "pf.open()";
+                    permission = "open()";
                 } else {
-                    permission = "pf.isAuthenticated()";
+                    permission = "isAuthenticated()";
                 }
             }
         }

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -1,8 +1,6 @@
 package restx.annotations.processor;
 
-import com.google.common.base.CaseFormat;
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
+import com.google.common.base.*;
 import com.google.common.base.Optional;
 import com.google.common.collect.*;
 import com.samskivert.mustache.Template;
@@ -38,6 +36,8 @@ import static restx.annotations.processor.TypeHelper.getTypeExpressionFor;
 })
 @SupportedOptions({ "debug" })
 public class RestxAnnotationProcessor extends RestxAbstractProcessor {
+    private static final Pattern ROLE_PARAM_INTERPOLATOR_REGEX = Pattern.compile("\\{([^}]+)\\}");
+
     final Template routerTpl;
 
     private static final Function<Class,String> FQN_EXTRACTOR = new Function<Class,String>(){
@@ -118,7 +118,9 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
             if (rolesAllowed != null) {
                 List<String> roles = new ArrayList<>();
                 for (String role : rolesAllowed.value()) {
-                    roles.add("hasRole(\"" + role + "\")");
+                    for(String wildcardedRole : generateWildcardRolesFor(role)){
+                        roles.add("hasRole(\"" + wildcardedRole + "\")");
+                    }
                 }
                 switch (roles.size()) {
                     case 0:
@@ -140,6 +142,39 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
             }
         }
         return permission;
+    }
+
+    private static List<String> generateWildcardRolesFor(String role) {
+        String[] roleChunks = Splitter.on(ROLE_PARAM_INTERPOLATOR_REGEX).splitToList(role).toArray(new String[0]);
+
+        List<String> combinatorialInterpolatedRoles = new ArrayList<>();
+        if(roleChunks.length == 1){
+            combinatorialInterpolatedRoles.add(role);
+        } else {
+            List<ImmutableSet<String>> variablePotentialValues = new ArrayList<>();
+
+            // Generating cartesian product with [variableName, "*"] on every variables in role
+            // It will allow to check for wildcards on every variable chunk in role
+            Matcher matcher = ROLE_PARAM_INTERPOLATOR_REGEX.matcher(role);
+            while(matcher.find()) {
+                String variableName = matcher.group(1);
+                variablePotentialValues.add(ImmutableSet.of("*", "{"+variableName+"}"));
+            }
+
+            Set<List<String>> variableCombinations = Sets.cartesianProduct(variablePotentialValues);
+            for(List<String> variableCombination : variableCombinations){
+                StringBuilder interpolatedRole = new StringBuilder(roleChunks[0]);
+                int i=1;
+                for(String value : variableCombination){
+                    interpolatedRole.append(value).append(roleChunks[i]);
+                    i++;
+                }
+
+                combinatorialInterpolatedRoles.add(interpolatedRole.toString());
+            }
+        }
+
+        return combinatorialInterpolatedRoles;
     }
 
     private void buildResourceMethodParams(ResourceMethodAnnotation annotation, ResourceMethod resourceMethod) {

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -112,32 +112,32 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
         String permission;
         PermitAll permitAll = annotation.methodElem.getAnnotation(PermitAll.class);
         if (permitAll != null) {
-            permission = "open()";
+            permission = "pf.open()";
         } else {
             RolesAllowed rolesAllowed = annotation.methodElem.getAnnotation(RolesAllowed.class);
             if (rolesAllowed != null) {
                 List<String> roles = new ArrayList<>();
                 for (String role : rolesAllowed.value()) {
                     for(String wildcardedRole : generateWildcardRolesFor(role)){
-                        roles.add("hasRole(\"" + wildcardedRole + "\")");
+                        roles.add("pf.hasRole(\"" + wildcardedRole + "\")");
                     }
                 }
                 switch (roles.size()) {
                     case 0:
-                        permission = "isAuthenticated()";
+                        permission = "pf.isAuthenticated()";
                         break;
                     case 1:
                         permission = roles.get(0);
                         break;
                     default:
-                        permission = "anyOf(" + Joiner.on(", ").join(roles) + ")";
+                        permission = "pf.anyOf(" + Joiner.on(", ").join(roles) + ")";
                 }
             } else {
                 permitAll = typeElem.getAnnotation(PermitAll.class);
                 if (permitAll != null) {
-                    permission = "open()";
+                    permission = "pf.open()";
                 } else {
-                    permission = "isAuthenticated()";
+                    permission = "pf.isAuthenticated()";
                 }
             }
         }

--- a/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
+++ b/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
@@ -12,7 +12,7 @@ import restx.entity.*;
 import restx.http.*;
 import restx.factory.*;
 import restx.security.*;
-import static restx.security.Permissions.*;
+import restx.security.PermissionFactory;
 import restx.description.*;
 import restx.converters.MainStringConverter;
 import static restx.common.MorePreconditions.checkPresent;
@@ -32,6 +32,7 @@ public class {{router}} extends RestxRouter {
                     final EntityRequestBodyReaderRegistry readerRegistry,
                     final EntityResponseWriterRegistry writerRegistry,
                     final MainStringConverter converter,
+                    final PermissionFactory pf,
                     final Optional<Validator> validator,
                     final RestxSecurityManager securityManager) {
         super(

--- a/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
+++ b/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
@@ -42,7 +42,7 @@ public class {{router}} extends RestxRouter {
                 readerRegistry.<{{inEntity}}>build({{inEntityType}}, {{inContentType}}),
                 writerRegistry.<{{outEntity}}>build({{outEntityType}}, {{outContentType}}),
                 new StdRestxRequestMatcher("{{method}}", "{{path}}"),
-                HttpStatus.{{successStatusName}}, RestxLogLevel.{{logLevelName}}) {
+                HttpStatus.{{successStatusName}}, RestxLogLevel.{{logLevelName}}, pf) {
             @Override
             protected Optional<{{outEntity}}> doRoute(RestxRequest request, RestxRequestMatch match, {{inEntity}} body) throws IOException {
                 {{securityCheck}}

--- a/restx-core/src/main/java/restx/RestxRouter.java
+++ b/restx-core/src/main/java/restx/RestxRouter.java
@@ -9,9 +9,9 @@ import com.google.common.collect.Lists;
 import restx.entity.MatchedEntityRoute;
 import restx.jackson.JsonEntityRouteBuilder;
 import restx.jackson.StdJsonProducerEntityRoute;
+import restx.security.PermissionFactory;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -88,8 +88,16 @@ public class RestxRouter {
             return addRoute(path, new StdRestxRequestMatcher(method, path), outputType, route);
         }
 
+        /**
+         * @deprecated Prefer to use addRoute(String, RestxRequestMatcher, PermissionFactory, Class<O>, MatchedEntityRoute<Void, O>)
+         * in order to avoid NPEs when checking permissions through permissionFactory
+         */
         public <O> Builder addRoute(String name, RestxRequestMatcher matcher, Class<O> outputType, final MatchedEntityRoute<Void, O> route) {
-            routes.add(new StdJsonProducerEntityRoute<O>(name, outputType, writer.withType(outputType), matcher) {
+            return addRoute(name, matcher, null, outputType, route);
+        }
+
+        public <O> Builder addRoute(String name, RestxRequestMatcher matcher, PermissionFactory permissionFactory, Class<O> outputType, final MatchedEntityRoute<Void, O> route) {
+            routes.add(new StdJsonProducerEntityRoute<O>(name, outputType, writer.withType(outputType), matcher, permissionFactory) {
                 @Override
                 protected Optional<O> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Void i) throws IOException {
                     return route.route(restxRequest, match, i);

--- a/restx-core/src/main/java/restx/entity/StdEntityRoute.java
+++ b/restx-core/src/main/java/restx/entity/StdEntityRoute.java
@@ -32,6 +32,7 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
         protected RestxRequestMatcher matcher;
         protected HttpStatus successStatus = HttpStatus.OK;
         protected RestxLogLevel logLevel = RestxLogLevel.DEFAULT;
+        protected PermissionFactory permissionFactory;
         protected MatchedEntityRoute<I,O> matchedEntityRoute;
 
         public Builder<I,O> entityRequestBodyReader(final EntityRequestBodyReader<I> entityRequestBodyReader) {
@@ -46,6 +47,11 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
 
         public Builder<I,O> name(final String name) {
             this.name = name;
+            return this;
+        }
+
+        public Builder<I,O> permissionFactory(final PermissionFactory permissionFactory) {
+            this.permissionFactory = permissionFactory;
             return this;
         }
 
@@ -74,7 +80,7 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
             return new StdEntityRoute<I, O>(
                     name, entityRequestBodyReader == null ? voidBodyReader() : entityRequestBodyReader,
                     entityResponseWriter,
-                    matcher, successStatus, logLevel) {
+                    matcher, successStatus, logLevel, permissionFactory) {
                 @Override
                 protected Optional<O> doRoute(RestxRequest restxRequest, RestxRequestMatch match, I i) throws IOException {
                     return matchedEntityRoute.route(restxRequest, match, i);
@@ -101,16 +107,6 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
     private final EntityResponseWriter<O> entityResponseWriter;
     private final RestxLogLevel logLevel;
     private final PermissionFactory permissionFactory;
-
-    public StdEntityRoute(String name,
-                          EntityRequestBodyReader<I> entityRequestBodyReader,
-                          EntityResponseWriter<O> entityResponseWriter,
-                          RestxRequestMatcher matcher,
-                          HttpStatus successStatus,
-                          RestxLogLevel logLevel
-    ) {
-        this(name, entityRequestBodyReader, entityResponseWriter, matcher, successStatus, logLevel, null);
-    }
 
     public StdEntityRoute(String name,
                           EntityRequestBodyReader<I> entityRequestBodyReader,

--- a/restx-core/src/main/java/restx/jackson/StdJsonProducerEntityRoute.java
+++ b/restx-core/src/main/java/restx/jackson/StdJsonProducerEntityRoute.java
@@ -6,6 +6,7 @@ import restx.RestxRequestMatcher;
 import restx.entity.StdEntityRoute;
 import restx.entity.VoidContentTypeModule;
 import restx.http.HttpStatus;
+import restx.security.PermissionFactory;
 
 import java.lang.reflect.Type;
 
@@ -14,11 +15,11 @@ import java.lang.reflect.Type;
  * Time: 11:06
  */
 public abstract class StdJsonProducerEntityRoute<O> extends StdEntityRoute<Void,O> {
-    public StdJsonProducerEntityRoute(String name, Type type, ObjectWriter writer, RestxRequestMatcher matcher) {
+    public StdJsonProducerEntityRoute(String name, Type type, ObjectWriter writer, RestxRequestMatcher matcher, PermissionFactory permissionFactory) {
         super(name,
                 VoidContentTypeModule.VoidEntityRequestBodyReader.INSTANCE,
                 JsonEntityResponseWriter.<O>using(type, writer),
                 matcher,
-                HttpStatus.OK, RestxLogLevel.DEFAULT);
+                HttpStatus.OK, RestxLogLevel.DEFAULT, permissionFactory);
     }
 }

--- a/restx-core/src/main/java/restx/security/Permission.java
+++ b/restx-core/src/main/java/restx/security/Permission.java
@@ -1,8 +1,8 @@
 package restx.security;
 
 import com.google.common.base.Optional;
-import restx.RestxRequest;
-import restx.RestxRequestMatch;
+
+import java.util.Map;
 
 /**
  * A permission is a generic security concept, used to check if a principal is allowed to access a resource.
@@ -15,9 +15,8 @@ public interface Permission {
      * more specific.
      *
      * @param principal the principal to check
-     * @param request the request to check
-     * @param match the request matcher to check
+     * @param roleInterpolationMap a role interpolation map which may be used to interpolate 'dynamic' roles
      * @return absent if not matched, the matching permission otherwise.
      */
-    Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match);
+    Optional<? extends Permission> has(RestxPrincipal principal, Map<String, String> roleInterpolationMap);
 }

--- a/restx-core/src/main/java/restx/security/Permission.java
+++ b/restx-core/src/main/java/restx/security/Permission.java
@@ -2,6 +2,7 @@ package restx.security;
 
 import com.google.common.base.Optional;
 import restx.RestxRequest;
+import restx.RestxRequestMatch;
 
 /**
  * A permission is a generic security concept, used to check if a principal is allowed to access a resource.
@@ -15,7 +16,8 @@ public interface Permission {
      *
      * @param principal the principal to check
      * @param request the request to check
+     * @param match the request matcher to check
      * @return absent if not matched, the matching permission otherwise.
      */
-    Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request);
+    Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match);
 }

--- a/restx-core/src/main/java/restx/security/PermissionFactory.java
+++ b/restx-core/src/main/java/restx/security/PermissionFactory.java
@@ -1,6 +1,7 @@
 package restx.security;
 
 import com.google.common.base.Optional;
+import restx.factory.Component;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -11,7 +12,8 @@ import java.util.regex.Pattern;
  * Provides a set of useful permissions, including the OPEN permission which is the only one that can allow access
  * to a resource without being authenticated.
  */
-    public class Permissions {
+@Component
+public class PermissionFactory {
     private static final Pattern ROLE_PARAM_INTERPOLATOR_REGEX = Pattern.compile("\\{(.+?)\\}");
 
     private static final Permission OPEN = new Permission() {
@@ -40,23 +42,30 @@ import java.util.regex.Pattern;
     /**
      * This is the only permission that can allow access to a resource without being authenticated.
      */
-    public static Permission open() {
+    public Permission open() {
         return OPEN;
     }
 
     /**
      * This is the most basic permission which is true as soon as a principal is authenticated.
      */
-    public static Permission isAuthenticated() {
+    public Permission isAuthenticated() {
         return IS_AUTHENTICATED;
     }
 
+    public boolean isOpen(Permission permission) {
+        return permission == open();
+    }
+
+    public boolean isIsAuthenticated(Permission permission) {
+        return permission == isAuthenticated();
+    }
 
     /**
      * This permission is true as soon as the principal has the given role
      * @param role the role to check
      */
-    public static Permission hasRole(final String role) {
+    public Permission hasRole(final String role) {
         return new Permission() {
             public final String TO_STRING = "HAS_ROLE[" + role + "]";
 
@@ -81,7 +90,7 @@ import java.util.regex.Pattern;
         };
     }
 
-    protected static String interpolateRole(String role, Map<String, String> roleInterpolationMap) {
+    protected String interpolateRole(String role, Map<String, String> roleInterpolationMap) {
         Matcher matcher = ROLE_PARAM_INTERPOLATOR_REGEX.matcher(role);
         StringBuffer interpolatedRole = new StringBuffer();
         while(matcher.find()){
@@ -99,7 +108,7 @@ import java.util.regex.Pattern;
     /**
      * A compound permission which is true if any of the underlying permissions is true
      */
-    public static Permission anyOf(final Permission... permissions) {
+    public Permission anyOf(final Permission... permissions) {
         return new Permission() {
             @Override
             public Optional<? extends Permission> has(RestxPrincipal principal, Map<String, String> roleInterpolationMap) {
@@ -123,7 +132,7 @@ import java.util.regex.Pattern;
     /**
      * A compound permission which is true if all underlying permissions are true
      */
-    public static Permission allOf(final Permission... permissions) {
+    public Permission allOf(final Permission... permissions) {
         return new Permission() {
             @Override
             public Optional<? extends Permission> has(RestxPrincipal principal, Map<String, String> roleInterpolationMap) {

--- a/restx-core/src/main/java/restx/security/Permissions.java
+++ b/restx-core/src/main/java/restx/security/Permissions.java
@@ -1,10 +1,9 @@
 package restx.security;
 
 import com.google.common.base.Optional;
-import restx.RestxRequest;
-import restx.RestxRequestMatch;
 
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Provides a set of useful permissions, including the OPEN permission which is the only one that can allow access
@@ -13,7 +12,7 @@ import java.util.Arrays;
 public class Permissions {
     private static final Permission OPEN = new Permission() {
         @Override
-        public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
+        public Optional<? extends Permission> has(RestxPrincipal principal, Map<String, String> roleInterpolationMap) {
             return Optional.of(this);
         }
 
@@ -24,7 +23,7 @@ public class Permissions {
     };
     private static final Permission IS_AUTHENTICATED = new Permission() {
         @Override
-        public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
+        public Optional<? extends Permission> has(RestxPrincipal principal, Map<String, String> roleInterpolationMap) {
             return Optional.of(this);
         }
 
@@ -58,7 +57,7 @@ public class Permissions {
             public final String TO_STRING = "HAS_ROLE[" + role + "]";
 
             @Override
-            public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
+            public Optional<? extends Permission> has(RestxPrincipal principal, Map<String, String> roleInterpolationMap) {
                 return principal.getPrincipalRoles().contains(role) || principal.getPrincipalRoles().contains("*")
                         ? Optional.of(this) : Optional.<Permission>absent();
             }
@@ -76,9 +75,9 @@ public class Permissions {
     public static Permission anyOf(final Permission... permissions) {
         return new Permission() {
             @Override
-            public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
+            public Optional<? extends Permission> has(RestxPrincipal principal, Map<String, String> roleInterpolationMap) {
                 for (Permission permission : permissions) {
-                    Optional<? extends Permission> p = permission.has(principal, request, match);
+                    Optional<? extends Permission> p = permission.has(principal, roleInterpolationMap);
                     if (p.isPresent()) {
                         return p;
                     }
@@ -100,9 +99,9 @@ public class Permissions {
     public static Permission allOf(final Permission... permissions) {
         return new Permission() {
             @Override
-            public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
+            public Optional<? extends Permission> has(RestxPrincipal principal, Map<String, String> roleInterpolationMap) {
                 for (Permission permission : permissions) {
-                    Optional<? extends Permission> p = permission.has(principal, request, match);
+                    Optional<? extends Permission> p = permission.has(principal, roleInterpolationMap);
                     if (!p.isPresent()) {
                         return Optional.absent();
                     }

--- a/restx-core/src/main/java/restx/security/Permissions.java
+++ b/restx-core/src/main/java/restx/security/Permissions.java
@@ -11,8 +11,8 @@ import java.util.regex.Pattern;
  * Provides a set of useful permissions, including the OPEN permission which is the only one that can allow access
  * to a resource without being authenticated.
  */
-public class Permissions {
-    private static final Pattern ROLE_PARAM_INTERPOLATOR_REGEX = Pattern.compile("\\{([^}]+)\\}");
+    public class Permissions {
+    private static final Pattern ROLE_PARAM_INTERPOLATOR_REGEX = Pattern.compile("\\{(.+?)\\}");
 
     private static final Permission OPEN = new Permission() {
         @Override

--- a/restx-core/src/main/java/restx/security/Permissions.java
+++ b/restx-core/src/main/java/restx/security/Permissions.java
@@ -2,6 +2,7 @@ package restx.security;
 
 import com.google.common.base.Optional;
 import restx.RestxRequest;
+import restx.RestxRequestMatch;
 
 import java.util.Arrays;
 
@@ -12,7 +13,7 @@ import java.util.Arrays;
 public class Permissions {
     private static final Permission OPEN = new Permission() {
         @Override
-        public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request) {
+        public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
             return Optional.of(this);
         }
 
@@ -23,7 +24,7 @@ public class Permissions {
     };
     private static final Permission IS_AUTHENTICATED = new Permission() {
         @Override
-        public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request) {
+        public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
             return Optional.of(this);
         }
 
@@ -57,7 +58,7 @@ public class Permissions {
             public final String TO_STRING = "HAS_ROLE[" + role + "]";
 
             @Override
-            public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request) {
+            public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
                 return principal.getPrincipalRoles().contains(role) || principal.getPrincipalRoles().contains("*")
                         ? Optional.of(this) : Optional.<Permission>absent();
             }
@@ -75,9 +76,9 @@ public class Permissions {
     public static Permission anyOf(final Permission... permissions) {
         return new Permission() {
             @Override
-            public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request) {
+            public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
                 for (Permission permission : permissions) {
-                    Optional<? extends Permission> p = permission.has(principal, request);
+                    Optional<? extends Permission> p = permission.has(principal, request, match);
                     if (p.isPresent()) {
                         return p;
                     }
@@ -99,9 +100,9 @@ public class Permissions {
     public static Permission allOf(final Permission... permissions) {
         return new Permission() {
             @Override
-            public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request) {
+            public Optional<? extends Permission> has(RestxPrincipal principal, RestxRequest request, RestxRequestMatch match) {
                 for (Permission permission : permissions) {
-                    Optional<? extends Permission> p = permission.has(principal, request);
+                    Optional<? extends Permission> p = permission.has(principal, request, match);
                     if (!p.isPresent()) {
                         return Optional.absent();
                     }

--- a/restx-core/src/main/java/restx/security/Permissions.java
+++ b/restx-core/src/main/java/restx/security/Permissions.java
@@ -85,7 +85,12 @@ public class Permissions {
         Matcher matcher = ROLE_PARAM_INTERPOLATOR_REGEX.matcher(role);
         StringBuffer interpolatedRole = new StringBuffer();
         while(matcher.find()){
-            matcher.appendReplacement(interpolatedRole, roleInterpolationMap.get(matcher.group(1)));
+            String interpolationVarName = matcher.group(1);
+            if(!roleInterpolationMap.containsKey(interpolationVarName)) {
+                throw new IllegalArgumentException(String.format("Variable <%s> not found in role interpolation map <%s>",
+                        interpolationVarName, roleInterpolationMap.toString()));
+            }
+            matcher.appendReplacement(interpolatedRole, roleInterpolationMap.get(interpolationVarName));
         }
         matcher.appendTail(interpolatedRole);
         return interpolatedRole.toString();

--- a/restx-core/src/main/java/restx/security/RestxSecurityManager.java
+++ b/restx-core/src/main/java/restx/security/RestxSecurityManager.java
@@ -1,6 +1,7 @@
 package restx.security;
 
 import restx.RestxRequest;
+import restx.RestxRequestMatch;
 
 /**
  * A security manager is responsible for checking if the principal associated with a given request (or current session)
@@ -13,7 +14,8 @@ public interface RestxSecurityManager {
      * The security manager can safely assume that a RestxSession is available in current thread context.
      *
      * @param request the request for which the check is performed
+     * @param request the request matcher for which the check is performed
      * @param permission the permission to check. must not be null.
      */
-    void check(RestxRequest request, Permission permission);
+    void check(RestxRequest request, RestxRequestMatch match, Permission permission);
 }

--- a/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
+++ b/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
@@ -1,6 +1,7 @@
 package restx.security;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
+++ b/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
@@ -124,7 +124,7 @@ public class RestxSessionCookieFilter implements RestxRouteFilter, RestxHandler 
             Optional<RestxPrincipal> principalOptional = RestxSession.getValue(
                     sessionDefinition, RestxPrincipal.class, RestxPrincipal.SESSION_DEF_KEY, principalName);
             if (principalOptional.isPresent()
-                    && Permissions.hasRole("restx-admin").has(principalOptional.get(), null, null).isPresent()) {
+                    && Permissions.hasRole("restx-admin").has(principalOptional.get(), Collections.<String,String>emptyMap()).isPresent()) {
                 Optional<String> su = req.getHeader("RestxSu");
                 if (su.isPresent() && !Strings.isNullOrEmpty(su.get())) {
                     try {

--- a/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
+++ b/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
@@ -51,19 +51,22 @@ public class RestxSessionCookieFilter implements RestxRouteFilter, RestxHandler 
     private final RestxSession.Definition sessionDefinition;
     private final ObjectMapper mapper;
 	private final Signer signer;
-	private final RestxSessionCookieDescriptor restxSessionCookieDescriptor;
+    private final PermissionFactory permissionFactory;
+    private final RestxSessionCookieDescriptor restxSessionCookieDescriptor;
     private final RestxSession emptySession;
 
 	public RestxSessionCookieFilter(
 			RestxSession.Definition sessionDefinition,
 			@Named(FrontObjectMapperFactory.MAPPER_NAME) ObjectMapper mapper,
 			@Named(COOKIE_SIGNER_NAME) Signer signer,
+            PermissionFactory permissionFactory,
 			RestxSessionCookieDescriptor restxSessionCookieDescriptor) {
 
 		this.sessionDefinition = sessionDefinition;
 		this.mapper = mapper;
 		this.signer = signer;
-		this.restxSessionCookieDescriptor = restxSessionCookieDescriptor;
+        this.permissionFactory = permissionFactory;
+        this.restxSessionCookieDescriptor = restxSessionCookieDescriptor;
 		this.emptySession = new RestxSession(sessionDefinition, ImmutableMap.<String, String>of(),
 				Optional.<RestxPrincipal>absent(), Duration.ZERO);
 	}
@@ -124,7 +127,7 @@ public class RestxSessionCookieFilter implements RestxRouteFilter, RestxHandler 
             Optional<RestxPrincipal> principalOptional = RestxSession.getValue(
                     sessionDefinition, RestxPrincipal.class, RestxPrincipal.SESSION_DEF_KEY, principalName);
             if (principalOptional.isPresent()
-                    && Permissions.hasRole("restx-admin").has(principalOptional.get(), Collections.<String,String>emptyMap()).isPresent()) {
+                    && permissionFactory.hasRole("restx-admin").has(principalOptional.get(), Collections.<String,String>emptyMap()).isPresent()) {
                 Optional<String> su = req.getHeader("RestxSu");
                 if (su.isPresent() && !Strings.isNullOrEmpty(su.get())) {
                     try {

--- a/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
+++ b/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
@@ -124,7 +124,7 @@ public class RestxSessionCookieFilter implements RestxRouteFilter, RestxHandler 
             Optional<RestxPrincipal> principalOptional = RestxSession.getValue(
                     sessionDefinition, RestxPrincipal.class, RestxPrincipal.SESSION_DEF_KEY, principalName);
             if (principalOptional.isPresent()
-                    && Permissions.hasRole("restx-admin").has(principalOptional.get(), null).isPresent()) {
+                    && Permissions.hasRole("restx-admin").has(principalOptional.get(), null, null).isPresent()) {
                 Optional<String> su = req.getHeader("RestxSu");
                 if (su.isPresent() && !Strings.isNullOrEmpty(su.get())) {
                     try {

--- a/restx-core/src/main/java/restx/security/StdRestxSecurityManager.java
+++ b/restx-core/src/main/java/restx/security/StdRestxSecurityManager.java
@@ -3,6 +3,7 @@ package restx.security;
 import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import restx.RestxRequestMatch;
 import restx.http.HttpStatus;
 import restx.RestxRequest;
 import restx.WebException;
@@ -17,7 +18,7 @@ public class StdRestxSecurityManager implements RestxSecurityManager {
     private static final Logger logger = LoggerFactory.getLogger(StdRestxSecurityManager.class);
 
     @Override
-    public void check(RestxRequest request, Permission permission) {
+    public void check(RestxRequest request, RestxRequestMatch requestMatch, Permission permission) {
         if (permission == Permissions.open()) {
             return;
         }

--- a/restx-core/src/main/java/restx/security/StdRestxSecurityManager.java
+++ b/restx-core/src/main/java/restx/security/StdRestxSecurityManager.java
@@ -30,7 +30,7 @@ public class StdRestxSecurityManager implements RestxSecurityManager {
             throw new WebException(HttpStatus.UNAUTHORIZED);
         }
 
-        Optional<? extends Permission> match = permission.has(principal.get(), request);
+        Optional<? extends Permission> match = permission.has(principal.get(), request, requestMatch);
         if (match.isPresent()) {
             logger.debug("permission matched: request={} principal={} perm={}", request, principal.get(), match.get());
             return;

--- a/restx-core/src/main/java/restx/security/StdRestxSecurityManager.java
+++ b/restx-core/src/main/java/restx/security/StdRestxSecurityManager.java
@@ -24,9 +24,15 @@ import java.util.Map;
 public class StdRestxSecurityManager implements RestxSecurityManager {
     private static final Logger logger = LoggerFactory.getLogger(StdRestxSecurityManager.class);
 
+    protected final PermissionFactory permissionFactory;
+
+    public StdRestxSecurityManager(PermissionFactory permissionFactory) {
+        this.permissionFactory = permissionFactory;
+    }
+
     @Override
     public void check(RestxRequest request, RestxRequestMatch requestMatch, Permission permission) {
-        if (permission == Permissions.open()) {
+        if (permissionFactory.isOpen(permission)) {
             return;
         }
 

--- a/restx-core/src/main/java/restx/security/StdRestxSecurityManager.java
+++ b/restx-core/src/main/java/restx/security/StdRestxSecurityManager.java
@@ -1,6 +1,9 @@
 package restx.security;
 
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import restx.RestxRequestMatch;
@@ -8,6 +11,10 @@ import restx.http.HttpStatus;
 import restx.RestxRequest;
 import restx.WebException;
 import restx.factory.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A simple implementation of security manager which throws 401 WebException if
@@ -30,7 +37,7 @@ public class StdRestxSecurityManager implements RestxSecurityManager {
             throw new WebException(HttpStatus.UNAUTHORIZED);
         }
 
-        Optional<? extends Permission> match = permission.has(principal.get(), request, requestMatch);
+        Optional<? extends Permission> match = permission.has(principal.get(), createRoleInterpolationMapFrom(request, requestMatch));
         if (match.isPresent()) {
             logger.debug("permission matched: request={} principal={} perm={}", request, principal.get(), match.get());
             return;
@@ -39,5 +46,27 @@ public class StdRestxSecurityManager implements RestxSecurityManager {
         logger.debug("permission not matched: request={} principal={} permission={}",
                 request, principal.get(), permission);
         throw new WebException(HttpStatus.FORBIDDEN);
+    }
+
+    protected Map<String, String> createRoleInterpolationMapFrom(RestxRequest request, RestxRequestMatch match) {
+        Map<String, String> roleInterpolationMap = new HashMap<>();
+
+        if(request != null) {
+            // When we have more than 1 query param value for a given key, subjectively keeping only the first one
+            // I don't think these multi-values query params should be taken into consideration when interpolating roles
+            // but I don't want to remove it from interpolation map either "if values.size()>1"
+            roleInterpolationMap.putAll(Maps.transformValues(request.getQueryParams(), new Function<List<String>, String>(){
+                @Override
+                public String apply(List<String> input) {
+                    return Iterables.getFirst(input, null);
+                }
+            }));
+        }
+
+        if(match != null) {
+            roleInterpolationMap.putAll(match.getPathParams());
+        }
+
+        return roleInterpolationMap;
     }
 }

--- a/restx-factory-admin/src/main/java/restx/factory/FactoryDumpRoute.java
+++ b/restx-factory-admin/src/main/java/restx/factory/FactoryDumpRoute.java
@@ -15,7 +15,7 @@ public class FactoryDumpRoute extends StdRoute {
     private PermissionFactory permissionFactory;
 
     @Inject
-    public FactoryDumpRoute(Factory factory, RestxSecurityManager securityManager, PermissionFactory permissionFactory) {
+    public FactoryDumpRoute(Factory factory, RestxSecurityManager securityManager, final PermissionFactory permissionFactory) {
         super("FactoryRoute", new StdRestxRequestMatcher("GET", "/@/factory"));
         this.factory = factory;
         this.securityManager = securityManager;

--- a/restx-factory-admin/src/main/java/restx/factory/FactoryDumpRoute.java
+++ b/restx-factory-admin/src/main/java/restx/factory/FactoryDumpRoute.java
@@ -24,7 +24,7 @@ public class FactoryDumpRoute extends StdRoute {
 
     @Override
     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-        securityManager.check(req, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
         resp.setContentType("text/plain");
         resp.getWriter().println(factory.dump());
     }

--- a/restx-factory-admin/src/main/java/restx/factory/FactoryDumpRoute.java
+++ b/restx-factory-admin/src/main/java/restx/factory/FactoryDumpRoute.java
@@ -1,10 +1,8 @@
 package restx.factory;
 
-import static restx.security.Permissions.hasRole;
-
-
 import restx.*;
 import restx.admin.AdminModule;
+import restx.security.PermissionFactory;
 import restx.security.RestxSecurityManager;
 
 import javax.inject.Inject;
@@ -14,17 +12,19 @@ import java.io.IOException;
 public class FactoryDumpRoute extends StdRoute {
     private final Factory factory;
     private final RestxSecurityManager securityManager;
+    private PermissionFactory permissionFactory;
 
     @Inject
-    public FactoryDumpRoute(Factory factory, RestxSecurityManager securityManager) {
+    public FactoryDumpRoute(Factory factory, RestxSecurityManager securityManager, PermissionFactory permissionFactory) {
         super("FactoryRoute", new StdRestxRequestMatcher("GET", "/@/factory"));
         this.factory = factory;
         this.securityManager = securityManager;
+        this.permissionFactory = permissionFactory;
     }
 
     @Override
     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(req, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
         resp.setContentType("text/plain");
         resp.getWriter().println(factory.dump());
     }

--- a/restx-factory-admin/src/main/java/restx/factory/WarehouseRoute.java
+++ b/restx-factory-admin/src/main/java/restx/factory/WarehouseRoute.java
@@ -33,7 +33,7 @@ public class WarehouseRoute extends StdRoute {
 
     @Override
     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-        securityManager.check(req, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
         resp.setContentType("application/json");
 
         List<String> nodesCode = Lists.newArrayList();

--- a/restx-factory-admin/src/main/java/restx/factory/WarehouseRoute.java
+++ b/restx-factory-admin/src/main/java/restx/factory/WarehouseRoute.java
@@ -1,13 +1,11 @@
 package restx.factory;
 
-import static restx.security.Permissions.hasRole;
-
-
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import restx.*;
 import restx.admin.AdminModule;
 import restx.annotations.RestxResource;
+import restx.security.PermissionFactory;
 import restx.security.RestxSecurityManager;
 
 import javax.inject.Inject;
@@ -19,21 +17,23 @@ import java.util.List;
 public class WarehouseRoute extends StdRoute {
     private final Warehouse warehouse;
     private final RestxSecurityManager securityManager;
+    private PermissionFactory permissionFactory;
 
     @Inject
-    public WarehouseRoute(Factory factory, RestxSecurityManager securityManager) {
-        this(factory.getWarehouse(), securityManager);
+    public WarehouseRoute(Factory factory, RestxSecurityManager securityManager, PermissionFactory permissionFactory) {
+        this(factory.getWarehouse(), securityManager, permissionFactory);
     }
 
-    public WarehouseRoute(Warehouse warehouse, RestxSecurityManager securityManager) {
+    public WarehouseRoute(Warehouse warehouse, RestxSecurityManager securityManager, PermissionFactory permissionFactory) {
         super("WarehouseRoute", new StdRestxRequestMatcher("GET", "/@/warehouse"));
         this.warehouse = warehouse;
         this.securityManager = securityManager;
+        this.permissionFactory = permissionFactory;
     }
 
     @Override
     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+        securityManager.check(req, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
         resp.setContentType("application/json");
 
         List<String> nodesCode = Lists.newArrayList();

--- a/restx-monitor-admin/src/main/java/restx/monitor/MonitorRouter.java
+++ b/restx-monitor-admin/src/main/java/restx/monitor/MonitorRouter.java
@@ -42,7 +42,7 @@ public class MonitorRouter extends RestxRouter {
         return new StdRoute("MonitorRoute", new StdRestxRequestMatcher("GET", "/@/monitor")) {
             @Override
             public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-                securityManager.check(req, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+                securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
                 resp.setStatus(HttpStatus.OK);
                 resp.setContentType("application/json");
                 resp.getWriter().print("[");

--- a/restx-monitor-admin/src/main/java/restx/monitor/MonitorRouter.java
+++ b/restx-monitor-admin/src/main/java/restx/monitor/MonitorRouter.java
@@ -1,8 +1,5 @@
 package restx.monitor;
 
-import static restx.security.Permissions.hasRole;
-
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableMap;
@@ -11,12 +8,12 @@ import restx.admin.AdminModule;
 import restx.factory.Component;
 import restx.http.HttpStatus;
 import restx.metrics.codahale.CodahaleMetricRegistry;
+import restx.security.PermissionFactory;
 import restx.security.RestxSecurityManager;
 
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * User: xavierhanin
@@ -26,13 +23,14 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class MonitorRouter extends RestxRouter {
     public MonitorRouter(final restx.common.metrics.api.MetricRegistry metricsRegistry,
-                         final RestxSecurityManager securityManager) {
+                         final RestxSecurityManager securityManager,
+                         final PermissionFactory permissionFactory) {
         super("restx-admin", "MonitorRouter",
                 getMonitorUIRoute(),
-                getGetMonitorRoute(metricsRegistry, securityManager));
+                getGetMonitorRoute(metricsRegistry, securityManager, permissionFactory));
     }
 
-    private static StdRoute getGetMonitorRoute(restx.common.metrics.api.MetricRegistry metricRegistry, final RestxSecurityManager securityManager) {
+    private static StdRoute getGetMonitorRoute(restx.common.metrics.api.MetricRegistry metricRegistry, final RestxSecurityManager securityManager, final PermissionFactory permissionFactory) {
         if (!(metricRegistry instanceof CodahaleMetricRegistry)){
             throw new IllegalStateException("restx-monitor-admin expects that module restx-monitor-codahale is loaded");
         }
@@ -42,7 +40,7 @@ public class MonitorRouter extends RestxRouter {
         return new StdRoute("MonitorRoute", new StdRestxRequestMatcher("GET", "/@/monitor")) {
             @Override
             public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-                securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+                securityManager.check(req, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
                 resp.setStatus(HttpStatus.OK);
                 resp.setContentType("application/json");
                 resp.getWriter().print("[");

--- a/restx-samplest/src/main/java/samplest/AppModule.java
+++ b/restx-samplest/src/main/java/samplest/AppModule.java
@@ -18,10 +18,14 @@ import java.util.Locale;
  */
 @Module
 public class AppModule {
-    private ImmutableMap<String, RestxPrincipal> principals = ImmutableMap.of(
-            "admin", AdminModule.RESTX_ADMIN_PRINCIPAL,
-            "user1", new StdUser("user1", ImmutableSet.<String>of("hello"))
-    );
+    private ImmutableMap<String, RestxPrincipal> principals = ImmutableMap.<String, RestxPrincipal>builder()
+            .put("admin", AdminModule.RESTX_ADMIN_PRINCIPAL)
+            .put("user1", new StdUser("user1", ImmutableSet.<String>of("hello")))
+            .put("user-belonging-to-1234-5678", new StdUser("user-belonging-to-1234-5678", ImmutableSet.<String>of("EDIT_COMPANY_1234_5678")))
+            .put("user-managing-1234-subcompanies", new StdUser("user-managing-1234-subcompanies", ImmutableSet.<String>of("EDIT_COMPANY_1234_*")))
+            .put("user-managing-all-companies", new StdUser("user-managing-companies", ImmutableSet.<String>of("EDIT_COMPANY_*_*")))
+            .put("user-managing-all-parents-for-a-given-subcompany", new StdUser("user-managing-all-parents-for-a-given-subcompany", ImmutableSet.<String>of("EDIT_COMPANY_*_5678")))
+            .build();
 
     @Provides @Named("restx.app.package")
     public String appPackage() {

--- a/restx-samplest/src/main/java/samplest/security/SecuredResource.java
+++ b/restx-samplest/src/main/java/samplest/security/SecuredResource.java
@@ -4,6 +4,7 @@ import restx.annotations.GET;
 import restx.annotations.RestxResource;
 import restx.factory.Component;
 import restx.security.RestxSession;
+import restx.security.RolesAllowed;
 
 /**
  * Date: 12/12/13
@@ -13,6 +14,12 @@ import restx.security.RestxSession;
 public class SecuredResource {
     @GET("/security/user")
     public String getUser() {
+        return RestxSession.current().getPrincipal().get().getName();
+    }
+
+    @GET("/security/{companyId}/{subCompanyId}")
+    @RolesAllowed("EDIT_COMPANY_{companyId}_{subCompanyId}")
+    public String editSubCompany(String companyId, String subCompanyId){
         return RestxSession.current().getPrincipal().get().getName();
     }
 }

--- a/restx-samplest/src/main/resources/specs/security/adminWithMultipleWildcardsAccess.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/security/adminWithMultipleWildcardsAccess.spec.yaml
@@ -1,0 +1,20 @@
+title: Admin user access with rights on every companies/sub companies
+given:
+  - time: 2015-10-27T01:18:00.822+02:00
+  - uuids: [ "e2b4430f-9541-4602-9a3a-413d17c56a6b" ]
+wts:
+  - when: |
+      GET security/1234/5678
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-all-companies","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      200
+  - when: |
+      GET security/1234/8765
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-all-companies","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      200
+  - when: |
+      GET security/4321/8765
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-all-companies","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      200

--- a/restx-samplest/src/main/resources/specs/security/adminWithOnlyOneWildcardAccess.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/security/adminWithOnlyOneWildcardAccess.spec.yaml
@@ -1,0 +1,45 @@
+title: Admin user accesses with rights on either every companies or every subcompanies
+given:
+  - time: 2015-10-27T01:18:00.822+02:00
+  - uuids: [ "e2b4430f-9541-4602-9a3a-413d17c56a6b" ]
+wts:
+  - when: |
+      GET security/1234/5678
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-1234-subcompanies","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      200
+  - when: |
+      GET security/4321/5678
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-1234-subcompanies","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      403
+  - when: |
+      GET security/1234/8765
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-1234-subcompanies","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      200
+  - when: |
+      GET security/4321/8765
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-1234-subcompanies","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      403
+  - when: |
+      GET security/1234/5678
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-all-parents-for-a-given-subcompany","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      200
+  - when: |
+      GET security/1234/8765
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-all-parents-for-a-given-subcompany","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      403
+  - when: |
+      GET security/4321/5678
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-all-parents-for-a-given-subcompany","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      200
+  - when: |
+      GET security/4321/8765
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-managing-all-parents-for-a-given-subcompany","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      403

--- a/restx-samplest/src/main/resources/specs/security/simpleUserAccess.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/security/simpleUserAccess.spec.yaml
@@ -1,0 +1,20 @@
+title: Simple user access with rights on company 1234 and sub company 5678
+given:
+  - time: 2015-10-27T01:18:00.822+02:00
+  - uuids: [ "e2b4430f-9541-4602-9a3a-413d17c56a6b" ]
+wts:
+  - when: |
+      GET security/1234/5678
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-belonging-to-1234-5678","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      200
+  - when: |
+      GET security/1234/8765
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-belonging-to-1234-5678","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      403
+  - when: |
+      GET security/4321/8765
+      $RestxSession: {"_expires":"2015-10-27T01:18:00.822+02:00","principal":"user-belonging-to-1234-5678","sessionKey":"e2b4430f-9541-4602-9a3a-413d17c56a6b"}
+    then: |
+      403

--- a/restx-samplest/src/test/java/samplest/security/SecurityResourceSpecsTest.java
+++ b/restx-samplest/src/test/java/samplest/security/SecurityResourceSpecsTest.java
@@ -1,0 +1,10 @@
+package samplest.security;
+
+import org.junit.runner.RunWith;
+import restx.tests.FindSpecsIn;
+import restx.tests.RestxSpecTestsRunner;
+
+@RunWith(RestxSpecTestsRunner.class)
+@FindSpecsIn("specs/security")
+public class SecurityResourceSpecsTest {
+}

--- a/restx-specs-admin/src/main/java/restx/specs/SpecRecorderRoute.java
+++ b/restx-specs-admin/src/main/java/restx/specs/SpecRecorderRoute.java
@@ -29,7 +29,7 @@ public class SpecRecorderRoute extends RestxRouter {
                 new StdRoute("RecorderRoute", new StdRestxRequestMatcher("GET", "/@/recorders")) {
                     @Override
                     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-                        securityManager.check(req, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+                        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
                         resp.setContentType("application/json");
                         List<String> data = Lists.newArrayList();
                         for (RestxSpecRecorder.RecordedSpec spec : recordedSpecsRepository.getRecordedSpecs()) {
@@ -48,7 +48,7 @@ public class SpecRecorderRoute extends RestxRouter {
                 new StdRoute("RecorderRecord", new StdRestxRequestMatcher("GET", "/@/recorders/{id}")) {
                     @Override
                     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-                        securityManager.check(req, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+                        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
                         int id = Integer.parseInt(match.getPathParam("id"));
                         for (RestxSpecRecorder.RecordedSpec spec : recordedSpecsRepository.getRecordedSpecs()) {
                             if (spec.getId() == id) {
@@ -65,7 +65,7 @@ public class SpecRecorderRoute extends RestxRouter {
                 new StdRoute("RecorderRecordStorage", new StdRestxRequestMatcher("POST", "/@/recorders/storage/{id}")) {
                     @Override
                     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-                        securityManager.check(req, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+                        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
                         int id = Integer.parseInt(match.getPathParam("id"));
                         for (RestxSpecRecorder.RecordedSpec spec : recordedSpecsRepository.getRecordedSpecs()) {
                             if (spec.getId() == id) {

--- a/restx-specs-admin/src/main/java/restx/specs/SpecRecorderRoute.java
+++ b/restx-specs-admin/src/main/java/restx/specs/SpecRecorderRoute.java
@@ -1,14 +1,12 @@
 package restx.specs;
 
-import static restx.security.Permissions.hasRole;
-
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import restx.*;
 import restx.admin.AdminModule;
+import restx.security.PermissionFactory;
 import restx.security.RestxSecurityManager;
 
 import java.io.File;
@@ -23,13 +21,14 @@ import java.util.List;
 public class SpecRecorderRoute extends RestxRouter {
     public SpecRecorderRoute(final RestxSpecRecorder.Repository recordedSpecsRepository,
                              final RestxSpec.StorageSettings storageSettings,
-                             final RestxSecurityManager securityManager) {
+                             final RestxSecurityManager securityManager,
+                             final PermissionFactory permissionFactory) {
         super("SpecRecorderRouter",
                 new ResourcesRoute("RecorderUIRoute", "/@/ui/recorder/", "restx.specs.recorder", ImmutableMap.of("", "index.html")),
                 new StdRoute("RecorderRoute", new StdRestxRequestMatcher("GET", "/@/recorders")) {
                     @Override
                     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-                        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+                        securityManager.check(req, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
                         resp.setContentType("application/json");
                         List<String> data = Lists.newArrayList();
                         for (RestxSpecRecorder.RecordedSpec spec : recordedSpecsRepository.getRecordedSpecs()) {
@@ -48,7 +47,7 @@ public class SpecRecorderRoute extends RestxRouter {
                 new StdRoute("RecorderRecord", new StdRestxRequestMatcher("GET", "/@/recorders/{id}")) {
                     @Override
                     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-                        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+                        securityManager.check(req, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
                         int id = Integer.parseInt(match.getPathParam("id"));
                         for (RestxSpecRecorder.RecordedSpec spec : recordedSpecsRepository.getRecordedSpecs()) {
                             if (spec.getId() == id) {
@@ -65,7 +64,7 @@ public class SpecRecorderRoute extends RestxRouter {
                 new StdRoute("RecorderRecordStorage", new StdRestxRequestMatcher("POST", "/@/recorders/storage/{id}")) {
                     @Override
                     public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx) throws IOException {
-                        securityManager.check(req, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
+                        securityManager.check(req, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
                         int id = Integer.parseInt(match.getPathParam("id"));
                         for (RestxSpecRecorder.RecordedSpec spec : recordedSpecsRepository.getRecordedSpecs()) {
                             if (spec.getId() == id) {

--- a/restx-specs-admin/src/main/java/restx/specs/SpecRecorderRouteFactoryMachine.java
+++ b/restx-specs-admin/src/main/java/restx/specs/SpecRecorderRouteFactoryMachine.java
@@ -6,6 +6,7 @@ import restx.AppSettings;
 import restx.RestxContext;
 import restx.admin.AdminPage;
 import restx.factory.*;
+import restx.security.PermissionFactory;
 import restx.security.RestxSecurityManager;
 
 @Machine
@@ -16,6 +17,7 @@ public class SpecRecorderRouteFactoryMachine extends DefaultFactoryMachine {
     private static final Factory.Query<RestxSpecRecorder.Repository> recordedSpecRepo = Factory.Query.byClass(RestxSpecRecorder.Repository.class);
     private static final Factory.Query<RestxSpec.StorageSettings> storageSettings = Factory.Query.byClass(RestxSpec.StorageSettings.class).mandatory();
     private static final Factory.Query<RestxSecurityManager> securityManager = Factory.Query.byClass(RestxSecurityManager.class).mandatory();
+    private static final Factory.Query<PermissionFactory> permissionFactory = Factory.Query.byClass(PermissionFactory.class).mandatory();
     private static final Name<AdminPage> ADMIN_PAGE_NAME = Name.of(AdminPage.class, "Recorder");
 
     public SpecRecorderRouteFactoryMachine() {
@@ -34,7 +36,7 @@ public class SpecRecorderRouteFactoryMachine extends DefaultFactoryMachine {
 
                 @Override
                 public BillOfMaterials getBillOfMaterial() {
-                    return new BillOfMaterials(ImmutableSet.<Factory.Query<?>>of(recordedSpecRepo, storageSettings, securityManager));
+                    return new BillOfMaterials(ImmutableSet.<Factory.Query<?>>of(recordedSpecRepo, storageSettings, securityManager, permissionFactory));
                 }
 
                 @Override
@@ -46,7 +48,8 @@ public class SpecRecorderRouteFactoryMachine extends DefaultFactoryMachine {
                     return BoundlessComponentBox.FACTORY.of(new NamedComponent<>(RECORDER_ROUTE_NAME,
                             new SpecRecorderRoute(recorder.get().getComponent(),
                                     satisfiedBOM.getOneAsComponent(storageSettings).get(),
-                                    satisfiedBOM.getOneAsComponent(securityManager).get()
+                                    satisfiedBOM.getOneAsComponent(securityManager).get(),
+                                    satisfiedBOM.getOneAsComponent(permissionFactory).get()
                                     )));
                 }
 


### PR DESCRIPTION
This PR allows to define "variabilized" security roles based on what we have in `query params` or `path param` for a dedicated endpoint.

It will allow to typically have such endpoint checks :
```
    @GET("/security/{companyId}/{subCompanyId}")
    @RolesAllowed("EDIT_COMPANY_{companyId}_{subCompanyId}")
    public String editSubCompany(String companyId, String subCompanyId){
        // ....
    }
```

Changes have been made to `StdRestxSecurityManager` in order to generate a `role interpolation map`, basically with `query` & `path` parameters (but which may be overwritten with specific stuff if wanted on every project .. you'll only need to `@Provide` another `StdRestxSecurityManager`)

By introducing variabilized roles, I added a support for wildcards on roles located in `RestxPrincipal`
That is to say, if current user has role named `EDIT_COMPANY_1234_*` he will be able to call every urls like `/security/1234/*` without having any `403 Forbidden` response.
The `wildcard roles` checks are generated at compilation time through `RestxAnnotationProcessor` (because variable cartesian product may take some time to generate, which we would like to avoid at runtime).

That is to say, corresponding generated code for endpoint above will be :
```
        new StdEntityRoute<Void, java.lang.String>("default#SecuredResource#editSubCompany",
                readerRegistry.<Void>build(Void.class, Optional.<String>absent()),
                writerRegistry.<java.lang.String>build(java.lang.String.class, Optional.<String>absent()),
                new StdRestxRequestMatcher("GET", "/security/{companyId}/{subCompanyId}"),
                HttpStatus.OK, RestxLogLevel.DEFAULT) {
            @Override
            protected Optional<java.lang.String> doRoute(RestxRequest request, RestxRequestMatch match, Void body) throws IOException {
                securityManager.check(request, match, anyOf(hasRole("EDIT_COMPANY_*_*"), hasRole("EDIT_COMPANY_*_{subCompanyId}"), hasRole("EDIT_COMPANY_{companyId}_*"), hasRole("EDIT_COMPANY_{companyId}_{subCompanyId}")));
                return Optional.of(resource.editSubCompany(
                        /* [PATH] companyId */ match.getPathParam("companyId"),
                        /* [PATH] subCompanyId */ match.getPathParam("subCompanyId")
                ));
            }
            // ....
`
``