### PR TITLE
By default, use QUERY params for DELETE endpoints parameters, instead of BODY content

### DIFF
--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -200,7 +200,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
                 pathParamNamesToMatch.remove(reqParamName);
                 parameterKind = ResourceMethodParameterKind.PATH;
             } else if (parameterKind == null) {
-                if (ImmutableList.of("GET", "HEAD").contains(resourceMethod.httpMethod)) {
+                if (ImmutableList.of("GET", "HEAD", "DELETE").contains(resourceMethod.httpMethod)) {
                     parameterKind = ResourceMethodParameterKind.QUERY;
                 } else {
                     parameterKind = ResourceMethodParameterKind.BODY;

--- a/restx-samplest/pom.xml
+++ b/restx-samplest/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>io.restx</groupId>
-            <artifactId>restx-server-simple</artifactId>
+            <artifactId>restx-server-jetty</artifactId>
         </dependency>
         <dependency>
             <groupId>io.restx</groupId>

--- a/restx-samplest/src/main/java/samplest/AppServer.java
+++ b/restx-samplest/src/main/java/samplest/AppServer.java
@@ -1,17 +1,21 @@
 package samplest;
 
 import com.google.common.base.Optional;
+import restx.server.JettyWebServer;
 import restx.server.WebServer;
-import restx.server.simple.simple.SimpleWebServer;
+//import restx.server.simple.simple.SimpleWebServer;
 
 /**
  * Date: 1/12/13
  * Time: 14:18
  */
 public class AppServer {
+    public static final String WEB_INF_LOCATION = "src/main/webapp/WEB-INF/web.xml";
+    public static final String WEB_APP_LOCATION = "src/main/webapp";
+
     public static void main(String[] args) throws Exception {
         int port = Integer.valueOf(Optional.fromNullable(System.getenv("PORT")).or("8080"));
-        WebServer server = SimpleWebServer.builder().setRouterPath("/api").setPort(port).build();
+        WebServer server = new JettyWebServer(WEB_INF_LOCATION, WEB_APP_LOCATION, port, "0.0.0.0");
 
         /*
          * load mode from system property if defined, or default to dev

--- a/restx-samplest/src/main/java/samplest/core/CoreResource.java
+++ b/restx-samplest/src/main/java/samplest/core/CoreResource.java
@@ -1,8 +1,7 @@
 package samplest.core;
 
-import restx.annotations.GET;
-import restx.annotations.POST;
-import restx.annotations.RestxResource;
+import com.google.common.base.Optional;
+import restx.annotations.*;
 import restx.factory.Component;
 
 /**
@@ -52,4 +51,8 @@ public class CoreResource {
         return new Message().setMsg("hello " + who.getMsg());
     }
 
+    @DELETE("/hellomsg")
+    public String deleteHello(String who) {
+        return "hello "+who;
+    }
 }

--- a/restx-samplest/src/test/java/samplest/autostartable/AutoStartableTest.java
+++ b/restx-samplest/src/test/java/samplest/autostartable/AutoStartableTest.java
@@ -1,16 +1,12 @@
 package samplest.autostartable;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.kevinsawicki.http.HttpRequest;
 import org.junit.Test;
 import restx.factory.*;
+import restx.server.WebServer;
+import restx.server.WebServerSupplier;
 import restx.server.WebServers;
-import restx.server.simple.simple.SimpleWebServer;
 import restx.tests.HttpTestClient;
-import samplest.autostartable.AutoStartableTestComponent;
-import samplest.autostartable.AutoStartableTestRoute;
-
-import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,8 +21,8 @@ public class AutoStartableTest {
                 new SingletonFactoryMachine<>(-1000, NamedComponent.of(String.class, "restx.mode", "dev")));
 
         try {
-            SimpleWebServer server = SimpleWebServer.builder()
-                    .setRouterPath("/api").setPort(WebServers.findAvailablePort()).build();
+            int port = WebServers.findAvailablePort();
+            WebServer server = Factory.getInstance().getComponent(WebServerSupplier.class).newWebServer(port);
             server.start();
             try {
                 HttpTestClient client = HttpTestClient.withBaseUrl(server.baseUrl());

--- a/restx-samplest/src/test/java/samplest/core/CoreResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/core/CoreResourceTest.java
@@ -39,6 +39,14 @@ public class CoreResourceTest {
     }
 
     @Test
+    public void should_return_hello_msg_when_delete_with_param() throws Exception {
+        HttpRequest httpRequest = server.client().authenticatedAs("admin").DELETE(
+                "/api/core/hellomsg?who=restx");
+        assertThat(httpRequest.code()).isEqualTo(200);
+        assertThat(httpRequest.body().trim()).isEqualTo("hello restx");
+    }
+
+    @Test
     public void should_post_hello() throws Exception {
         HttpRequest httpRequest = server.client().authenticatedAs("admin").POST(
                 "/api/core/hellomsg").send("{\"msg\": \"restx\"}");


### PR DESCRIPTION
Currently, when we create a `@DELETE` endpoint, and put some parameters as endpoint parameters without using any `@Param(kind=...)` annotation, restx behaviour is to try to fill those parameters with BODY content instead of query parameter.

For instance :

```
    @DELETE("/hellomsg")
    public String deleteHello(String who) {
        return "hello "+who;
    }
```

will generate :
```
            @Override
            protected Optional<java.lang.String> doRoute(RestxRequest request, RestxRequestMatch match, java.lang.String body) throws IOException {
                securityManager.check(request, match, isAuthenticated());
                return Optional.of(resource.deleteHello(
                        /* [BODY] who */ checkValid(validator, body)
                ));
            }
```

Since it is more likely that `DELETE` HTTP request won't have any `BODY` content (this is not really stated in the spec, but I think we can make it a de facto standard here), we should rather use `QUERY` parameters to fill those method parameters rather than `BODY` content.

Note that if one really want to map request's BODY content to some method parameters, it will still be possible to use the `@Param(kind=Kind.BODY)` annotation to do so.

This change is marked as `[breaking]` because we're changing default behaviour here. 
But I don't think a lot of people will be impacted by this default change : people I know is working around this problem by putting manual `@Param(kind=Kind.QUERY)` annotation on `@DELETE` endpoints, and in that case, their code will still produce the exact same behaviour as before.

Also, note that I had to change `restx-samplest`'s `restx-server` implementation (from `simple` to `jetty`) to have better feedback on my added test case.
This change has been made because `simpleframework` HTTP server is completely obfuscating exception when one is raised to its layer, making error troubleshooting very complicated.

Since `restx-samplest` behaviour is first to provide some playground / testing area for bugs / new features, I guess it will be a better thing (moreover, current defaults in generated restx apps is `restx-server-jetty`, so I guess we're aligning on this as well).