### PR TITLE
Domains on cookies

### DIFF
--- a/restx-core/src/main/java/restx/AbstractResponse.java
+++ b/restx-core/src/main/java/restx/AbstractResponse.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import restx.http.HTTP;
 import restx.http.HttpStatus;
+import restx.security.RestxSessionCookieDescriptor;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -130,8 +131,8 @@ public abstract class AbstractResponse<R> implements RestxResponse {
     }
 
     @Override
-    public RestxResponse addCookie(String cookie, String value) {
-        addCookie(cookie, value, Duration.ZERO);
+    public RestxResponse addCookie(String cookie, String value, RestxSessionCookieDescriptor cookieDescriptor) {
+        addCookie(cookie, value, cookieDescriptor, Duration.ZERO);
         return this;
     }
 

--- a/restx-core/src/main/java/restx/RestxResponse.java
+++ b/restx-core/src/main/java/restx/RestxResponse.java
@@ -3,6 +3,7 @@ package restx;
 import com.google.common.base.Optional;
 import org.joda.time.Duration;
 import restx.http.HttpStatus;
+import restx.security.RestxSessionCookieDescriptor;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -56,9 +57,9 @@ public interface RestxResponse extends AutoCloseable {
 
     OutputStream getOutputStream() throws IOException;
 
-    RestxResponse addCookie(String cookie, String value);
-    RestxResponse addCookie(String cookie, String value, Duration expires);
-    RestxResponse clearCookie(String cookie);
+    RestxResponse addCookie(String cookie, String value, RestxSessionCookieDescriptor cookieDescriptor);
+    RestxResponse addCookie(String cookie, String value, RestxSessionCookieDescriptor cookieDescriptor, Duration expires);
+    RestxResponse clearCookie(String cookie, RestxSessionCookieDescriptor cookieDescriptor);
 
     RestxResponse setHeader(String headerName, String header);
 

--- a/restx-core/src/main/java/restx/RestxResponseWrapper.java
+++ b/restx-core/src/main/java/restx/RestxResponseWrapper.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import org.joda.time.Duration;
 import restx.http.HttpStatus;
+import restx.security.RestxSessionCookieDescriptor;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -58,8 +59,8 @@ public class RestxResponseWrapper implements RestxResponse {
         return this;
     }
 
-    public RestxResponse addCookie(String cookie, String value, Duration expires) {
-        restxResponse.addCookie(cookie, value, expires);
+    public RestxResponse addCookie(String cookie, String value, RestxSessionCookieDescriptor cookieDescriptor, Duration expires) {
+        restxResponse.addCookie(cookie, value, cookieDescriptor, expires);
         return this;
     }
 
@@ -79,8 +80,8 @@ public class RestxResponseWrapper implements RestxResponse {
         return restxResponse.isClosed();
     }
 
-    public RestxResponse clearCookie(String cookie) {
-        restxResponse.clearCookie(cookie);
+    public RestxResponse clearCookie(String cookie, RestxSessionCookieDescriptor cookieDescriptor) {
+        restxResponse.clearCookie(cookie, cookieDescriptor);
         return this;
     }
 
@@ -94,8 +95,8 @@ public class RestxResponseWrapper implements RestxResponse {
         return restxResponse.getHeader(headerName);
     }
 
-    public RestxResponse addCookie(String cookie, String value) {
-        restxResponse.addCookie(cookie, value);
+    public RestxResponse addCookie(String cookie, String value, RestxSessionCookieDescriptor cookieDescriptor) {
+        restxResponse.addCookie(cookie, value, cookieDescriptor);
         return this;
     }
 

--- a/restx-core/src/main/java/restx/security/RestxSessionCookieDescriptor.java
+++ b/restx-core/src/main/java/restx/security/RestxSessionCookieDescriptor.java
@@ -1,5 +1,7 @@
 package restx.security;
 
+import com.google.common.base.Optional;
+
 import static restx.http.HTTP.headerTokenCompatible;
 
 /**
@@ -8,10 +10,19 @@ import static restx.http.HTTP.headerTokenCompatible;
 public class RestxSessionCookieDescriptor {
     private String cookieName;
     private String cookieSignatureName;
+    private String domain;
+    private Boolean secure;
 
     public RestxSessionCookieDescriptor(String cookieName, String cookieSignatureName) {
+        this(cookieName, cookieSignatureName, Optional.<String>absent(), Optional.<Boolean>absent());
+    }
+
+    public RestxSessionCookieDescriptor(String cookieName, String cookieSignatureName,
+                                        Optional<String> domain, Optional<Boolean> secure) {
         this.cookieName = headerTokenCompatible(cookieName, "_");
         this.cookieSignatureName = headerTokenCompatible(cookieSignatureName, "_");
+        this.domain = domain.orNull();
+        this.secure = secure.orNull();
     }
 
     public String getCookieName() {
@@ -20,5 +31,13 @@ public class RestxSessionCookieDescriptor {
 
     public String getCookieSignatureName() {
         return cookieSignatureName;
+    }
+
+    public Optional<String> getDomain() {
+        return Optional.fromNullable(domain);
+    }
+
+    public Optional<Boolean> getSecure() {
+        return Optional.fromNullable(secure);
     }
 }

--- a/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
+++ b/restx-core/src/main/java/restx/security/RestxSessionCookieFilter.java
@@ -155,12 +155,12 @@ public class RestxSessionCookieFilter implements RestxRouteFilter, RestxHandler 
     private void updateSessionInClient(RestxResponse resp, RestxSession session) {
         ImmutableMap<String, String> cookiesMap = toCookiesMap(session);
         if (cookiesMap.isEmpty()) {
-            resp.clearCookie(restxSessionCookieDescriptor.getCookieName());
-            resp.clearCookie(restxSessionCookieDescriptor.getCookieSignatureName());
+            resp.clearCookie(restxSessionCookieDescriptor.getCookieName(), restxSessionCookieDescriptor);
+            resp.clearCookie(restxSessionCookieDescriptor.getCookieSignatureName(), restxSessionCookieDescriptor);
         } else {
             for (Map.Entry<String, String> cookie : cookiesMap.entrySet()) {
                 logger.debug("setting cookie: {} {}", cookie.getKey(), cookie.getValue());
-                resp.addCookie(cookie.getKey(), cookie.getValue(), session.getExpires());
+                resp.addCookie(cookie.getKey(), cookie.getValue(), restxSessionCookieDescriptor, session.getExpires());
             }
         }
     }

--- a/restx-server-simple/src/main/java/restx/server/simple/simple/SimpleRestxResponse.java
+++ b/restx-server-simple/src/main/java/restx/server/simple/simple/SimpleRestxResponse.java
@@ -6,6 +6,7 @@ import org.simpleframework.http.Response;
 import restx.AbstractResponse;
 import restx.http.HttpStatus;
 import restx.RestxResponse;
+import restx.security.RestxSessionCookieDescriptor;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -24,18 +25,30 @@ public class SimpleRestxResponse extends AbstractResponse<Response> {
     }
 
     @Override
-    public RestxResponse addCookie(String cookie, String value, Duration expiration) {
+    public RestxResponse addCookie(String cookie, String value, RestxSessionCookieDescriptor cookieDescriptor, Duration expiration) {
         Cookie c = new Cookie(cookie, value, "/");
         c.setExpiry(expiration.getStandardSeconds() > 0 ? (int) expiration.getStandardSeconds() : -1);
+        if(cookieDescriptor.getDomain().isPresent()) {
+            c.setDomain(cookieDescriptor.getDomain().get());
+        }
+        if(cookieDescriptor.getSecure().isPresent()) {
+            c.setSecure(cookieDescriptor.getSecure().get().booleanValue());
+        }
         response.setCookie(c);
         return this;
     }
 
     @Override
-    public RestxResponse clearCookie(String cookie) {
+    public RestxResponse clearCookie(String cookie, RestxSessionCookieDescriptor cookieDescriptor) {
         Cookie c = new Cookie(cookie, "");
         c.setPath("/");
         c.setExpiry(0);
+        if(cookieDescriptor.getDomain().isPresent()) {
+            c.setDomain(cookieDescriptor.getDomain().get());
+        }
+        if(cookieDescriptor.getSecure().isPresent()) {
+            c.setSecure(cookieDescriptor.getSecure().get().booleanValue());
+        }
         response.setCookie(c);
         return this;
     }

--- a/restx-servlet/src/main/java/restx/servlet/HttpServletRestxResponse.java
+++ b/restx-servlet/src/main/java/restx/servlet/HttpServletRestxResponse.java
@@ -4,6 +4,7 @@ import org.joda.time.Duration;
 import restx.AbstractResponse;
 import restx.http.HttpStatus;
 import restx.RestxResponse;
+import restx.security.RestxSessionCookieDescriptor;
 
 import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
@@ -44,9 +45,15 @@ public class HttpServletRestxResponse extends AbstractResponse<HttpServletRespon
     }
 
     @Override
-    public RestxResponse addCookie(String cookie, String value, Duration expiration) {
+    public RestxResponse addCookie(String cookie, String value, RestxSessionCookieDescriptor cookieDescriptor, Duration expiration) {
         Cookie existingCookie = HttpServletRestxRequest.getCookie(request.getCookies(), cookie);
         if (existingCookie != null) {
+            if(cookieDescriptor.getDomain().isPresent()) {
+                existingCookie.setDomain(cookieDescriptor.getDomain().get());
+            }
+            if(cookieDescriptor.getSecure().isPresent()) {
+                existingCookie.setSecure(cookieDescriptor.getSecure().get().booleanValue());
+            }
             if ("/".equals(existingCookie.getPath())
                     || existingCookie.getPath() == null // in some cases cookies set on path '/' are returned with a null path
                     ) {
@@ -70,18 +77,30 @@ public class HttpServletRestxResponse extends AbstractResponse<HttpServletRespon
             Cookie c = new Cookie(cookie, value);
             c.setPath("/");
             c.setMaxAge(expiration.getStandardSeconds() > 0 ? (int) expiration.getStandardSeconds() : -1);
+            if(cookieDescriptor.getDomain().isPresent()) {
+                c.setDomain(cookieDescriptor.getDomain().get());
+            }
+            if(cookieDescriptor.getSecure().isPresent()) {
+                c.setSecure(cookieDescriptor.getSecure().get().booleanValue());
+            }
             resp.addCookie(c);
         }
         return this;
     }
 
     @Override
-    public RestxResponse clearCookie(String cookie) {
+    public RestxResponse clearCookie(String cookie, RestxSessionCookieDescriptor cookieDescriptor) {
         Cookie existingCookie = HttpServletRestxRequest.getCookie(request.getCookies(), cookie);
         if (existingCookie != null) {
             existingCookie.setPath("/");
             existingCookie.setValue("");
             existingCookie.setMaxAge(0);
+            if(cookieDescriptor.getDomain().isPresent()) {
+                existingCookie.setDomain(cookieDescriptor.getDomain().get());
+            }
+            if(cookieDescriptor.getSecure().isPresent()) {
+                existingCookie.setSecure(cookieDescriptor.getSecure().get().booleanValue());
+            }
             resp.addCookie(existingCookie);
         }
         return this;


### PR DESCRIPTION
Added `domain` and `secure` properties in `RestxSessionCookieDescriptor`, allowing to put cookie domain (if needed) when manipulating Cookies.
This aims at fixing #239 

Note that existing behaviour of not setting any Cookie domain is kept by default.

If you want to override this default behaviour and use a particular Cookie domain, simply provide your own `RestxSessionCookieDescriptor`, eg :

```
@Module
public class YourAppModule {
    @Provides
    public RestxSessionCookieDescriptor restxSessionCookieDescriptor(@Named("app.name") String appName){
        Boolean isSecured = Boolean.FALSE;
        return new RestxSessionCookieDescriptor(
                String.format("%s-%s", "RestxSession", appName.get()),
                String.format("%s-%s", "RestxSessionSignature", appName.get()),
                Optional.of("my.domain.tld"),
                Optional.of(isSecured));
    }
}
`
``