### PR TITLE
Allowing to install dependencies from pom.xml or module.ivy file

### DIFF
--- a/restx-build/src/main/java/restx/build/MavenSupport.java
+++ b/restx-build/src/main/java/restx/build/MavenSupport.java
@@ -27,12 +27,12 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
             if (jsonObject.has("parent")) {
                 JSONObject parentObject = jsonObject.getJSONObject("parent");
                 // No packaging type is allowed on <parent> tag
-                parent = getGav(parentObject, null);
+                parent = getGav(parentObject, null, null);
             } else {
                 parent = null;
             }
             // Packaging is defined with <packaging> tag on artefact definition
-            GAV gav = getGav(jsonObject, "packaging");
+            GAV gav = getGav(jsonObject, "packaging", parent);
             String packaging = jsonObject.has("packaging") ? jsonObject.getString("packaging") : "jar";
 
             Map<String, String> properties = new LinkedHashMap<>();
@@ -64,7 +64,7 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
                     }
 
                     // Packaging is defined with <type> tag on dependencies
-                    scopeDependencies.add(new ModuleDependency(getGav(dep, "type")));
+                    scopeDependencies.add(new ModuleDependency(getGav(dep, "type", null)));
                 }
             }
 
@@ -72,12 +72,12 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
                     properties, new HashMap<String,List<ModuleFragment>>(), dependencies);
         }
 
-        private GAV getGav(JSONObject jsonObject, String typeKey) {
+        private GAV getGav(JSONObject jsonObject, String typeKey, GAV parentGAV) {
             return new GAV(
-                    jsonObject.getString("groupId"),
-                    jsonObject.getString("artifactId"),
-                    String.valueOf(jsonObject.get("version")),
-                    typeKey==null?null:jsonObject.has(typeKey)?jsonObject.getString(typeKey):null,
+                    jsonObject.has("groupId")?jsonObject.getString("groupId"):parentGAV==null?null:parentGAV.getGroupId(),
+                    jsonObject.has("artifactId")?jsonObject.getString("artifactId"):parentGAV==null?null:parentGAV.getArtifactId(),
+                    jsonObject.has("version")?String.valueOf(jsonObject.get("version")):parentGAV==null?null:parentGAV.getVersion(),
+                    typeKey==null?null:jsonObject.has(typeKey)?jsonObject.getString(typeKey):parentGAV==null?null:parentGAV.getType(),
                     jsonObject.has("classifier")?jsonObject.getString("classifier"):null,
                     jsonObject.has("optional")?jsonObject.getBoolean("optional"):false);
         }

--- a/restx-core-shell/src/main/java/restx/core/shell/AppShellCommand.java
+++ b/restx-core-shell/src/main/java/restx/core/shell/AppShellCommand.java
@@ -305,7 +305,7 @@ public class AppShellCommand extends StdShellCommand {
                             "You can always install the deps later by using the `deps install` command\n" +
                             "and run the app with the `app run` command")) {
                 shell.println("restx> deps install");
-                new DepsShellCommand().new InstallDepsCommandRunner().run(shell);
+                new DepsShellCommand.InstallDepsCommandRunner().run(shell);
                 shell.println("restx> app run");
                 new RunAppCommandRunner(Collections.<String>emptyList()).run(shell);
             }
@@ -632,7 +632,7 @@ public class AppShellCommand extends StdShellCommand {
 
             if (!DepsShellCommand.depsUpToDate(shell)) {
                 shell.println("restx> deps install");
-                new DepsShellCommand().new InstallDepsCommandRunner().run(shell);
+                new DepsShellCommand.InstallDepsCommandRunner().run(shell);
             }
 
             List<String> vmOptions = new ArrayList<>(this.vmOptions);

--- a/restx-core-shell/src/main/java/restx/core/shell/DepsShellCommand.java
+++ b/restx-core-shell/src/main/java/restx/core/shell/DepsShellCommand.java
@@ -67,7 +67,7 @@ public class DepsShellCommand extends StdShellCommand {
                 new StringsCompleter("deps"), new StringsCompleter("install", "add")));
     }
 
