### PR TITLE
console - not urlencoding PATH parameters when sending request through restx console

### DIFF
--- a/restx-apidocs/src/main/resources/restx/apidocs/js/controllers/OperationController.js
+++ b/restx-apidocs/src/main/resources/restx/apidocs/js/controllers/OperationController.js
@@ -52,7 +52,7 @@ adminApp.controller('OperationController', function OperationController(
         var queryParams = [];
         _.each($scope.operation.parameters, function(p) {
             if (p.paramType == 'path') {
-                path = path.replace('{' + p.name + '}', encodeURIComponent(p.value));
+                path = path.replace('{' + p.name + '}', p.value);
             } else if (p.paramType == 'query') {
                 if (p.value !== undefined && p.value !== '') {
                     queryParams.push(encodeURIComponent(p.name) + '=' + encodeURIComponent(p.value));

--- a/restx-core/src/main/java/restx/AbstractRequest.java
+++ b/restx-core/src/main/java/restx/AbstractRequest.java
@@ -18,7 +18,7 @@ import java.util.Map;
  * Time: 18:38
  */
 public abstract class AbstractRequest implements RestxRequest {
-    private final HttpSettings httpSettings;
+    protected final HttpSettings httpSettings;
 
     protected AbstractRequest(HttpSettings httpSettings) {
         this.httpSettings = httpSettings;

--- a/restx-core/src/main/java/restx/HttpSettings.java
+++ b/restx-core/src/main/java/restx/HttpSettings.java
@@ -21,4 +21,8 @@ public interface HttpSettings {
 
     @SettingsKey(key = "restx.http.gzip.paths", defaultValue = "/{s:.+}")
     Collection<String> gzipPaths();
+
+    @SettingsKey(key = "restx.http.decode.url.path.params", defaultValue = "true",
+            doc="Will issue a URLDecoder.decode() on every PATH parameters if true")
+    boolean decodeURLPathParams();
 }

--- a/restx-core/src/main/java/restx/HttpSettingsConfig.java
+++ b/restx-core/src/main/java/restx/HttpSettingsConfig.java
@@ -39,4 +39,9 @@ public class HttpSettingsConfig implements HttpSettings {
         return Splitter.on(",").trimResults().splitToList(
                 config.getString("restx.http.gzip.paths").or("/{s:.+}"));
     }
+
+    @Override
+    public boolean decodeURLPathParams() {
+        return config.getBoolean("restx.http.decode.url.path.params").or(Boolean.TRUE).booleanValue();
+    }
 }

--- a/restx-core/src/main/resources/restx/httpConfig.properties
+++ b/restx-core/src/main/resources/restx/httpConfig.properties
@@ -16,3 +16,6 @@ restx.http.scheme=
 # the collection of RESTX paths on which gzip filter should be applied
 # to enable it on all resources, use `/{s:.+}`
 restx.http.gzip.paths=/{s:.+}
+
+# Will issue a URLDecoder.decode() on restx path resolution
+restx.http.decode.url.path.params=true

--- a/restx-samplest/src/test/java/samplest/core/ParametersResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/core/ParametersResourceTest.java
@@ -18,14 +18,6 @@ public class ParametersResourceTest {
     public static RestxServerRule server = new RestxServerRule();
 
     @Test
-    public void should_return_path_params() throws Exception {
-        HttpRequest httpRequest = server.client().authenticatedAs("admin").GET(
-                "/api/params/path/v1/v2/35v4/v5");
-        assertThat(httpRequest.code()).isEqualTo(200);
-        assertThat(httpRequest.body().trim()).isEqualTo("a=v1 b=v2 c=35 d=v4 e=v5");
-    }
-
-    @Test
     public void should_return_header_params() throws Exception {
         HttpRequest httpRequest = server.client().authenticatedAs("admin")
                 .GET("/api/params/headers")

--- a/restx-samplest/src/test/java/samplest/core/UrlParametersResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/core/UrlParametersResourceTest.java
@@ -27,7 +27,7 @@ public class UrlParametersResourceTest {
     @Parameterized.Parameters(name="{0}")
     public static Iterable<Object[]> data(){
         return Arrays.asList(new Object[][]{
-                {"/v1/v2/35v4/v5", "a=v1 b=v2 c=35 d=v4 e=v5"}
+                {"/v1/hello%20world/35v4/v5", "a=v1 b=hello world c=35 d=v4 e=v5"},
         });
     }
 

--- a/restx-samplest/src/test/java/samplest/core/UrlParametersResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/core/UrlParametersResourceTest.java
@@ -1,0 +1,45 @@
+package samplest.core;
+
+import com.github.kevinsawicki.http.HttpRequest;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import restx.tests.RestxServerRule;
+
+import java.net.URLEncoder;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Date: 13/12/13
+ * Time: 23:59
+ */
+@RunWith(Parameterized.class)
+public class UrlParametersResourceTest {
+    private final String url;
+    private final String expectedBody;
+
+    @ClassRule
+    public static RestxServerRule server = new RestxServerRule();
+
+    @Parameterized.Parameters(name="{0}")
+    public static Iterable<Object[]> data(){
+        return Arrays.asList(new Object[][]{
+                {"/v1/v2/35v4/v5", "a=v1 b=v2 c=35 d=v4 e=v5"}
+        });
+    }
+
+    public UrlParametersResourceTest(String url, String expectedBody) {
+        this.url = url;
+        this.expectedBody = expectedBody;
+    }
+
+    @Test
+    public void should_return_path_params() throws Exception {
+        HttpRequest httpRequest = server.client().authenticatedAs("admin").GET("/api/params/path"+this.url);
+        assertThat(httpRequest.code()).isEqualTo(200);
+        assertThat(httpRequest.body().trim()).isEqualTo(this.expectedBody);
+    }
+}

--- a/restx-servlet/src/main/java/restx/servlet/HttpServletRestxRequest.java
+++ b/restx-servlet/src/main/java/restx/servlet/HttpServletRestxRequest.java
@@ -1,6 +1,7 @@
 package restx.servlet;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
 import com.google.common.collect.*;
 import restx.AbstractRequest;
 import restx.HttpSettings;
@@ -11,6 +12,8 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -48,7 +51,15 @@ public class HttpServletRestxRequest extends AbstractRequest {
 
     @Override
     public String getRestxPath() {
-        return request.getRequestURI().substring((getBaseApiPath()).length());
+        String restxPath = request.getRequestURI().substring((getBaseApiPath()).length());
+        if(this.httpSettings.decodeURLPathParams()) {
+            try {
+                restxPath = URLDecoder.decode(restxPath, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw Throwables.propagate(e);
+            }
+        }
+        return restxPath;
     }
 
     @Override


### PR DESCRIPTION
This fixes #257