### PR TITLE
Upgrade jongo to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <!-- Mongo modules -->
         <mongo-java-driver.version>2.11.3</mongo-java-driver.version>
         <bson4jackson.version>2.3.1</bson4jackson.version>
-        <jongo.version>1.0</jongo.version>
+        <jongo.version>1.3.0</jongo.version>
         <de.flapdoodle.embed.version>1.42</de.flapdoodle.embed.version>
 
         <!-- Test libs -->


### PR DESCRIPTION
It fixes error "Unable to set objectid on class caused by: Class org.jongo.ReflectiveObjectIdUpdater can not access a member of class XXX" (brought by Xavier few years ago : https://github.com/bguerout/jongo/commit/bc14bba4da8bdc6c31a0070fa1f315b577a91dd3)

It should not be a breaking change (no breaking change are listed in the release note : http://jongo.org/tags/1.1/1.1.html#release-notes)

Currently, I upgraded to 1.1 which is the desirable version for me (since I hit the objectid issue), but we may consider upgrading [to 1.2](https://groups.google.com/forum/?fromgroups#!topic/jongo-user/f2O3NWUGAvM) bringing support for Mongo 3 (and deprecated @Id / @ObjectId, replacing it by @MongoObjectId).
Jongo 1.2 was released 9 month ago
