### PR TITLE
Generics in dependency injection BREAKING

### DIFF
--- a/restx-common/src/main/java/restx/common/MoreObjects.java
+++ b/restx-common/src/main/java/restx/common/MoreObjects.java
@@ -1,5 +1,8 @@
 package restx.common;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
 /**
  * Date: 29/11/13
  * Time: 11:13
@@ -11,6 +14,24 @@ public class MoreObjects {
         }
         return clazz.getName() + "[" + toString(clazz.getClassLoader()) + "]";
     }
+
+	public static String toString(Type type) {
+		if (type == null) {
+			return "null";
+		}
+        String typeString;
+        /*
+            in jse8 another case should be done, using type.getTypeName() if
+            type is an instanceof ParameterizedType
+         */
+        if (type instanceof Class) {
+            typeString = ((Class) type).getName();
+        } else {
+            typeString = String.valueOf(type);
+        }
+
+		return  typeString + "[" + toString(Types.getRawType(type).getClassLoader()) + "]";
+	}
 
     public static String toString(ClassLoader classLoader) {
         if (classLoader == null) {

--- a/restx-common/src/main/java/restx/common/TypeReference.java
+++ b/restx-common/src/main/java/restx/common/TypeReference.java
@@ -33,6 +33,11 @@ public abstract class TypeReference<T> {
 	}
 
 	public Type getType() { return type; }
+
+	@Override
+	public String toString() {
+		return String.valueOf(type);
+	}
 }
 
 

--- a/restx-common/src/main/java/restx/common/Types.java
+++ b/restx-common/src/main/java/restx/common/Types.java
@@ -14,7 +14,9 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Date: 23/10/13
@@ -37,7 +39,25 @@ public class Types {
             public Type getOwnerType() {
                 return rawType.getEnclosingClass();
             }
-        };
+
+			@Override
+			public int hashCode() {
+				return Objects.hashCode(getOwnerType())
+						^ Objects.hashCode(rawType)
+						^ Arrays.hashCode(arguments);
+			}
+
+			@Override
+			public boolean equals(Object obj) {
+				if (obj instanceof ParameterizedType) {
+					ParameterizedType type = (ParameterizedType) obj;
+					return Objects.equals(type.getOwnerType(), getOwnerType())
+							&& Objects.equals(type.getRawType(), rawType)
+							&& Arrays.equals(type.getActualTypeArguments(), arguments);
+				}
+				return false;
+			}
+		};
     }
 
 	/**

--- a/restx-common/src/main/java/restx/common/Types.java
+++ b/restx-common/src/main/java/restx/common/Types.java
@@ -57,6 +57,46 @@ public class Types {
 				}
 				return false;
 			}
+
+			@Override
+			public String toString() {
+				StringBuilder sb = new StringBuilder();
+				Type ownerType = getOwnerType();
+				if (ownerType != null) {
+					if (ownerType instanceof Class) {
+						sb.append(((Class) ownerType).getName());
+					} else {
+						sb.append(ownerType.toString());
+					}
+
+					sb.append(".");
+					if (ownerType instanceof ParameterizedType) {
+
+						sb.append(rawType.getName().replace(((Class) ((ParameterizedType) ownerType).getRawType()).getName() + "$", ""));
+					} else {
+						sb.append(rawType.getName());
+					}
+				} else {
+					sb.append(rawType.getName());
+				}
+
+				if (arguments != null && arguments.length > 0) {
+					sb.append("<");
+					boolean first = true;
+
+					for (Type current : arguments) {
+						if (!first) {
+							sb.append(", ");
+						}
+						sb.append(current.toString()); // getTypeName() in jse8
+						first = false;
+					}
+
+					sb.append(">");
+				}
+
+				return sb.toString();
+			}
 		};
     }
 

--- a/restx-common/src/main/java/restx/common/processor/RestxAbstractProcessor.java
+++ b/restx-common/src/main/java/restx/common/processor/RestxAbstractProcessor.java
@@ -2,6 +2,7 @@ package restx.common.processor;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -29,6 +30,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.Arrays;
 import java.util.Set;
 
 /**
@@ -270,4 +272,31 @@ public abstract class RestxAbstractProcessor extends AbstractProcessor {
 			}
 		}
 	}
+
+    /**
+     * Checks of the TypeMirror has the same raw type as the specified class.
+     *
+     * @param typeMirror the type mirror
+     * @param clazz the class
+     * @return true if both have the same raw type
+     */
+    public static boolean isClass(TypeMirror typeMirror, Class clazz) {
+        return typeMirror.toString().startsWith(clazz.getCanonicalName());
+    }
+
+    /**
+     * Checks if the TypeMirror has the same raw type as one of the specified class array.
+     *
+     * @param typeMirror the type mirror
+     * @param classes the classes
+     * @return true if one of the classes has the same type as the type mirror's type.
+     */
+    public static boolean isClass(final TypeMirror typeMirror, Class... classes) {
+        for (Class aClass : classes) {
+            if (isClass(typeMirror, aClass)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/restx-common/src/test/java/restx/common/TypesTest.java
+++ b/restx-common/src/test/java/restx/common/TypesTest.java
@@ -9,6 +9,7 @@ import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.lang.reflect.Type;
 import java.util.AbstractList;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -23,6 +24,38 @@ public class TypesTest {
 
 	@Rule
 	public JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+	@Test
+	public void newParameterizedType_should_create_equals_parameters_types() {
+		Type parameterizedType1 = Types.newParameterizedType(List.class, String.class);
+		Type parameterizedType2 = Types.newParameterizedType(List.class, String.class);
+		softly.assertThat(parameterizedType1.equals(parameterizedType2)).isTrue();
+
+		Type typeReference = new TypeReference<List<String>>() {}.getType();
+		softly.assertThat(typeReference.equals(parameterizedType1)).isTrue();
+	}
+
+	static class GenericHolder<T> {
+		final T value;
+
+		GenericHolder(T value) {
+			this.value = value;
+		}
+
+		public T getValue() {
+			return value;
+		}
+	}
+
+	@Test
+	public void newParameterizedType_should_create_equals_inner_parameters_types() {
+		Type genericHolder1 = Types.newParameterizedType(GenericHolder.class, String.class);
+		Type genericHolder2 = Types.newParameterizedType(GenericHolder.class, String.class);
+		softly.assertThat(genericHolder1.equals(genericHolder2)).isTrue();
+
+		Type typeReference = new TypeReference<GenericHolder<String>>() {}.getType();
+		softly.assertThat(typeReference.equals(genericHolder1)).isTrue();
+	}
 
 	@Test
 	public void getRawType_should_return_the_class_of_non_parametrized_types() {

--- a/restx-factory-testing/src/test/java/restx/factory/generics/GenericsTest.java
+++ b/restx-factory-testing/src/test/java/restx/factory/generics/GenericsTest.java
@@ -113,4 +113,18 @@ public class GenericsTest {
 		TestGenericInterface<Double> componentDouble = factory.getComponent(new TypeReference<TestGenericInterface<Double>>() {});
 		softly.assertThat(componentDouble.execute(23d)).isEqualTo("42.0");
 	}
+
+	@Test
+	public void should_inject_generic_components() {
+		Factory factory = Factory.newInstance();
+
+		String component = factory.getComponent(Name.of(String.class, "withDependency"));
+		softly.assertThat(component).isEqualTo("42");
+
+		component = factory.getComponent(Name.of(String.class, "withNamedDependency"));
+		softly.assertThat(component).isEqualTo("23");
+
+		TestGenericComponentWithDep componentWithDep = factory.getComponent(TestGenericComponentWithDep.class);
+		softly.assertThat(componentWithDep.execute(42d)).isEqualTo("42.0#23");
+	}
 }

--- a/restx-factory-testing/src/test/java/restx/factory/generics/GenericsTest.java
+++ b/restx-factory-testing/src/test/java/restx/factory/generics/GenericsTest.java
@@ -1,0 +1,116 @@
+package restx.factory.generics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static restx.factory.Factory.LocalMachines.overrideComponents;
+import static restx.factory.Factory.LocalMachines.threadLocal;
+
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
+import restx.common.TypeReference;
+import restx.factory.Factory;
+import restx.factory.Name;
+
+/**
+ * @author apeyrard
+ */
+public class GenericsTest {
+
+	@Rule
+	public JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+	/**
+	 * ElementsFromConfig component can not be build, because of module TestMandatoryDependency
+	 * which use a missing dependency.
+	 */
+	@BeforeClass
+	public static void deactivateElementsFromConfig() {
+		System.setProperty("restx.activation::restx.factory.FactoryMachine::ElementsFromConfig", "false");
+	}
+
+	/**
+	 * cleanup state before each test method
+	 */
+	@Before
+	public void cleanupBefore() {
+		threadLocal().clear();
+	}
+
+	/**
+	 * cleanup state after this test class execution
+	 */
+	@AfterClass
+	public static void cleanupAfterClass() {
+		threadLocal().clear();
+	}
+
+	@Test
+	public void should_query_generics_components() {
+		Factory factory = Factory.newInstance();
+
+		TestGenericInterface<Double> componentDouble = factory.getComponent(new TypeReference<TestGenericInterface<Double>>() {});
+		softly.assertThat(componentDouble.execute(23d)).isEqualTo("23.0");
+
+		TestGenericInterface<Integer> componentInteger = factory.getComponent(new TypeReference<TestGenericInterface<Integer>>() {});
+		softly.assertThat(componentInteger.execute(23)).isEqualTo("23");
+
+		TestGenericInterface<Long> component = factory.getComponent(new TypeReference<TestGenericInterface<Long>>() {});
+		softly.assertThat(component.execute(23L)).isEqualTo("23");
+	}
+
+	@Test
+	public void should_query_by_raw_type_generics_components() {
+		Factory factory = Factory.newInstance();
+
+		Set<Name<TestGenericInterface>> names = factory.queryByClass(TestGenericInterface.class).findNames();
+		assertThat(names).extracting("type").containsOnly(
+				TestGenericComponent.class,
+				new TypeReference<TestGenericInterface<Integer>>() {}.getType(),
+				new TypeReference<TestGenericInterface<Long>>() {}.getType(),
+				new TypeReference<TestGenericInterface<TestGenericInterface<TestGenericInterface<Long>>>>() {}.getType()
+		);
+
+		Set<TestGenericInterface> components = factory.getComponents(TestGenericInterface.class);
+		softly.assertThat(components).hasSize(4);
+	}
+
+	@Test
+	public void should_query_type_with_multiple_parameters() {
+		Factory factory = Factory.newInstance();
+
+		Map<String, Double> component = factory.getComponent(new TypeReference<Map<String, Double>>() {});
+		softly.assertThat(component.get("foo")).isEqualTo(23d);
+	}
+
+	@Test
+	public void should_query_generics_of_generics() {
+		Factory factory = Factory.newInstance();
+
+		TestGenericInterface<TestGenericInterface<TestGenericInterface<Long>>> component =
+				factory.getComponent(new TypeReference<TestGenericInterface<TestGenericInterface<TestGenericInterface<Long>>>>() {});
+		softly.assertThat(component.execute(null)).isEqualTo("foo");
+	}
+
+	@Test
+	public void should_query_allow_generics_in_conditional() {
+		Factory factory = Factory.newInstance();
+		softly.assertThat(factory.queryByType(new TypeReference<Map<String, Long>>() {}).findOne().isPresent()).isFalse();
+
+		overrideComponents().set("answer-of", "universe");
+
+		factory = Factory.newInstance();
+
+		Map<String, Long> component = factory.getComponent(new TypeReference<Map<String, Long>>() {});
+		softly.assertThat(component.get("foo")).isEqualTo(42);
+
+		TestGenericInterface<Double> componentDouble = factory.getComponent(new TypeReference<TestGenericInterface<Double>>() {});
+		softly.assertThat(componentDouble.execute(23d)).isEqualTo("42.0");
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/generics/TestGenericComponent.java
+++ b/restx-factory-testing/src/test/java/restx/factory/generics/TestGenericComponent.java
@@ -1,0 +1,15 @@
+package restx.factory.generics;
+
+import restx.factory.Component;
+
+/**
+ * @author apeyrard
+ */
+@Component
+public class TestGenericComponent implements TestGenericInterface<Double> {
+
+	@Override
+	public String execute(Double element) {
+		return String.valueOf(element);
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/generics/TestGenericComponentAlternative.java
+++ b/restx-factory-testing/src/test/java/restx/factory/generics/TestGenericComponentAlternative.java
@@ -1,0 +1,17 @@
+package restx.factory.generics;
+
+import restx.factory.Alternative;
+import restx.factory.When;
+
+/**
+ * @author apeyrard
+ */
+@Alternative(to = TestGenericComponent.class)
+@When(name = "answer-of", value = "universe")
+public class TestGenericComponentAlternative extends TestGenericComponent {
+
+	@Override
+	public String execute(Double element) {
+		return String.valueOf(42d);
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/generics/TestGenericComponentWithDep.java
+++ b/restx-factory-testing/src/test/java/restx/factory/generics/TestGenericComponentWithDep.java
@@ -1,0 +1,22 @@
+package restx.factory.generics;
+
+import javax.inject.Named;
+import restx.factory.Component;
+
+/**
+ * @author apeyrard
+ */
+@Component
+public class TestGenericComponentWithDep {
+	private final TestGenericInterface<Double> testGenericComponent;
+	private final String fixedValue;
+
+	public TestGenericComponentWithDep(TestGenericInterface<Double> testGenericComponent, @Named("withNamedDependency") String fixedValue) {
+		this.testGenericComponent = testGenericComponent;
+		this.fixedValue = fixedValue;
+	}
+
+	public String execute(Double element) {
+		return testGenericComponent.execute(element) + "#" + fixedValue;
+	}
+}

--- a/restx-factory-testing/src/test/java/restx/factory/generics/TestGenericInterface.java
+++ b/restx-factory-testing/src/test/java/restx/factory/generics/TestGenericInterface.java
@@ -1,0 +1,8 @@
+package restx.factory.generics;
+
+/**
+ * @author apeyrard
+ */
+public interface TestGenericInterface<T> {
+	String execute(T element);
+}

--- a/restx-factory-testing/src/test/java/restx/factory/generics/TestModuleWithGenerics.java
+++ b/restx-factory-testing/src/test/java/restx/factory/generics/TestModuleWithGenerics.java
@@ -3,6 +3,7 @@ package restx.factory.generics;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import javax.inject.Named;
 import restx.factory.Module;
 import restx.factory.Provides;
 import restx.factory.When;
@@ -52,5 +53,15 @@ public class TestModuleWithGenerics {
 	@When(name = "answer-of", value = "universe")
 	public Map<String, Long> longTestGenericInterfaceMapConditional() {
 		return ImmutableMap.of("foo", 42l);
+	}
+
+	@Provides
+	public String withDependency(TestGenericInterface<Long> dep) {
+		return dep.execute(42l);
+	}
+
+	@Provides
+	public String withNamedDependency(@Named("longTestGenericInterface") TestGenericInterface<Long> dep) {
+		return dep.execute(23l);
 	}
 }

--- a/restx-factory-testing/src/test/java/restx/factory/generics/TestModuleWithGenerics.java
+++ b/restx-factory-testing/src/test/java/restx/factory/generics/TestModuleWithGenerics.java
@@ -1,0 +1,56 @@
+package restx.factory.generics;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import restx.factory.Module;
+import restx.factory.Provides;
+import restx.factory.When;
+
+/**
+ * @author apeyrard
+ */
+@Module
+public class TestModuleWithGenerics {
+
+	@Provides
+	public TestGenericInterface<Integer> integerTestGenericInterface() {
+		return new TestGenericInterface<Integer>() {
+			@Override
+			public String execute(Integer element) {
+				return String.valueOf(element);
+			}
+		};
+	}
+
+	@Provides
+	 public TestGenericInterface<Long> longTestGenericInterface() {
+		return new TestGenericInterface<Long>() {
+			@Override
+			public String execute(Long element) {
+				return String.valueOf(element);
+			}
+		};
+	}
+
+	@Provides
+	 public TestGenericInterface<TestGenericInterface<TestGenericInterface<Long>>> longTestGenericInterface2() {
+		return new TestGenericInterface<TestGenericInterface<TestGenericInterface<Long>>>() {
+			@Override
+			public String execute(TestGenericInterface<TestGenericInterface<Long>> element) {
+				return "foo";
+			}
+		};
+	}
+
+	@Provides
+	public Map<String, Double> longTestGenericInterfaceMap() {
+		return ImmutableMap.of("foo", 23d);
+	}
+
+	@Provides(priority = -1000)
+	@When(name = "answer-of", value = "universe")
+	public Map<String, Long> longTestGenericInterfaceMapConditional() {
+		return ImmutableMap.of("foo", 42l);
+	}
+}

--- a/restx-factory/src/main/java/restx/config/ConsolidatedConfigFactoryMachine.java
+++ b/restx-factory/src/main/java/restx/config/ConsolidatedConfigFactoryMachine.java
@@ -6,6 +6,7 @@ import static com.google.common.collect.Iterables.addAll;
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -98,8 +99,8 @@ public class ConsolidatedConfigFactoryMachine implements FactoryMachine {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
-        if (componentClass == RestxConfig.class) {
+    public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
+        if (componentType == RestxConfig.class) {
             return Collections.singleton(Name.of((Class<T>) RestxConfig.class));
         } else {
             return Collections.emptySet();

--- a/restx-factory/src/main/java/restx/config/ElementsFromConfigFactoryMachine.java
+++ b/restx-factory/src/main/java/restx/config/ElementsFromConfigFactoryMachine.java
@@ -6,6 +6,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Set;
 import restx.common.ConfigElement;
@@ -69,8 +70,8 @@ public class ElementsFromConfigFactoryMachine extends DefaultFactoryMachine {
 
                     @Override
                     @SuppressWarnings("unchecked")
-                    public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
-                        if (String.class == componentClass) {
+                    public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
+                        if (String.class == componentType) {
                             return (Set) Sets.newHashSet(Iterables.transform(config.elements(),
                                     new Function<ConfigElement, Name<String>>() {
                                 @Override
@@ -78,7 +79,7 @@ public class ElementsFromConfigFactoryMachine extends DefaultFactoryMachine {
                                     return Name.of(String.class, input.getKey());
                                 }
                             }));
-                        } else if (ConfigElement.class == componentClass) {
+                        } else if (ConfigElement.class == componentType) {
                             return (Set) Sets.newHashSet(Iterables.transform(config.elements(),
                                     new Function<ConfigElement, Name<ConfigElement>>() {
                                 @Override

--- a/restx-factory/src/main/java/restx/factory/DeactivationFactoryMachine.java
+++ b/restx-factory/src/main/java/restx/factory/DeactivationFactoryMachine.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+import java.lang.reflect.Type;
 import java.util.Set;
 
 public class DeactivationFactoryMachine implements FactoryMachine {
@@ -45,8 +46,8 @@ public class DeactivationFactoryMachine implements FactoryMachine {
 	}
 
 	@Override
-	public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
-		if (componentClass != String.class) {
+	public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
+		if (componentType != String.class) {
 			return ImmutableSet.of();
 		}
 		return Sets.newLinkedHashSet(Iterables.transform(keys, new Function<String, Name<T>>() {

--- a/restx-factory/src/main/java/restx/factory/DefaultFactoryMachine.java
+++ b/restx-factory/src/main/java/restx/factory/DefaultFactoryMachine.java
@@ -3,7 +3,9 @@ package restx.factory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
+import java.lang.reflect.Type;
 import java.util.Set;
+import restx.common.Types;
 
 /**
  * User: xavierhanin
@@ -37,10 +39,10 @@ public class DefaultFactoryMachine implements FactoryMachine {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
+    public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
         Set<Name<T>> names = Sets.newHashSet();
         for (Name<?> name : engines.keySet()) {
-            if (componentClass.isAssignableFrom(name.getClazz())) {
+            if (Types.isAssignableFrom(componentType, name.getType())) {
                 names.add((Name<T>) name);
             }
         }

--- a/restx-factory/src/main/java/restx/factory/Factory.java
+++ b/restx-factory/src/main/java/restx/factory/Factory.java
@@ -784,6 +784,10 @@ public class Factory implements AutoCloseable {
         return "restx.activation::" + aClass.getName() + "::" + name;
     }
 
+    public static <T> String activationKey(TypeReference<T> type, String name) {
+        return "restx.activation::" + type.getType() + "::" + name;
+    }
+
     private final class CanBuildPredicate implements Predicate<FactoryMachine> {
         private final Name<?> name;
 

--- a/restx-factory/src/main/java/restx/factory/Factory.java
+++ b/restx-factory/src/main/java/restx/factory/Factory.java
@@ -1274,7 +1274,7 @@ public class Factory implements AutoCloseable {
 
     private <T> Set<Name<T>> nameBuildableComponents(FactoryMachine machine, Class<T> componentClass) {
         Set<Name<T>> buildableComponents = new LinkedHashSet<>();
-        for (Name<T> tName : machine.nameBuildableComponents(componentClass)) {
+        for (Name<T> tName : machine.<T>nameBuildableComponents(componentClass)) {
             if (checkActive(tName)) {
                 buildableComponents.add(tName);
             }

--- a/restx-factory/src/main/java/restx/factory/Factory.java
+++ b/restx-factory/src/main/java/restx/factory/Factory.java
@@ -914,6 +914,22 @@ public class Factory implements AutoCloseable {
     }
 
     /**
+     * Builds a component by type.
+     *
+     * This is a shortcut for queryByType(typeReference).mandatory().findOneAsComponent().get()
+     *
+     * Therefore it raises an exception if no component of this type is found or if several one match.
+     *
+     * @param componentTypeReference
+     * @param <T>
+     * @return
+     */
+    public <T> T getComponent(TypeReference<T> componentTypeReference) {
+        return checkPresent(queryByType(componentTypeReference).mandatory().findOneAsComponent(),
+                "component of type %s not found", componentTypeReference);
+    }
+
+    /**
      * Builds a component by name.
      *
      * This is a shortcut for queryByName(name).mandatory().findOneAsComponent().get()
@@ -940,6 +956,19 @@ public class Factory implements AutoCloseable {
      */
     public <T> Set<T> getComponents(Class<T> componentClass) {
         return queryByClass(componentClass).findAsComponents();
+    }
+
+    /**
+     * Builds and return all the component of given type.
+     *
+     * This is a shortcut for queryByType(typeReference).findAsComponents()
+     *
+     * @param typeReference the type reference of the components to build and return
+     * @param <T> the type of components
+     * @return the set of components of given type
+     */
+    public <T> Set<T> getComponents(TypeReference<T> typeReference) {
+        return queryByType(typeReference).findAsComponents();
     }
 
     /**

--- a/restx-factory/src/main/java/restx/factory/FactoryMachine.java
+++ b/restx-factory/src/main/java/restx/factory/FactoryMachine.java
@@ -1,5 +1,6 @@
 package restx.factory;
 
+import java.lang.reflect.Type;
 import java.util.Set;
 
 /**
@@ -10,6 +11,6 @@ import java.util.Set;
 public interface FactoryMachine {
     boolean canBuild(Name<?> name);
     <T> MachineEngine<T> getEngine(Name<T> name);
-    <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass);
+    <T> Set<Name<T>> nameBuildableComponents(Type componentType);
     int priority();
 }

--- a/restx-factory/src/main/java/restx/factory/FactoryMachineWrapper.java
+++ b/restx-factory/src/main/java/restx/factory/FactoryMachineWrapper.java
@@ -5,6 +5,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,8 +109,9 @@ public class FactoryMachineWrapper implements FactoryMachine {
         return original.getEngine(name);
     }
 
-    public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
-        return original.nameBuildableComponents(componentClass);
+	@Override
+    public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
+        return original.nameBuildableComponents(componentType);
     }
 
     @Override

--- a/restx-factory/src/main/java/restx/factory/Name.java
+++ b/restx-factory/src/main/java/restx/factory/Name.java
@@ -1,8 +1,12 @@
 package restx.factory;
 
-import restx.common.MoreObjects;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+
+
+import java.lang.reflect.Type;
+import restx.common.MoreObjects;
+import restx.common.TypeReference;
+import restx.common.Types;
 
 /**
  * User: xavierhanin
@@ -11,23 +15,49 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class Name<T> {
     private final String name;
-    private final Class<T> clazz;
+	private final Type type;
+	private final Class<T> rawType;
 
     public static <T> Name<T> of(Class<T> clazz, String name) {
-        return new Name<>(clazz, name);
+        return new Name<>(clazz, clazz, name);
     }
 
     public static <T> Name<T> of(Class<T> clazz) {
-        return new Name<>(clazz, clazz.getSimpleName());
+        return new Name<>(clazz, clazz, clazz.getSimpleName());
     }
 
-    public Name(Class<T> clazz, String name) {
+	public static <T> Name<T> of(Type type, String name) {
+		return new Name<>(type, name);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Name<T> of(Type type) {
+		Class<T> rawType = (Class<T>) Types.getRawType(type);
+		return new Name<>(type, rawType, rawType.getSimpleName());
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Name<T> of(String name, Class<?> rawType, Type... arguments) {
+		return (Name<T>) new Name<>(Types.newParameterizedType(rawType, arguments), rawType, name);
+	}
+
+	public static <T> Name<T> of(TypeReference<T> typeReference, String name) {
+		return new Name<>(checkNotNull(typeReference).getType(), name);
+	}
+
+	@SuppressWarnings("unchecked")
+	public Name(Type type, String name) {
+		this(type,  (Class<T>) Types.getRawType(type), name);
+	}
+
+    private Name(Type type, Class<T> rawType, String name) {
         this.name = checkNotNull(name);
-        this.clazz = checkNotNull(clazz);
+		this.type = checkNotNull(type);
+		this.rawType = checkNotNull(rawType);
     }
 
     public String getSimpleName() {
-        String simpleName = clazz.getSimpleName();
+        String simpleName = String.valueOf(type);
         if (!simpleName.equalsIgnoreCase(name)) {
             simpleName = name + "[" + simpleName + "]";
         }
@@ -35,22 +65,26 @@ public final class Name<T> {
     }
 
     public String asId() {
-        return "[" + clazz.getName() + "]" + name;
+        return "[" + String.valueOf(type) + "]" + name;
     }
 
     public String getName() {
         return name;
     }
 
+	public Type getType() {
+		return type;
+	}
+
     public Class<T> getClazz() {
-        return clazz;
-    }
+		return rawType;
+	}
 
     @Override
     public String toString() {
         return "Name{" +
                 "name='" + name + '\'' +
-                ", clazz=" + MoreObjects.toString(clazz) +
+                ", type=" + MoreObjects.toString(type) +
                 '}';
     }
 
@@ -61,7 +95,8 @@ public final class Name<T> {
 
         Name name1 = (Name) o;
 
-        if (!clazz.equals(name1.clazz)) return false;
+        if (!rawType.equals(name1.rawType)) return false;
+        if (!type.equals(name1.type)) return false;
         if (!name.equals(name1.name)) return false;
 
         return true;
@@ -70,7 +105,8 @@ public final class Name<T> {
     @Override
     public int hashCode() {
         int result = name.hashCode();
-        result = 31 * result + clazz.hashCode();
+        result = 31 * result + rawType.hashCode();
+		result = 31 * result + type.hashCode();
         return result;
     }
 }

--- a/restx-factory/src/main/java/restx/factory/NamedComponent.java
+++ b/restx-factory/src/main/java/restx/factory/NamedComponent.java
@@ -1,8 +1,11 @@
 package restx.factory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+
 import com.google.common.base.Function;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.lang.reflect.Type;
 
 /**
  * User: xavierhanin
@@ -29,12 +32,22 @@ public final class NamedComponent<T> {
     }
 
     public static <T> NamedComponent<T> of(Class<T> clazz, String name, T component) {
-        return new NamedComponent<>(new Name<>(clazz, name), component);
+        return new NamedComponent<>(Name.of(clazz, name), component);
     }
 
     public static <T> NamedComponent<T> of(Class<T> clazz, String name, int priority, T component) {
-        return new NamedComponent<>(new Name<>(clazz, name), priority, component);
+        return new NamedComponent<>(Name.of(clazz, name), priority, component);
     }
+
+	@SuppressWarnings("unchecked")
+	public static <T> NamedComponent<T> of(Type type, String name, T component) {
+		return new NamedComponent<>((Name<T>) Name.of(type, name), component);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> NamedComponent<T> of(Type type, String name, int priority, T component) {
+		return new NamedComponent<>((Name<T>) Name.of(type, name), priority, component);
+	}
 
     private final Name<T> name;
     private final int priority;

--- a/restx-factory/src/main/java/restx/factory/NoopFactoryMachine.java
+++ b/restx-factory/src/main/java/restx/factory/NoopFactoryMachine.java
@@ -1,5 +1,6 @@
 package restx.factory;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Set;
 
@@ -23,7 +24,7 @@ public class NoopFactoryMachine implements FactoryMachine {
     }
 
     @Override
-    public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
+    public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
         return Collections.emptySet();
     }
 

--- a/restx-factory/src/main/java/restx/factory/SingleNameFactoryMachine.java
+++ b/restx-factory/src/main/java/restx/factory/SingleNameFactoryMachine.java
@@ -24,8 +24,8 @@ public class SingleNameFactoryMachine<C> implements FactoryMachine {
     @Override
     public boolean canBuild(Name<?> name) {
         return (this.name.equals(name)
-                || (   this.name.getName().equals(name.getName())
-                    && name.getClazz().isAssignableFrom(this.name.getClazz())));
+                || (this.name.getName().equals(name.getName())
+                && Types.isAssignableFrom(name.getType(), this.name.getType())));
     }
 
     @Override

--- a/restx-factory/src/main/java/restx/factory/SingleNameFactoryMachine.java
+++ b/restx-factory/src/main/java/restx/factory/SingleNameFactoryMachine.java
@@ -1,7 +1,9 @@
 package restx.factory;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Set;
+import restx.common.Types;
 
 /**
  * User: xavierhanin
@@ -34,8 +36,8 @@ public class SingleNameFactoryMachine<C> implements FactoryMachine {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
-        if (componentClass.isAssignableFrom(name.getClazz())) {
+    public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
+        if (Types.isAssignableFrom(componentType, name.getType())) {
             return Collections.singleton((Name<T>) name);
         } else {
             return Collections.emptySet();

--- a/restx-factory/src/main/java/restx/factory/SystemPropertyFactoryMachine.java
+++ b/restx-factory/src/main/java/restx/factory/SystemPropertyFactoryMachine.java
@@ -3,6 +3,7 @@ package restx.factory;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 
+import java.lang.reflect.Type;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -30,8 +31,8 @@ public class SystemPropertyFactoryMachine implements FactoryMachine {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
-        if (componentClass != String.class) {
+    public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
+        if (componentType != String.class) {
             return emptySet();
         }
         Set<Name<T>> names = new LinkedHashSet<>();

--- a/restx-factory/src/main/java/restx/factory/WarehouseProvidersMachine.java
+++ b/restx-factory/src/main/java/restx/factory/WarehouseProvidersMachine.java
@@ -6,8 +6,10 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
+import java.lang.reflect.Type;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import restx.common.Types;
 
 /**
  * Date: 16/11/13
@@ -95,11 +97,11 @@ public class WarehouseProvidersMachine implements FactoryMachine {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
+    public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
         Set<Name<T>> names = new LinkedHashSet<>();
         for (Warehouse provider : providers) {
             for (Name<?> name : provider.listNames()) {
-                if (componentClass.isAssignableFrom(name.getClazz())) {
+                if (Types.isAssignableFrom(componentType, name.getType())) {
                     names.add((Name<T>) name);
                 }
             }

--- a/restx-factory/src/main/resources/restx/factory/processor/ComponentMachine.mustache
+++ b/restx-factory/src/main/resources/restx/factory/processor/ComponentMachine.mustache
@@ -1,6 +1,7 @@
 package {{package}};
 
 import com.google.common.collect.ImmutableSet;
+import restx.common.Types;
 import restx.factory.*;
 import {{componentFqcn}};
 

--- a/restx-factory/src/main/resources/restx/factory/processor/ConditionalMachine.mustache
+++ b/restx-factory/src/main/resources/restx/factory/processor/ConditionalMachine.mustache
@@ -1,6 +1,7 @@
 package {{package}};
 
 import com.google.common.collect.ImmutableSet;
+import restx.common.Types;
 import restx.factory.*;
 {{#imports}}
 import {{.}};

--- a/restx-factory/src/main/resources/restx/factory/processor/ModuleMachine.mustache
+++ b/restx-factory/src/main/resources/restx/factory/processor/ModuleMachine.mustache
@@ -1,6 +1,8 @@
 package {{package}};
 
 import com.google.common.collect.ImmutableSet;
+
+import restx.common.Types;
 import restx.factory.*;
 import {{moduleFqcn}};
 
@@ -12,7 +14,14 @@ public class {{machine}} extends DefaultFactoryMachine {
     public {{machine}}() {
         super({{priority}}, new MachineEngine[] {
 {{#engines}}
-            new StdMachineEngine<{{type}}>(Name.of({{type}}.class, "{{injectionName}}"), {{enginePriority}}, BoundlessComponentBox.FACTORY) {
+            new StdMachineEngine<{{type}}>(
+                    Name.<{{type}}>of(
+                            {{typeFactory}},
+                            "{{injectionName}}"
+                    ),
+                    {{enginePriority}},
+                    BoundlessComponentBox.FACTORY) {
+
         {{queriesDeclarations}}
                 @Override
                 public BillOfMaterials getBillOfMaterial() {
@@ -49,8 +58,12 @@ public class {{machine}} extends DefaultFactoryMachine {
                             && satisfiedBOM.getOne(query).get().getComponent().equals("{{whenValue}}")) {
                         return new SingleNameFactoryMachine<{{componentType}}>({{priority}},
                                         new StdMachineEngine<{{componentType}}>(
-                                                Name.of({{componentType}}.class, "{{componentName}}"),
-                                                {{priority}}, BoundlessComponentBox.FACTORY) {
+                                                Name.<{{componentType}}>of(
+                                                        {{componentTypeFactory}},
+                                                        "{{componentName}}"
+                                                ),
+                                                {{priority}},
+                                                BoundlessComponentBox.FACTORY) {
                                             {{queriesDeclarations}}
 
                                             @Override

--- a/restx-factory/src/test/java/restx/factory/DeactivationFactoryMachineTest.java
+++ b/restx-factory/src/test/java/restx/factory/DeactivationFactoryMachineTest.java
@@ -4,6 +4,9 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
+import restx.common.TypeReference;
+
 public class DeactivationFactoryMachineTest {
     @Test
     public void should_deactivate_components() throws Exception {
@@ -16,5 +19,51 @@ public class DeactivationFactoryMachineTest {
                 .build();
 
         assertThat(factory.getComponents(Integer.class)).containsExactly(2);
+    }
+
+    @Test
+    public void should_deactivate_parameterized_components() throws Exception {
+        Name<Generic<Integer>> one = Name.of(new TypeReference<Generic<Integer>>(){}, "one");
+        Name<Generic<Integer>> two = Name.of(new TypeReference<Generic<Integer>>(){}, "two");
+        Factory factory = Factory.builder()
+                .addMachine(new SingletonFactoryMachine<>(0, new NamedComponent<>(one, new Generic<>(1))))
+                .addMachine(new SingletonFactoryMachine<>(0, new NamedComponent<>(two, new Generic<>(2))))
+                .addMachine(DeactivationFactoryMachine.forNames(one))
+                .build();
+
+        assertThat(factory.getComponents(new TypeReference<Generic<Integer>>() {}))
+                .containsExactly(
+                        new Generic<>(2)
+                );
+    }
+
+    public static class Generic<T> {
+        final T obj;
+
+        public Generic(T obj) {
+            this.obj = obj;
+        }
+
+        public T getObj() {
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (!(o instanceof Generic))
+                return false;
+
+            Generic<?> generic = (Generic<?>) o;
+
+            return obj.equals(generic.obj);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return obj.hashCode();
+        }
     }
 }

--- a/restx-factory/src/test/java/restx/factory/FactoryTest.java
+++ b/restx-factory/src/test/java/restx/factory/FactoryTest.java
@@ -10,7 +10,9 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.After;
 import org.junit.Test;
 
+import java.lang.reflect.Type;
 import java.util.Set;
+import restx.common.TypeReference;
 
 /**
  * User: xavierhanin
@@ -46,6 +48,173 @@ public class FactoryTest {
         assertThat(component.get().getComponent()).isEqualTo("value1");
 
         assertThat(factory.queryByName(Name.of(String.class, "test")).findOne().get()).isEqualTo(component.get());
+    }
+
+    @Test
+    public void should_permit_to_query_component_by_name_using_types() throws Exception {
+        Factory factory = Factory.builder().addMachine(testMachine()).build();
+
+        // the cast permit to force the use of the name with Type signature
+        Name<String> name = Name.of((Type) String.class, "test");
+        Optional<NamedComponent<String>> component = factory.queryByName(name).findOne();
+
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName()).isEqualTo(Name.of(String.class, "test"));
+        assertThat(component.get().getComponent()).isEqualTo("value1");
+
+        assertThat(factory.queryByName(Name.of(String.class, "test")).findOne().get()).isEqualTo(component.get());
+    }
+
+    @Test
+    public void should_permit_to_query_component_by_types() throws Exception {
+        Factory factory = Factory.builder().addMachine(testMachine()).build();
+
+        // first test the query by type signature with the Type
+        Optional<NamedComponent<String>> component = factory.<String>queryByType(String.class).findOne();
+
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName()).isEqualTo(Name.of(String.class, "test"));
+        assertThat(component.get().getComponent()).isEqualTo("value1");
+
+        assertThat(factory.queryByName(Name.of(String.class, "test")).findOne().get()).isEqualTo(component.get());
+
+        // the signature with raw type and types args might not be tested here, as String is not a parameterized type
+
+        // finally with type reference
+        component = factory.queryByType(new TypeReference<String>() {}).findOne();
+
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName()).isEqualTo(Name.of(String.class, "test"));
+        assertThat(component.get().getComponent()).isEqualTo("value1");
+
+        assertThat(factory.queryByName(Name.of(String.class, "test")).findOne().get()).isEqualTo(component.get());
+    }
+
+    @Test
+    public void should_permit_to_query_generic_components_using_types() throws Exception {
+        Factory factory = Factory.builder()
+                .addMachine(testGenericStringMachine("generic"))
+                .addMachine(testGenericIntegerMachine("generic"))
+                .build();
+
+        Optional<NamedComponent<GenericHolder<String>>> component = factory.<GenericHolder<String>>queryByType(GenericHolder.class, String.class).findOne();
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName().getName()).isEqualTo("generic");
+        assertThat(component.get().getComponent().getValue()).isEqualTo("foo");
+
+        Optional<NamedComponent<GenericHolder<Integer>>> component2 = factory.<GenericHolder<Integer>>queryByType(GenericHolder.class, Integer.class).findOne();
+        assertThat(component2.isPresent()).isTrue();
+        assertThat(component2.get().getName().getName()).isEqualTo("generic");
+        assertThat(component2.get().getComponent().getValue()).isEqualTo(42);
+
+        Optional<NamedComponent<GenericHolder<Integer>>> component3 = factory.queryByType(new TypeReference<GenericHolder<Integer>>() {}).findOne();
+        assertThat(component3.isPresent()).isTrue();
+        assertThat(component3.get().getName().getName()).isEqualTo("generic");
+        assertThat(component3.get().getComponent().getValue()).isEqualTo(42);
+    }
+
+    @Test
+     public void should_permit_to_query_generic_components_using_names() throws Exception {
+        Factory factory = Factory.builder()
+                .addMachine(testGenericStringMachine("generic"))
+                .addMachine(testGenericIntegerMachine("generic"))
+                .build();
+
+        Optional<NamedComponent<GenericHolder<String>>> component = factory.queryByName(Name.<GenericHolder<String>>of("generic", GenericHolder
+                .class, String.class)).findOne();
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName().getName()).isEqualTo("generic");
+        assertThat(component.get().getComponent().getValue()).isEqualTo("foo");
+
+        Optional<NamedComponent<GenericHolder<Integer>>> component2 = factory.queryByName(Name.<GenericHolder<Integer>>of("generic", GenericHolder
+                .class, Integer.class)).findOne();
+        assertThat(component2.isPresent()).isTrue();
+        assertThat(component2.get().getName().getName()).isEqualTo("generic");
+        assertThat(component2.get().getComponent().getValue()).isEqualTo(42);
+
+        Optional<NamedComponent<GenericHolder<Integer>>> component3 = factory.queryByName(Name.of(new TypeReference<GenericHolder<Integer>>() {
+        }, "generic")).findOne();
+        assertThat(component3.isPresent()).isTrue();
+        assertThat(component3.get().getName().getName()).isEqualTo("generic");
+        assertThat(component3.get().getComponent().getValue()).isEqualTo(42);
+    }
+
+    @Test
+    public void should_permit_to_query_generic_components_using_rawType() throws Exception {
+        Factory factory = Factory.builder()
+                .addMachine(testGenericStringMachine("genericstring"))
+                .addMachine(testGenericIntegerMachine("genericinteger"))
+                .build();
+
+        Optional<NamedComponent<GenericHolder>> component = factory.queryByName(Name.of(GenericHolder.class, "genericstring")).findOne();
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName().getName()).isEqualTo("genericstring");
+        assertThat(component.get().getComponent().getValue()).isEqualTo("foo");
+
+        Optional<NamedComponent<GenericHolder>> component2 = factory.queryByName(Name.of(GenericHolder.class, "genericinteger")).findOne();
+        assertThat(component2.isPresent()).isTrue();
+        assertThat(component2.get().getName().getName()).isEqualTo("genericinteger");
+        assertThat(component2.get().getComponent().getValue()).isEqualTo(42);
+    }
+
+    @Test
+    public void should_not_allow_more_than_one_matching_component_if_raw_type_are_used() throws Exception {
+        Factory factory = Factory.builder()
+                .addMachine(testGenericStringMachine("genericstring"))
+                .addMachine(testGenericIntegerMachine("genericinteger"))
+                .build();
+
+        try {
+            factory.queryByClass(GenericHolder.class).findOne();
+            fail("should throw exception");
+        } catch (Factory.UnsatisfiedDependenciesException ignored) {}
+
+        try {
+            factory.queryByType(GenericHolder.class).findOne();
+            fail("should throw exception");
+        } catch (Factory.UnsatisfiedDependenciesException ignored) {}
+    }
+
+    @Test
+    public void should_retrieve_highest_priority_for_raw_types_using_query_by_names() {
+        Factory factory = Factory.builder()
+                .addMachine(testGenericStringMachine("generic", -100))
+                .addMachine(testGenericIntegerMachine("generic", 10))
+                .build();
+        Optional<NamedComponent<GenericHolder>> component = factory.queryByName(Name.of(GenericHolder.class, "generic")).findOne();
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName().getName()).isEqualTo("generic");
+        assertThat(component.get().getComponent().getValue()).isEqualTo("foo");
+
+        factory = Factory.builder()
+                .addMachine(testGenericStringMachine("generic", 10))
+                .addMachine(testGenericIntegerMachine("generic", -1000))
+                .build();
+        component = factory.queryByName(Name.of(GenericHolder.class, "generic")).findOne();
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName().getName()).isEqualTo("generic");
+        assertThat(component.get().getComponent().getValue()).isEqualTo(42);
+    }
+
+    @Test
+    public void should_retrieve_highest_priority_using_query_by_names() {
+        Factory factory = Factory.builder()
+                .addMachine(testMachine("common_name", "foo", -100))
+                .addMachine(testMachine("common_name", "bar", 10))
+                .build();
+        Optional<NamedComponent<String>> component = factory.queryByName(Name.of(String.class, "common_name")).findOne();
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName().getName()).isEqualTo("common_name");
+        assertThat(component.get().getComponent()).isEqualTo("foo");
+
+        factory = Factory.builder()
+                .addMachine(testMachine("common_name", "foo", 100))
+                .addMachine(testMachine("common_name", "bar", 10))
+                .build();
+        component = factory.queryByName(Name.of(String.class, "common_name")).findOne();
+        assertThat(component.isPresent()).isTrue();
+        assertThat(component.get().getName().getName()).isEqualTo("common_name");
+        assertThat(component.get().getComponent()).isEqualTo("bar");
     }
 
     @Test
@@ -181,12 +350,12 @@ public class FactoryTest {
             assertThat(e)
                 .hasMessageStartingWith(
                     "\n" +
-                            "  QueryByName{name=Name{name='test', type=class java.lang.String[]}}\n" +
-                            "    |       \\__=> Name{name='test', type=class java.lang.String[]}\n" +
+                            "  QueryByName{name=Name{name='test', type=java.lang.String[]}}\n" +
+                            "    |       \\__=> Name{name='test', type=java.lang.String[]}\n" +
                             "    |\n" +
-                            "    +-> QueryByName{name=Name{name='missing', type=class java.lang.String[]}}\n" +
+                            "    +-> QueryByName{name=Name{name='missing', type=java.lang.String[]}}\n" +
                             "          |\n" +
-                            "          +--: Name{name='missing', type=class java.lang.String[]} can't be satisfied")
+                            "          +--: Name{name='missing', type=java.lang.String[]} can't be satisfied")
             ;
         }
     }
@@ -219,9 +388,9 @@ public class FactoryTest {
                             " Please select which one you want with a more specific query,\n" +
                             " or by deactivating one of the available components.\n" +
                             " Available components:\n" +
-                            " - NamedComponent{name=Name{name='test', type=class java.lang.String[]}, priority=0, component=value1}\n" +
+                            " - NamedComponent{name=Name{name='test', type=java.lang.String[]}, priority=0, component=value1}\n" +
                             "         [Activation key: 'restx.activation::java.lang.String::test']\n" +
-                            " - NamedComponent{name=Name{name='test2', type=class java.lang.String[]}, priority=0, component=value1}\n" +
+                            " - NamedComponent{name=Name{name='test2', type=java.lang.String[]}, priority=0, component=value1}\n" +
                             "         [Activation key: 'restx.activation::java.lang.String::test2']\n")
             ;
         }
@@ -587,6 +756,56 @@ public class FactoryTest {
             }
         });
     }
+
+    private SingleNameFactoryMachine<String> testMachine(String name, final String returnValue, int priority) {
+        return new SingleNameFactoryMachine<>(
+                priority, new NoDepsMachineEngine<String>(Name.of(String.class, name), priority, BoundlessComponentBox.FACTORY) {
+            @Override
+            protected String doNewComponent(SatisfiedBOM satisfiedBOM) {
+                return returnValue;
+            }
+        });
+    }
+
+	private SingleNameFactoryMachine<GenericHolder<String>> testGenericStringMachine(String name) {
+        return testGenericStringMachine(name, 0);
+    }
+
+    private SingleNameFactoryMachine<GenericHolder<String>> testGenericStringMachine(String name, int priority) {
+        return new SingleNameFactoryMachine<>(
+                priority, new NoDepsMachineEngine<GenericHolder<String>>(Name.<GenericHolder<String>>of(name, GenericHolder.class, String.class), priority, BoundlessComponentBox.FACTORY) {
+            @Override
+            protected GenericHolder<String> doNewComponent(SatisfiedBOM satisfiedBOM) {
+                return new GenericHolder<>("foo");
+            }
+        });
+    }
+
+    private SingleNameFactoryMachine<GenericHolder<Integer>> testGenericIntegerMachine(String name) {
+        return testGenericIntegerMachine(name, 0);
+    }
+
+    private SingleNameFactoryMachine<GenericHolder<Integer>> testGenericIntegerMachine(String name, int priority) {
+        return new SingleNameFactoryMachine<>(
+                priority, new NoDepsMachineEngine<GenericHolder<Integer>>(Name.<GenericHolder<Integer>>of(name, GenericHolder.class, Integer.class), BoundlessComponentBox.FACTORY) {
+            @Override
+            protected GenericHolder<Integer> doNewComponent(SatisfiedBOM satisfiedBOM) {
+                return new GenericHolder<>(42);
+            }
+        });
+    }
+
+    static class GenericHolder<T> {
+		final T value;
+
+		GenericHolder(T value) {
+			this.value = value;
+		}
+
+		public T getValue() {
+			return value;
+		}
+	}
 
     private SingleNameFactoryMachine<String> machineWithMissingDependency() {
         return new SingleNameFactoryMachine<>(

--- a/restx-factory/src/test/java/restx/factory/FactoryTest.java
+++ b/restx-factory/src/test/java/restx/factory/FactoryTest.java
@@ -1,14 +1,16 @@
 package restx.factory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static restx.factory.Factory.LocalMachines.threadLocal;
+
+
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import org.junit.After;
 import org.junit.Test;
 
 import java.util.Set;
-
-import static org.assertj.core.api.Assertions.*;
-import static restx.factory.Factory.LocalMachines.threadLocal;
 
 /**
  * User: xavierhanin
@@ -179,12 +181,12 @@ public class FactoryTest {
             assertThat(e)
                 .hasMessageStartingWith(
                     "\n" +
-                            "  QueryByName{name=Name{name='test', clazz=java.lang.String[]}}\n" +
-                            "    |       \\__=> Name{name='test', clazz=java.lang.String[]}\n" +
+                            "  QueryByName{name=Name{name='test', type=class java.lang.String[]}}\n" +
+                            "    |       \\__=> Name{name='test', type=class java.lang.String[]}\n" +
                             "    |\n" +
-                            "    +-> QueryByName{name=Name{name='missing', clazz=java.lang.String[]}}\n" +
+                            "    +-> QueryByName{name=Name{name='missing', type=class java.lang.String[]}}\n" +
                             "          |\n" +
-                            "          +--: Name{name='missing', clazz=java.lang.String[]} can't be satisfied")
+                            "          +--: Name{name='missing', type=class java.lang.String[]} can't be satisfied")
             ;
         }
     }
@@ -217,9 +219,9 @@ public class FactoryTest {
                             " Please select which one you want with a more specific query,\n" +
                             " or by deactivating one of the available components.\n" +
                             " Available components:\n" +
-                            " - NamedComponent{name=Name{name='test', clazz=java.lang.String[]}, priority=0, component=value1}\n" +
+                            " - NamedComponent{name=Name{name='test', type=class java.lang.String[]}, priority=0, component=value1}\n" +
                             "         [Activation key: 'restx.activation::java.lang.String::test']\n" +
-                            " - NamedComponent{name=Name{name='test2', clazz=java.lang.String[]}, priority=0, component=value1}\n" +
+                            " - NamedComponent{name=Name{name='test2', type=class java.lang.String[]}, priority=0, component=value1}\n" +
                             "         [Activation key: 'restx.activation::java.lang.String::test2']\n")
             ;
         }

--- a/restx-factory/src/test/java/restx/factory/FactoryTest.java
+++ b/restx-factory/src/test/java/restx/factory/FactoryTest.java
@@ -114,6 +114,34 @@ public class FactoryTest {
     }
 
     @Test
+    public void should_permit_to_query_generic_components_using_types_with_shortcuts_methods() throws Exception {
+        Factory factory = Factory.builder()
+                .addMachine(testGenericStringMachine("generic"))
+                .addMachine(testGenericIntegerMachine("generic"))
+                .build();
+
+        GenericHolder<Integer> componentInteger = factory.getComponent(new TypeReference<GenericHolder<Integer>>() {});
+        assertThat(componentInteger.getValue()).isEqualTo(42);
+
+        GenericHolder<String> componentString = factory.getComponent(new TypeReference<GenericHolder<String>>() {});
+        assertThat(componentString.getValue()).isEqualTo("foo");
+
+        // now query multiple components
+        factory = Factory.builder()
+                .addMachine(testGenericStringMachine("generic1"))
+                .addMachine(testGenericStringMachine("generic2"))
+                .build();
+
+        Set<GenericHolder<String>> components = factory.getComponents(new TypeReference<GenericHolder<String>>() {});
+        assertThat(components).hasSize(2);
+
+        try {
+            factory.getComponent(new TypeReference<GenericHolder<String>>() {});
+            fail("should throw exception, as two component were available for the type");
+        } catch (Factory.UnsatisfiedDependenciesException ignored) {}
+    }
+
+    @Test
      public void should_permit_to_query_generic_components_using_names() throws Exception {
         Factory factory = Factory.builder()
                 .addMachine(testGenericStringMachine("generic"))

--- a/restx-jongo/src/main/java/restx/jongo/JongoCollectionFactory.java
+++ b/restx-jongo/src/main/java/restx/jongo/JongoCollectionFactory.java
@@ -3,6 +3,7 @@ package restx.jongo;
 import org.jongo.Jongo;
 import restx.factory.*;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Set;
 
@@ -39,7 +40,7 @@ public class JongoCollectionFactory implements FactoryMachine {
     }
 
     @Override
-    public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
+    public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
         return Collections.emptySet();
     }
 


### PR DESCRIPTION
This PR brings the management of generics by the restx factory (the DI engine of restx).

Components can be queried using generic types like this:
```java
Generic<String> c = factory.getComponent(new TypeReference<Generic<String>>() {});
```
All the other methods permitting to query components also offer new signatures permitting to specify generics types:
```java
Generic<String> c = 
    factory.getComponent(Name.of(new TypeReference<Generic<String>>() {}, "foo"));
Optional<Generic<String>> c1 = 
    factory.queryByType(new TypeReference<Generic<String>>() {}).findOneAsComponent();
Set<Generic<String>> components = 
    factory.getComponents(new TypeReference<Generic<String>>() {});    
```

The new `TypeReference` has been introduced since #166, and permit to have reified types.
So new public methods in the API have been created using the `TypeReference` type.
But as it's not always convenient to create a new `TypeReference`. 
Signatures using a "fake" parameterized type have also been added:
```java
Generic<String> foo = 
    factory.getComponent(Name.<Generic<String>>of("foo", Generic.class, String.class));
```
(The diamonds operators has to be specified, see #159 comments for more explanation of what java can infer)
Note that `getComponent` and `getComponents` signatures does not allow the use of "fake" parameterized types as they would collide with original signatures.

Most of the time injection is done by the annotation processing, so this PR also modifies the AP in order to be able to inject generic types in constructors
```java
@Component public class MyComponent {
    public MyComponent(Generic<String> genericString) {
      // ...
    }
}
```
or in `@Provides` method arguments
```java
@Provides public MyComponent myComponent(Generic<String> genericString) {
    // ...
}
```

And to provide generic types in the system, the `@Component` annotation can be used:
```java
@Component public class MyGenericComponent implements Generic<String> {
    // ...
}
```
or by providing them in modules:
```java
@Provides public Generic<String> genericString() {
    // ...
}
```

So from now on, by mixing all of this, this kind of design can be used:
```java
@Provides public Generic<String> genericString() {
    // ...
}

@Provides public Generic<Integer> genericInteger() {
    // ...
}

@Provides public MyComponent myComponent(Generic<String> genericString, Generic<Integer> genericInteger) {
    // ...
}
```

There is some limitation of generic injection though. 
Iterable types: `Iterable.class`, `Collection.class`, `List.class`, `Set.class`, `ImmutableList.class`, `ImmutableSet.class` are reserved by the restx DI mechanism to inject all components of a type,
so we will not be able to provides generics components using those generics types.


This PR is breaking, because it changes the `FactoryMachine` API (see ceb7a5bfa3b2427574256c46ea1a5bd664e3ec7b):
```java
public <T> Set<Name<T>> nameBuildableComponents(Class<T> componentClass) {
``` 
has been replaced by:
```java
public <T> Set<Name<T>> nameBuildableComponents(Type componentType) {
```
Another breaking change is the use of a `Type` instead of a `Class` in the `Name` type (see 460715b711061a50f4405036bb200bb3386b9473).
But I don't think anyone would be annoyed by this change. As the public API is still compatible.

I will be happy to discuss with you about this PR. 
And I'm really eager to have this merged as I already designed so much thing at work using generics injection ;)  