-    public class InstallDepsCommandRunner implements ShellCommandRunner {
+    public static class InstallDepsCommandRunner implements ShellCommandRunner {
 
         @Override
         public void run(RestxShell shell) throws Exception {
@@ -111,7 +111,7 @@ public class DepsShellCommand extends StdShellCommand {
         }
     }
 
-    class AddDepsCommandRunner implements ShellCommandRunner {
+    static class AddDepsCommandRunner implements ShellCommandRunner {
         private final String scope;
         private Optional<List<String>> pluginIds;
 

--- a/restx-core-shell/src/main/java/restx/core/shell/DepsShellCommand.java
+++ b/restx-core-shell/src/main/java/restx/core/shell/DepsShellCommand.java
@@ -72,11 +72,21 @@ public class DepsShellCommand extends StdShellCommand {
         @Override
         public void run(RestxShell shell) throws Exception {
             File mdFile = mdFile(shell);
-            if (!mdFile.exists()) {
+            if(!mdFile.exists()) {
                 throw new IllegalStateException(
                         "md.restx.json file not found in " + shell.currentLocation() + "." +
                                 " It is required to perform deps management");
             }
+
+            installDepsFromModuleDescriptor(shell, mdFile);
+
+            File md5File = md5File(shell);
+            Files.write(Files.hash(mdFile, Hashing.md5()).toString(), md5File, Charsets.UTF_8);
+
+            shell.println("DONE");
+        }
+
+        private void installDepsFromModuleDescriptor(RestxShell shell, File mdFile) throws Exception {
             Ivy ivy = ShellIvy.loadIvy(shell);
             File tempFile = File.createTempFile("restx-md", ".ivy");
             try (FileInputStream is = new FileInputStream(mdFile)) {
@@ -93,13 +103,8 @@ public class DepsShellCommand extends StdShellCommand {
                         new RetrieveOptions()
                                 .setDestArtifactPattern(
                                         shell.currentLocation().toAbsolutePath() + "/target/dependency/[artifact]-[revision](-[classifier]).[ext]")
-                        .setSync(true)
+                                .setSync(true)
                 );
-
-                File md5File = md5File(shell);
-                Files.write(Files.hash(mdFile, Hashing.md5()).toString(), md5File, Charsets.UTF_8);
-
-                shell.println("DONE");
             } finally {
                 tempFile.delete();
             }

--- a/restx-core-shell/src/main/java/restx/core/shell/ModuleDescriptorType.java
+++ b/restx-core-shell/src/main/java/restx/core/shell/ModuleDescriptorType.java
@@ -1,0 +1,43 @@
+package restx.core.shell;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+public enum ModuleDescriptorType {
+    RESTX("md.restx.json"), MAVEN("pom.xml"), IVY("module.ivy");
+
+    private String descriptorFileName;
+
+    ModuleDescriptorType(String descriptorFileName) {
+        this.descriptorFileName = descriptorFileName;
+    }
+
+    public String getDescriptorFileName() {
+        return descriptorFileName;
+    }
+
+    public File resolveDescriptorFile(Path inDirectory) {
+        return inDirectory.resolve(this.getDescriptorFileName()).toFile();
+    }
+
+    public File resolveDescriptorMd5File(Path inDirectory) {
+        return inDirectory.resolve(String.format("target/dependency/%s.md5", this.getDescriptorFileName())).toFile();
+    }
+
+    public static Optional<ModuleDescriptorType> firstModuleDescriptorTypeWithExistingFile(final Path inDirectory) {
+        return FluentIterable
+            .from(Arrays.asList(ModuleDescriptorType.RESTX))
+            .filter(new Predicate<ModuleDescriptorType>() {
+                @Override
+                public boolean apply(ModuleDescriptorType mdType) {
+                    return mdType.resolveDescriptorFile(inDirectory).exists();
+                }
+            }).first();
+    }
+
+}

--- a/restx-core-shell/src/main/java/restx/core/shell/ModuleDescriptorType.java
+++ b/restx-core-shell/src/main/java/restx/core/shell/ModuleDescriptorType.java
@@ -31,7 +31,7 @@ public enum ModuleDescriptorType {
 
     public static Optional<ModuleDescriptorType> firstModuleDescriptorTypeWithExistingFile(final Path inDirectory) {
         return FluentIterable
-            .from(Arrays.asList(ModuleDescriptorType.RESTX))
+            .from(Arrays.asList(ModuleDescriptorType.RESTX, ModuleDescriptorType.MAVEN))
             .filter(new Predicate<ModuleDescriptorType>() {
                 @Override
                 public boolean apply(ModuleDescriptorType mdType) {

--- a/restx-core-shell/src/main/resources/restx/core/shell/deps.man
+++ b/restx-core-shell/src/main/resources/restx/core/shell/deps.man
@@ -1,9 +1,9 @@
 ## deps install
 
-Resolve dependencies declared in current module descriptor (in order: either `md.restx.json` or `pom.xml`),
+Resolve dependencies declared in current module descriptor (in order: either `md.restx.json`, `pom.xml` or `module.ivy`),
 and synchronize them in `target/dependency` directory.
 
-For `md.restx.json` `module.ivy`, this command uses Apache Ivy under the hood to perform dependency resolution,
+For both `md.restx.json` and `module.ivy`, this command uses Apache Ivy under the hood to perform dependency resolution,
 using settings provided by restx. You can override these Ivy settings by placing a file named ivysettings.xml in your
 restx shell install location (usually `~/.restx`).
 

--- a/restx-core-shell/src/main/resources/restx/core/shell/deps.man
+++ b/restx-core-shell/src/main/resources/restx/core/shell/deps.man
@@ -1,11 +1,13 @@
 ## deps install
 
-Resolve the dependencies declared in the file `md.restx.json`, and synchronize them in `target/dependency` directory.
+Resolve dependencies declared in current module descriptor (in order: either `md.restx.json` or `pom.xml`),
+and synchronize them in `target/dependency` directory.
 
-This command uses Apache Ivy under the hood to perform dependency resolution, using settings provided by restx.
+For `md.restx.json` `module.ivy`, this command uses Apache Ivy under the hood to perform dependency resolution,
+using settings provided by restx. You can override these Ivy settings by placing a file named ivysettings.xml in your
+restx shell install location (usually `~/.restx`).
 
-You can override these Ivy settings by placing a file named ivysettings.xml in your restx shell install location
-(usually `~/.restx`).
+For `pom.xml`, this command will use maven-dependency-plugin:copy-dependencies goal to perform dependency resolution.
 
 Note: You need to be placed in a restx app root directory to run this command.
 

--- a/restx-core-shell/src/test/java/restx/core/shell/NewAppTest.java
+++ b/restx-core-shell/src/test/java/restx/core/shell/NewAppTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 
@@ -52,8 +53,11 @@ public class NewAppTest {
     @Parameterized.Parameters(name="{0}")
     public static Iterable<Object[]> data() throws IOException {
         return Arrays.asList(
-            new Object[]{ "Simplest app", createDescriptor("test1", false) },
-            new Object[]{ "App with hello resource", createDescriptor("test2", true) }
+            new Object[]{ "Simplest app", createDescriptor("test1", false, Arrays.asList(ModuleDescriptorType.values())) },
+            new Object[]{ "App with hello resource + all descriptors", createDescriptor("test2", true, Arrays.asList(ModuleDescriptorType.values())) },
+            new Object[]{ "App with hello resource + maven descriptor only", createDescriptor("test3", true, Arrays.asList(ModuleDescriptorType.MAVEN)) }
+            // Disabled because executing maven goals won't work with ivy-only file
+            // new Object[]{ "App with hello resource + ivy descriptor only", createDescriptor("test4", true, Arrays.asList(ModuleDescriptorType.IVY)) }
         );
     }
 
@@ -101,7 +105,7 @@ public class NewAppTest {
         return shell;
     }
 
-    private static AppShellCommand.NewAppDescriptor createDescriptor(String name, boolean generateHelloResource) throws IOException {
+    private static AppShellCommand.NewAppDescriptor createDescriptor(String name, boolean generateHelloResource, List<ModuleDescriptorType> buildFiles) throws IOException {
         AppShellCommand.NewAppDescriptor desc = new AppShellCommand.NewAppDescriptor();
         desc.appName = name+"App";
         desc.groupId = "com.foo";
@@ -109,7 +113,7 @@ public class NewAppTest {
         desc.targetPath = name;
         desc.mainPackage = "com.foo";
         desc.version = "0.1-SNAPSHOT";
-        desc.buildFile = "all";
+        desc.buildFiles = buildFiles;
         desc.signatureKey = "blah blah blah";
         desc.adminPassword = "pwd";
         desc.defaultPort = "8080";

--- a/restx-specs-shell/src/main/java/restx/specs/shell/SpecsShellCommand.java
+++ b/restx-specs-shell/src/main/java/restx/specs/shell/SpecsShellCommand.java
@@ -104,7 +104,7 @@ public class SpecsShellCommand extends StdShellCommand {
 
             if (!DepsShellCommand.depsUpToDate(shell)) {
                 shell.println("restx> deps install");
-                new DepsShellCommand().new InstallDepsCommandRunner().run(shell);
+                new DepsShellCommand.InstallDepsCommandRunner().run(shell);
             }
 
             new ShellAppRunner(appSettings, "restx.tests.RestxSpecTestServer",


### PR DESCRIPTION
... and not exclusively with `md.restx.json` module descriptor.

As proposed in #250, I added more options during `restx app new` to generate `md.restx.json` file only, or `pom.xml` only, or `module.ivy` only.

This fixes #250