### PR TITLE
shell - replaced hash' md5+bcrypt and sha1+bcrypt by md5#bcrypt and sha1#bcrypt

### DIFF
--- a/restx-core-shell/src/main/java/restx/core/shell/HashShellCommand.java
+++ b/restx-core-shell/src/main/java/restx/core/shell/HashShellCommand.java
@@ -61,7 +61,7 @@ public class HashShellCommand extends StdShellCommand {
     public Iterable<Completer> getCompleters() {
         return ImmutableList.<Completer>of(new ArgumentCompleter(
                 new StringsCompleter("hash"),
-                new StringsCompleter("md5", "sha1", "bcrypt", "md5+bcrypt", "sha1+bcrypt")));
+                new StringsCompleter("md5", "sha1", "bcrypt", "md5#bcrypt", "sha1#bcrypt")));
     }
 
     private class HashCommandRunner implements ShellCommandRunner {
@@ -85,10 +85,10 @@ public class HashShellCommand extends StdShellCommand {
                 case "bcrypt":
                     shell.println(BCrypt.hashpw(plaintext, BCrypt.gensalt()));
                     break;
-                case "md5+bcrypt":
+                case "md5#bcrypt":
                     shell.println(BCrypt.hashpw(Hashing.md5().hashString(plaintext, Charsets.UTF_8).toString(), BCrypt.gensalt()));
                     break;
-                case "sha1+bcrypt":
+                case "sha1#bcrypt":
                     shell.println(BCrypt.hashpw(Hashing.sha1().hashString(plaintext, Charsets.UTF_8).toString(), BCrypt.gensalt()));
                     break;
                 default:

--- a/restx-core-shell/src/main/resources/restx/core/shell/hash.man
+++ b/restx-core-shell/src/main/resources/restx/core/shell/hash.man
@@ -10,10 +10,10 @@ Computes the sha1 of given plain text string
 
 bcrypt given plain text string
 
-## hash md5+bcrypt <plaintext>
+## hash md5#bcrypt <plaintext>
 
 Hash with md5, and then bcrypt the given plain text password
 
-## hash sha1+bcrypt <plaintext>
+## hash sha1#bcrypt <plaintext>
 
 Hash with sha1, and then bcrypt the given plain text password

--- a/restx-core-shell/src/main/resources/templates/srv/main/data/credentials.json
+++ b/restx-core-shell/src/main/resources/templates/srv/main/data/credentials.json
@@ -1,7 +1,7 @@
 {
     "//": "lines with // keys are just comments (we don't have real comments in json)",
-    "//": "this file stores password passed through md5+bcrypt hash",
-    "//": "you can use `restx hash md5+bcrypt {password}` shell command to get hashed passwords to put here",
+    "//": "this file stores password passed through md5#bcrypt hash",
+    "//": "you can use `restx hash md5#bcrypt {password}` shell command to get hashed passwords to put here",
 
     "//": "to help startup with restx, there are comments with clear text passwords,",
     "//": "which should obviously not be stored here.",


### PR DESCRIPTION
As it doesn't work anymore since the existence of + operator in shell.

This fixes #199