### PR TITLE
[breaking] Update to guava 18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <!-- 3rd party libs -->
         <jackson.version>2.3.3</jackson.version>
-        <guava.version>17.0</guava.version>
+        <guava.version>18.0</guava.version>
         <joda-time.version>2.3</joda-time.version>
         <jna.version>3.2.7</jna.version>
         <slf4j-api.version>1.7.5</slf4j-api.version>


### PR DESCRIPTION
# Guava 18.0

See release notes: https://github.com/google/guava/wiki/Release18

Actually this is causing a conflict in my elasticsearch project when using elasticsearch 2.0 (which does not shade anymore 3rd party libs) and RestX.

Closes #224.

Note: This PR must be rebased and merged only after #225 is merged in master branch.