### PR TITLE
Storing parsed representation of module descriptor

### DIFF
--- a/restx-apidocs-doclet/module.ivy
+++ b/restx-apidocs-doclet/module.ivy
@@ -15,10 +15,10 @@
     </publications>
     <dependencies>
         <dependency org="com.sun.tools" name="tools" rev="1.7" conf="system->default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.3.3" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.3.3" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.3.3" conf="default" />
-        <dependency org="com.google.guava" name="guava" rev="17.0" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
+        <dependency org="com.google.guava" name="guava" rev="18.0" conf="default" />
         <dependency org="joda-time" name="joda-time" rev="2.3" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />
         <dependency org="org.assertj" name="assertj-core" rev="1.6.0" conf="test->default" />

--- a/restx-apidocs/module.ivy
+++ b/restx-apidocs/module.ivy
@@ -18,7 +18,7 @@
         <dependency org="io.restx" name="restx-core" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-core-annotation-processor" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-admin" rev="latest.integration" conf="default" />
-        <dependency org="com.fasterxml.jackson.module" name="jackson-module-jsonSchema" rev="2.3.3" conf="default" />
+        <dependency org="com.fasterxml.jackson.module" name="jackson-module-jsonSchema" rev="2.8.10" conf="default" />
         <dependency org="io.restx" name="restx-webjars" rev="latest.integration" conf="default" />
     </dependencies>
 </ivy-module>

--- a/restx-build-shell/md.restx.json
+++ b/restx-build-shell/md.restx.json
@@ -6,11 +6,23 @@
         "@files": ["../restx.build.properties.json"]
     },
 
+    "fragments": {
+        "maven": [
+            "classpath:///restx/build/fragments/maven/testing-build-shell.xml"
+        ]
+    },
+
     "dependencies": {
         "compile": [
             "io.restx:restx-factory:${restx.version}",
             "io.restx:restx-shell:${restx.version}",
             "io.restx:restx-build:${restx.version}"
+        ],
+        "test": [
+            "junit:junit:4.11",
+            "com.googlecode.junit-toolbox:junit-toolbox:2.3",
+            "org.assertj:assertj-core:1.6.0",
+            "org.apache.maven.shared:maven-verifier:${maven-verifier.version}"
         ]
     }
 }

--- a/restx-build-shell/module.ivy
+++ b/restx-build-shell/module.ivy
@@ -17,5 +17,9 @@
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-shell" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-build" rev="latest.integration" conf="default" />
+        <dependency org="junit" name="junit" rev="4.11" conf="test->default" />
+        <dependency org="com.googlecode.junit-toolbox" name="junit-toolbox" rev="2.3" conf="test->default" />
+        <dependency org="org.assertj" name="assertj-core" rev="1.6.0" conf="test->default" />
+        <dependency org="org.apache.maven.shared" name="maven-verifier" rev="1.4" conf="test->default" />
     </dependencies>
 </ivy-module>

--- a/restx-build-shell/pom.xml
+++ b/restx-build-shell/pom.xml
@@ -13,6 +13,21 @@
     <artifactId>restx-build-shell</artifactId>
     <name>restx-build-shell</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <restxSourcesRootDir>${project.basedir}/../</restxSourcesRootDir>
+                        <maxParallelTestThreads>10</maxParallelTestThreads>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>io.restx</groupId>
@@ -25,6 +40,28 @@
         <dependency>
             <groupId>io.restx</groupId>
             <artifactId>restx-build</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- For parallel Parameterized tests execution -->
+            <groupId>com.googlecode.junit-toolbox</groupId>
+            <artifactId>junit-toolbox</artifactId>
+            <version>2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-verifier</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/restx-build-shell/src/test/java/restx/build/shell/RestxModuleDescriptorsDiscrepanciesDetectorWithPomAndIvyTest.java
+++ b/restx-build-shell/src/test/java/restx/build/shell/RestxModuleDescriptorsDiscrepanciesDetectorWithPomAndIvyTest.java
@@ -1,0 +1,195 @@
+package restx.build.shell;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.io.LineProcessor;
+import com.googlecode.junittoolbox.ParallelParameterized;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import restx.build.*;
+import restx.common.OSUtils;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(ParallelParameterized.class)
+public class RestxModuleDescriptorsDiscrepanciesDetectorWithPomAndIvyTest {
+
+    private enum GenerationType {
+        IVY("module.ivy") {
+            @Override
+            public RestxBuild.Generator generator() {
+                return new IvySupport();
+            }
+
+        }, POM("pom.xml") {
+            @Override
+            public RestxBuild.Generator generator() {
+                return new MavenSupport();
+            }
+
+            class RunMavenEffectivePom implements Runnable {
+                File targetPom;
+                File effectivePom;
+
+                public RunMavenEffectivePom(File targetPom, File effectivePom) {
+                    this.targetPom = targetPom;
+                    this.effectivePom = effectivePom;
+                }
+
+                @Override
+                public void run() {
+
+                    try {
+                        Verifier mavenVerifier = new Verifier(targetPom.getParentFile().getAbsolutePath());
+
+                        if (OSUtils.isMacOSX()) {
+                            // on MacOSX, when using the verifier JAVA_HOME is not always properly detected
+                            // sometimes it points to JRE, making javadoc call fail.
+                            // Here is a workaround for that problem
+                            String javaHome = System.getProperty("java.home");
+                            if (javaHome.endsWith("jre")) {
+                                javaHome = new File(javaHome).getParentFile().getCanonicalPath();
+                                mavenVerifier.setEnvironmentVariable("JAVA_HOME", javaHome);
+                            }
+                        }
+                        if(System.getProperty("skip-offline") == null) {
+                            mavenVerifier.addCliOption("--offline");
+                        }
+                        mavenVerifier.addCliOption("-f "+targetPom.getAbsolutePath());
+                        mavenVerifier.addCliOption("--no-snapshot-updates");
+                        mavenVerifier.setSystemProperty("output", effectivePom.getAbsolutePath());
+                        mavenVerifier.setAutoclean(false);
+                        String logFileName = "___log.txt";
+                        File logFile = targetPom.getParentFile().toPath().resolve(logFileName).toFile();
+                        mavenVerifier.setLogFileName(logFileName);
+                        mavenVerifier.executeGoal("org.apache.maven.plugins:maven-help-plugin:2.2:effective-pom");
+                        mavenVerifier.verifyErrorFreeLog();
+
+                        assertTrue(logFile.delete());
+                        removeGeneratedLineIn(effectivePom);
+                    } catch (VerificationException | IOException e) {
+                        throw Throwables.propagate(e);
+                    }
+
+                    System.out.println("Over");
+                }
+            }
+
+            @Override
+            public void assertExistingAndGeneratedDescriptorsAreSimilar(File existingDescriptor, File generatedDescriptor, TemporaryFolder tempFolder) throws IOException {
+                File existingEffectivePom = tempFolder.newFile("existingEffectivePom");
+                File generatedEffectivePom = tempFolder.newFile("generatedEffectivePom");
+
+                // I tried to execute those tasks through a fixedThreadPool(2) executor but ... doesn't detect some testing failures
+                // (for unknown reasons)
+                new RunMavenEffectivePom(existingDescriptor, existingEffectivePom).run();
+                new RunMavenEffectivePom(generatedDescriptor, generatedEffectivePom).run();
+
+                super.assertExistingAndGeneratedDescriptorsAreSimilar(existingEffectivePom, generatedEffectivePom, tempFolder);
+            }
+
+            private void removeGeneratedLineIn(File file) throws IOException {
+                List<String> trimmedLines = com.google.common.io.Files.readLines(file, Charsets.UTF_8, new LineProcessor<List<String>>() {
+                    List<String> result = Lists.newArrayList();
+
+                    @Override
+                    public boolean processLine(String line) throws IOException {
+                        if(!line.contains("Generated by Maven Help Plugin on")) {
+                            result.add(line);
+                        }
+                        return true;
+                    }
+
+                    @Override
+                    public List<String> getResult() {
+                        return result;
+                    }
+                });
+
+                Files.write(file.toPath(), trimmedLines, Charsets.UTF_8, StandardOpenOption.CREATE);
+            }
+        };
+
+        private String filename;
+        GenerationType(String filename) {
+            this.filename = filename;
+        }
+
+        public abstract RestxBuild.Generator generator();
+        public void assertExistingAndGeneratedDescriptorsAreSimilar(File existingDescriptor, File generatedDescriptor, TemporaryFolder tempFolder) throws IOException {
+            assertEquals(com.google.common.io.Files.toString(existingDescriptor, Charsets.UTF_8),
+                    com.google.common.io.Files.toString(generatedDescriptor, Charsets.UTF_8));
+        }
+    }
+
+    private final String moduleName;
+    private final GenerationType generationType;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Parameterized.Parameters(name="{0}/{1}")
+    public static Iterable<Object[]> data(){
+        Path restxSourcesRootDir = getRestxSourcesRootDir();
+        String[] directories = restxSourcesRootDir.toFile().list(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return new File(dir, name).isDirectory();
+            }
+        });
+
+        List<Object[]> testingData = new ArrayList<>();
+        for(String moduleName: directories) {
+            if(Files.exists(restxSourcesRootDir.resolve(moduleName).resolve("md.restx.json"))) {
+                for(GenerationType generationType: GenerationType.values()) {
+                    if(Files.exists(restxSourcesRootDir.resolve(moduleName).resolve(generationType.filename))) {
+                        testingData.add(new Object[]{ moduleName, generationType });
+                    }
+                }
+            }
+        }
+
+        return testingData;
+    }
+
+    private static Path getRestxSourcesRootDir() {
+        return Paths.get(System.getProperty("restxSourcesRootDir"));
+    }
+
+    public RestxModuleDescriptorsDiscrepanciesDetectorWithPomAndIvyTest(String moduleName, GenerationType generationType) {
+        this.moduleName = moduleName;
+        this.generationType = generationType;
+    }
+
+    @Test
+    public void should_restx_module_descriptor_and_pom_or_ivy_descriptors_equivalents() throws IOException {
+        Path restxSourcesRootDir = getRestxSourcesRootDir();
+        Path moduleDirectory = restxSourcesRootDir.resolve(this.moduleName);
+        File existingDescriptor = moduleDirectory.resolve(this.generationType.filename).toFile();
+
+        ModuleDescriptor moduleDescriptor = new RestxJsonSupport().parse(moduleDirectory.resolve("md.restx.json"));
+        // Generating the generated descriptor into the same directory than existingDescriptor, in case we would have file-tree
+        // related stuff into the descriptor (particularly for maven)
+        File generatedDescriptor = existingDescriptor.getParentFile().toPath().resolve("generated-"+this.generationType.name()+"-descriptor").toFile();
+        assertTrue(generatedDescriptor.createNewFile());
+        generatedDescriptor.deleteOnExit();
+
+        try (Writer w = com.google.common.io.Files.newWriter(generatedDescriptor, Charsets.UTF_8)) {
+            this.generationType.generator().generate(moduleDescriptor, w);
+        }
+
+        this.generationType.assertExistingAndGeneratedDescriptorsAreSimilar(existingDescriptor, generatedDescriptor, tempFolder);
+    }
+}

--- a/restx-build/src/main/java/restx/build/MavenSupport.java
+++ b/restx-build/src/main/java/restx/build/MavenSupport.java
@@ -69,7 +69,7 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
             }
 
             return new ModuleDescriptor(parent, gav, packaging,
-                    properties, Collections.<String>emptyList(), new HashMap<String,List<ModuleFragment>>(), dependencies);
+                    properties, Collections.<String>emptyList(), new HashMap<String,List<ModuleFragment>>(), dependencies, null);
         }
 
         private GAV getGav(JSONObject jsonObject, String typeKey, GAV parentGAV) {
@@ -117,7 +117,7 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
 
             w.write("    <dependencies>\n");
             for (String scope : md.getDependencyScopes()) {
-                for (ModuleDependency dependency : md.getDependencies(scope)) {
+                for (ModuleDependency dependency : md.getParsedModuleDescriptor().getDependencies(scope)) {
                     w.write("        <dependency>\n");
                     toMavenGAV(dependency.getGav(), "            ", w);
                     if (!"compile".equals(scope)) {
@@ -160,7 +160,7 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
 
         private boolean isVersionPropertyUsed(ModuleDescriptor md, String property) {
             for (String scope : md.getDependencyScopes()) {
-                for (ModuleDependency dependency : md.getDependencies(scope)) {
+                for (ModuleDependency dependency : md.getParsedModuleDescriptor().getDependencies(scope)) {
                     if (dependency.getGav().getVersion().indexOf("${" + property + "}") != -1) {
                         return true;
                     }

--- a/restx-build/src/main/java/restx/build/MavenSupport.java
+++ b/restx-build/src/main/java/restx/build/MavenSupport.java
@@ -69,7 +69,7 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
             }
 
             return new ModuleDescriptor(parent, gav, packaging,
-                    properties, new HashMap<String,List<ModuleFragment>>(), dependencies);
+                    properties, Collections.<String>emptyList(), new HashMap<String,List<ModuleFragment>>(), dependencies);
         }
 
         private GAV getGav(JSONObject jsonObject, String typeKey, GAV parentGAV) {

--- a/restx-build/src/main/java/restx/build/MavenSupport.java
+++ b/restx-build/src/main/java/restx/build/MavenSupport.java
@@ -36,16 +36,18 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
             String packaging = jsonObject.has("packaging") ? jsonObject.getString("packaging") : "jar";
 
             Map<String, String> properties = new LinkedHashMap<>();
+            Map<String, String> calculatedProperties = new LinkedHashMap<>();
             if (jsonObject.has("properties")) {
                 JSONObject props = jsonObject.getJSONObject("properties");
                 for (Object o : props.keySet()) {
                     String p = (String) o;
 
                     if (p.equals("maven.compiler.target") || p.equals("maven.compiler.source")) {
-                        properties.put("java.version", String.valueOf(props.get(p)));
+                        calculatedProperties.put("java.version", String.valueOf(props.get(p)));
                     } else {
-                        properties.put(p, String.valueOf(props.get(p)));
+                        calculatedProperties.put(p, String.valueOf(props.get(p)));
                     }
+                    properties.put(p, String.valueOf(props.get(p)));
                 }
             }
 
@@ -68,8 +70,11 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
                 }
             }
 
-            return new ModuleDescriptor(parent, gav, packaging,
+            ModuleDescriptor parsedMavenDescriptor = new ModuleDescriptor(parent, gav, packaging,
                     properties, Collections.<String>emptyList(), new HashMap<String,List<ModuleFragment>>(), dependencies, null);
+
+            return new ModuleDescriptor(parent, gav, packaging,
+                    calculatedProperties, Collections.<String>emptyList(), new HashMap<String,List<ModuleFragment>>(), dependencies, parsedMavenDescriptor);
         }
 
         private GAV getGav(JSONObject jsonObject, String typeKey, GAV parentGAV) {

--- a/restx-build/src/main/java/restx/build/MavenSupport.java
+++ b/restx-build/src/main/java/restx/build/MavenSupport.java
@@ -139,7 +139,7 @@ public class MavenSupport implements RestxBuild.Parser, RestxBuild.Generator {
             for (ModuleFragment fragment : md.getFragments("maven")) {
                 if (fragment.matches(PLUGIN_PATTERN)) {
                     fragment.write(md, plugins);
-                } else {
+                } else if(fragment.resolvedContent()) {
                     fragment.write(md, others);
                 }
             }

--- a/restx-build/src/main/java/restx/build/ModuleDescriptor.java
+++ b/restx-build/src/main/java/restx/build/ModuleDescriptor.java
@@ -15,12 +15,14 @@ public class ModuleDescriptor {
     private final List<String> propertiesFileReferences;
     private final Map<String, List<ModuleFragment>> fragments;
     private final Map<String, List<ModuleDependency>> dependencies;
+    private final ModuleDescriptor parsedModuleDescriptor;
 
     public ModuleDescriptor(GAV parent, GAV gav, String packaging,
                             Map<String, String> properties,
                             List<String> propertiesFileReferences,
                             Map<String, List<ModuleFragment>> fragments,
-                            Map<String, List<ModuleDependency>> dependencies) {
+                            Map<String, List<ModuleDependency>> dependencies,
+                            ModuleDescriptor parsedModuleDescriptor) {
         this.parent = parent;
         this.gav = gav;
         this.packaging = packaging;
@@ -28,6 +30,7 @@ public class ModuleDescriptor {
         this.fragments = Collections.unmodifiableMap(fragments);
         this.properties = Collections.unmodifiableMap(properties);
         this.dependencies = Collections.unmodifiableMap(dependencies);
+        this.parsedModuleDescriptor = parsedModuleDescriptor;
     }
 
     public GAV getParent() {
@@ -72,7 +75,7 @@ public class ModuleDescriptor {
         }
         newDeps.get(scope).add(dep);
 
-        return new ModuleDescriptor(parent, gav, packaging, properties, propertiesFileReferences, fragments, newDeps);
+        return new ModuleDescriptor(parent, gav, packaging, properties, propertiesFileReferences, fragments, newDeps, parsedModuleDescriptor);
     }
     
     public boolean hasClassifier() {
@@ -84,6 +87,10 @@ public class ModuleDescriptor {
             }
         }
         return false;
+    }
+
+    public ModuleDescriptor getParsedModuleDescriptor() {
+        return parsedModuleDescriptor==null?this:parsedModuleDescriptor;
     }
 
     public List<String> getPropertiesFileReferences() {

--- a/restx-build/src/main/java/restx/build/ModuleDescriptor.java
+++ b/restx-build/src/main/java/restx/build/ModuleDescriptor.java
@@ -51,6 +51,10 @@ public class ModuleDescriptor {
         return dependencies.get(scope);
     }
 
+    public Set<String> getFragmentTypes() {
+        return fragments.keySet();
+    }
+
     public List<ModuleFragment> getFragments(String s) {
         List<ModuleFragment> moduleFragments = fragments.get(s);
         return moduleFragments == null ? Collections.<ModuleFragment>emptyList() : moduleFragments;

--- a/restx-build/src/main/java/restx/build/ModuleDescriptor.java
+++ b/restx-build/src/main/java/restx/build/ModuleDescriptor.java
@@ -12,16 +12,19 @@ public class ModuleDescriptor {
     private final GAV gav;
     private final String packaging;
     private final Map<String,String> properties;
+    private final List<String> propertiesFileReferences;
     private final Map<String, List<ModuleFragment>> fragments;
     private final Map<String, List<ModuleDependency>> dependencies;
 
     public ModuleDescriptor(GAV parent, GAV gav, String packaging,
                             Map<String, String> properties,
+                            List<String> propertiesFileReferences,
                             Map<String, List<ModuleFragment>> fragments,
                             Map<String, List<ModuleDependency>> dependencies) {
         this.parent = parent;
         this.gav = gav;
         this.packaging = packaging;
+        this.propertiesFileReferences = propertiesFileReferences;
         this.fragments = Collections.unmodifiableMap(fragments);
         this.properties = Collections.unmodifiableMap(properties);
         this.dependencies = Collections.unmodifiableMap(dependencies);
@@ -69,7 +72,7 @@ public class ModuleDescriptor {
         }
         newDeps.get(scope).add(dep);
 
-        return new ModuleDescriptor(parent, gav, packaging, properties, fragments, newDeps);
+        return new ModuleDescriptor(parent, gav, packaging, properties, propertiesFileReferences, fragments, newDeps);
     }
     
     public boolean hasClassifier() {
@@ -81,5 +84,9 @@ public class ModuleDescriptor {
             }
         }
         return false;
+    }
+
+    public List<String> getPropertiesFileReferences() {
+        return propertiesFileReferences;
     }
 }

--- a/restx-build/src/main/java/restx/build/ModuleFragment.java
+++ b/restx-build/src/main/java/restx/build/ModuleFragment.java
@@ -1,7 +1,9 @@
 package restx.build;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Writer;
+import java.net.URL;
 import java.util.regex.Pattern;
 
 /**
@@ -10,17 +12,61 @@ import java.util.regex.Pattern;
  * Time: 12:32 PM
  */
 public class ModuleFragment {
-    private final String fragment;
+    private final String url;
+    private boolean lazyContentLoaded = false;
+    private String lazyContent = null;
 
-    public ModuleFragment(String fragment) {
-        this.fragment = fragment;
+    public ModuleFragment(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
     }
 
     public void write(ModuleDescriptor md, Writer w) throws IOException {
-        w.write(fragment);
+        String content = getLazilyContent();
+        if(content != null) {
+            w.write(content);
+        }
     }
 
-    public boolean matches(Pattern pattern) {
-        return pattern.matcher(fragment).matches();
+    public boolean resolvedContent() {
+        try {
+            String content = getLazilyContent();
+            return content != null;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    public boolean matches(Pattern pattern) throws IOException {
+        String content = getLazilyContent();
+        return pattern.matcher(content).matches();
+    }
+
+    public String getLazilyContent() throws IOException {
+        if(!lazyContentLoaded) {
+            try {
+                if (url.startsWith("classpath://")) {
+                    String fragmentPath = url.substring("classpath://".length());
+                    try(InputStream stream = getClass().getResourceAsStream(fragmentPath)) {
+                        if (stream == null) {
+                            throw new IllegalArgumentException("classpath fragment not found: '" + fragmentPath + "'" +
+                                    ". Check your classpath.");
+                        }
+                        lazyContent = RestxBuildHelper.toString(stream);
+                    }
+                } else {
+                    URL fragmentUrl = new URL(url);
+                    try (InputStream stream = fragmentUrl.openStream()) {
+                        lazyContent = RestxBuildHelper.toString(stream);
+                    }
+                }
+            } finally {
+                lazyContentLoaded = true;
+            }
+        }
+        return lazyContent;
     }
 }

--- a/restx-build/src/main/java/restx/build/RestxJsonSupport.java
+++ b/restx-build/src/main/java/restx/build/RestxJsonSupport.java
@@ -120,21 +120,7 @@ public class RestxJsonSupport implements RestxBuild.Parser, RestxBuild.Generator
                     JSONArray array = jsonFragments.getJSONArray(type);
                     for (int i = 0; i < array.length(); i++) {
                         String url = expandProperties(properties, array.getString(i));
-
-                        if (url.startsWith("classpath://")) {
-                            String fragmentPath = url.substring("classpath://".length());
-                            InputStream stream = getClass().getResourceAsStream(fragmentPath);
-                            if (stream == null) {
-                                throw new IllegalArgumentException("classpath fragment not found: '" + fragmentPath + "'" +
-                                        ". Check your classpath.");
-                            }
-                            fragmentsForType.add(new ModuleFragment(RestxBuildHelper.toString(stream)));
-                        } else {
-                            URL fragmentUrl = new URL(url);
-                            try (InputStream stream = fragmentUrl.openStream()) {
-                                fragmentsForType.add(new ModuleFragment(RestxBuildHelper.toString(stream)));
-                            }
-                        }
+                        fragmentsForType.add(new ModuleFragment(url));
                     }
 
                     fragments.put(type, fragmentsForType);

--- a/restx-build/src/main/java/restx/build/RestxJsonSupport.java
+++ b/restx-build/src/main/java/restx/build/RestxJsonSupport.java
@@ -44,6 +44,26 @@ public class RestxJsonSupport implements RestxBuild.Parser, RestxBuild.Generator
             }
             w.write("    },\n\n");
 
+            if(!md.getFragmentTypes().isEmpty()) {
+                w.write("    \"fragments\": {\n");
+                for (Iterator<String> itFragmentType = md.getFragmentTypes().iterator(); itFragmentType.hasNext(); ) {
+                    String fragmentType = itFragmentType.next();
+                    w.write(String.format("      \"%s\": [\n", fragmentType));
+                    for (Iterator<ModuleFragment> itFragment = md.getFragments(fragmentType).iterator(); itFragment.hasNext(); ) {
+                        w.write(String.format("        \"%s\"", itFragment.next().getUrl()));
+                        if(itFragment.hasNext()) {
+                            w.write(",");
+                        }
+                        w.write("\n");
+                    }
+                    w.write("      ]");
+                    if(itFragmentType.hasNext()) {
+                        w.write(",");
+                    }
+                    w.write("\n");
+                }
+                w.write("    },\n\n");
+            }
 
             w.write("    \"dependencies\": {\n");
             Set<String> scopes = md.getDependencyScopes();

--- a/restx-build/src/main/resources/restx/build/fragments/maven/java-agent.xml
+++ b/restx-build/src/main/resources/restx/build/fragments/maven/java-agent.xml
@@ -1,5 +1,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/restx-build/src/main/resources/restx/build/fragments/maven/testing-build-shell.xml
+++ b/restx-build/src/main/resources/restx/build/fragments/maven/testing-build-shell.xml
@@ -1,0 +1,10 @@
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <restxSourcesRootDir>${project.basedir}/../</restxSourcesRootDir>
+                        <maxParallelTestThreads>10</maxParallelTestThreads>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>

--- a/restx-classloader/module.ivy
+++ b/restx-classloader/module.ivy
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency org="io.restx" name="restx-common" rev="latest.integration" conf="default" />
         <dependency org="javax.inject" name="javax.inject" rev="1" conf="default" />
-        <dependency org="com.google.guava" name="guava" rev="17.0" conf="default" />
+        <dependency org="com.google.guava" name="guava" rev="18.0" conf="default" />
         <dependency org="joda-time" name="joda-time" rev="2.3" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />

--- a/restx-common/module.ivy
+++ b/restx-common/module.ivy
@@ -14,7 +14,7 @@
         <artifact type="jar"/>
     </publications>
     <dependencies>
-        <dependency org="com.google.guava" name="guava" rev="17.0" conf="default" />
+        <dependency org="com.google.guava" name="guava" rev="18.0" conf="default" />
         <dependency org="joda-time" name="joda-time" rev="2.3" conf="default" />
         <dependency org="org.reflections" name="reflections" rev="0.9.9-RC1" conf="default" />
         <dependency org="com.samskivert" name="jmustache" rev="1.8" conf="default" />

--- a/restx-core-java8/module.ivy
+++ b/restx-core-java8/module.ivy
@@ -15,6 +15,6 @@
     </publications>
     <dependencies>
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
-        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-jsr310" rev="2.3.3" conf="default" />
+        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-jsr310" rev="2.8.10" conf="default" />
     </dependencies>
 </ivy-module>

--- a/restx-core-shell/src/main/java/restx/core/shell/DepsShellCommand.java
+++ b/restx-core-shell/src/main/java/restx/core/shell/DepsShellCommand.java
@@ -239,7 +239,7 @@ public class DepsShellCommand extends StdShellCommand {
 
             ModuleDescriptor descriptor;
             try (FileInputStream is = new FileInputStream(mdFile)) {
-                descriptor = new RestxJsonSupport().parse(is);
+                descriptor = new RestxJsonSupport().parse(is).getParsedModuleDescriptor();
 
                 for (String s : pluginIds.get()) {
                     descriptor = descriptor.concatDependency(scope, new ModuleDependency(GAV.parse(s)));

--- a/restx-core/module.ivy
+++ b/restx-core/module.ivy
@@ -14,16 +14,16 @@
         <artifact type="jar"/>
     </publications>
     <dependencies>
-        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.3.3" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.3.3" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.3.3" conf="default" />
-        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.3.3" conf="default" />
-        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-guava" rev="2.3.3" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-guava" rev="2.8.10" conf="default" />
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-classloader" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-apidocs-doclet" rev="latest.integration" conf="default" />
         <dependency org="javax.inject" name="javax.inject" rev="1" conf="default" />
-        <dependency org="com.google.guava" name="guava" rev="17.0" conf="default" />
+        <dependency org="com.google.guava" name="guava" rev="18.0" conf="default" />
         <dependency org="joda-time" name="joda-time" rev="2.3" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />
         <dependency org="javax.validation" name="validation-api" rev="1.1.0.Final" conf="default" />

--- a/restx-factory/module.ivy
+++ b/restx-factory/module.ivy
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency org="io.restx" name="restx-common" rev="latest.integration" conf="default" />
         <dependency org="javax.inject" name="javax.inject" rev="1" conf="default" />
-        <dependency org="com.google.guava" name="guava" rev="17.0" conf="default" />
+        <dependency org="com.google.guava" name="guava" rev="18.0" conf="default" />
         <dependency org="joda-time" name="joda-time" rev="2.3" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />
         <dependency org="org.reflections" name="reflections" rev="0.9.9-RC1" conf="default" />

--- a/restx-jongo/module.ivy
+++ b/restx-jongo/module.ivy
@@ -18,13 +18,13 @@
         <dependency org="io.restx" name="restx-core" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-core-annotation-processor" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-security-basic" rev="latest.integration" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.3.3" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.3.3" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.3.3" conf="default" />
-        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.3.3" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
         <dependency org="de.undercouch" name="bson4jackson" rev="2.3.1" conf="default" />
         <dependency org="org.mongodb" name="mongo-java-driver" rev="2.11.3" conf="default" />
-        <dependency org="org.jongo" name="jongo" rev="1.0" conf="default" />
+        <dependency org="org.jongo" name="jongo" rev="1.3.0" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />
         <dependency org="org.assertj" name="assertj-core" rev="1.6.0" conf="test->default" />

--- a/restx-samplest/md.restx.json
+++ b/restx-samplest/md.restx.json
@@ -23,7 +23,7 @@
             "io.restx:restx-monitor-codahale:${restx.version}",
             "io.restx:restx-monitor-admin:${restx.version}",
             "io.restx:restx-servlet:${restx.version}",
-            "io.restx:restx-server-simple:${restx.version}",
+            "io.restx:restx-server-jetty8:${restx.version}!optional",
             "io.restx:restx-apidocs:${restx.version}",
             "io.restx:restx-specs-admin:${restx.version}",
             "io.restx:restx-i18n-admin:${restx.version}",

--- a/restx-samplest/module.ivy
+++ b/restx-samplest/module.ivy
@@ -22,7 +22,7 @@
         <dependency org="io.restx" name="restx-monitor-codahale" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-monitor-admin" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-servlet" rev="latest.integration" conf="default" />
-        <dependency org="io.restx" name="restx-server-simple" rev="latest.integration" conf="default" />
+        <dependency org="io.restx" name="restx-server-jetty8" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-apidocs" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-specs-admin" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-i18n-admin" rev="latest.integration" conf="default" />

--- a/restx-server-jetty7/md.restx.json
+++ b/restx-server-jetty7/md.restx.json
@@ -10,7 +10,6 @@
         "compile": [
             "io.restx:restx-factory:${restx.version}",
             "io.restx:restx-core:${restx.version}",
-            "javax.servlet:servlet-api:2.5",
             "io.restx:restx-servlet:${restx.version}",
             "org.eclipse.jetty:jetty-server:${jetty7.version}",
             "org.eclipse.jetty:jetty-servlet:${jetty7.version}",
@@ -18,6 +17,9 @@
             "org.eclipse.jetty:jetty-util:${jetty7.version}",
             "org.eclipse.jetty:jetty-webapp:${jetty7.version}",
             "org.eclipse.jetty:jetty-servlets:${jetty7.version}"
+        ],
+        "provided": [
+            "javax.servlet:servlet-api:2.5"
         ]
     }
 }

--- a/restx-server-jetty7/module.ivy
+++ b/restx-server-jetty7/module.ivy
@@ -16,7 +16,6 @@
     <dependencies>
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-core" rev="latest.integration" conf="default" />
-        <dependency org="javax.servlet" name="servlet-api" rev="2.5" conf="default" />
         <dependency org="io.restx" name="restx-servlet" rev="latest.integration" conf="default" />
         <dependency org="org.eclipse.jetty" name="jetty-server" rev="7.6.21.v20160908" conf="default" />
         <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="7.6.21.v20160908" conf="default" />
@@ -24,5 +23,6 @@
         <dependency org="org.eclipse.jetty" name="jetty-util" rev="7.6.21.v20160908" conf="default" />
         <dependency org="org.eclipse.jetty" name="jetty-webapp" rev="7.6.21.v20160908" conf="default" />
         <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="7.6.21.v20160908" conf="default" />
+        <dependency org="javax.servlet" name="servlet-api" rev="2.5" conf="provided->default" />
     </dependencies>
 </ivy-module>

--- a/restx-server-jetty7/pom.xml
+++ b/restx-server-jetty7/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <jetty7.version>7.6.21.v20160908</jetty7.version>
-        <servlet-api.version>2.5</servlet-api.version>
     </properties>
 
     <dependencies>
@@ -30,12 +29,6 @@
         <dependency>
             <groupId>io.restx</groupId>
             <artifactId>restx-servlet</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Jetty -->
@@ -68,6 +61,12 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
             <version>${jetty7.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/restx-server-jetty8/md.restx.json
+++ b/restx-server-jetty8/md.restx.json
@@ -10,7 +10,6 @@
         "compile": [
             "io.restx:restx-factory:${restx.version}",
             "io.restx:restx-core:${restx.version}",
-            "javax.servlet:javax.servlet-api:3.0.1",
             "io.restx:restx-servlet:${restx.version}",
             "org.eclipse.jetty:jetty-server:${jetty8.version}",
             "org.eclipse.jetty:jetty-servlet:${jetty8.version}",
@@ -18,6 +17,9 @@
             "org.eclipse.jetty:jetty-util:${jetty8.version}",
             "org.eclipse.jetty:jetty-webapp:${jetty8.version}",
             "org.eclipse.jetty:jetty-servlets:${jetty8.version}"
+        ],
+        "provided": [
+            "javax.servlet:javax.servlet-api:3.0.1"
         ]
     }
 }

--- a/restx-server-jetty8/module.ivy
+++ b/restx-server-jetty8/module.ivy
@@ -16,7 +16,6 @@
     <dependencies>
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-core" rev="latest.integration" conf="default" />
-        <dependency org="javax.servlet" name="javax.servlet-api" rev="3.0.1" conf="default" />
         <dependency org="io.restx" name="restx-servlet" rev="latest.integration" conf="default" />
         <dependency org="org.eclipse.jetty" name="jetty-server" rev="8.1.8.v20121106" conf="default" />
         <dependency org="org.eclipse.jetty" name="jetty-servlet" rev="8.1.8.v20121106" conf="default" />
@@ -24,5 +23,6 @@
         <dependency org="org.eclipse.jetty" name="jetty-util" rev="8.1.8.v20121106" conf="default" />
         <dependency org="org.eclipse.jetty" name="jetty-webapp" rev="8.1.8.v20121106" conf="default" />
         <dependency org="org.eclipse.jetty" name="jetty-servlets" rev="8.1.8.v20121106" conf="default" />
+        <dependency org="javax.servlet" name="javax.servlet-api" rev="3.0.1" conf="provided->default" />
     </dependencies>
 </ivy-module>

--- a/restx-server-jetty8/pom.xml
+++ b/restx-server-jetty8/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <jetty8.version>8.1.8.v20121106</jetty8.version>
-        <servlet-api.version>3.0.1</servlet-api.version>
     </properties>
 
     <dependencies>
@@ -30,12 +29,6 @@
         <dependency>
             <groupId>io.restx</groupId>
             <artifactId>restx-servlet</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Jetty -->
@@ -68,6 +61,12 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
             <version>${jetty8.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/restx-server-tomcat/md.restx.json
+++ b/restx-server-tomcat/md.restx.json
@@ -10,10 +10,12 @@
         "compile": [
             "io.restx:restx-factory:${restx.version}",
             "io.restx:restx-core:${restx.version}",
-            "javax.servlet:javax.servlet-api:3.0.1",
             "org.apache.tomcat:tomcat-catalina:${embedded.tomcat.version}",
             "org.apache.tomcat.embed:tomcat-embed-core:${embedded.tomcat.version}",
             "org.apache.tomcat:tomcat-jasper:${embedded.tomcat.version}"
+        ],
+        "provided": [
+            "javax.servlet:javax.servlet-api:3.0.1"
         ]
     }
 }

--- a/restx-server-tomcat/module.ivy
+++ b/restx-server-tomcat/module.ivy
@@ -16,9 +16,9 @@
     <dependencies>
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-core" rev="latest.integration" conf="default" />
-        <dependency org="javax.servlet" name="javax.servlet-api" rev="3.0.1" conf="default" />
         <dependency org="org.apache.tomcat" name="tomcat-catalina" rev="7.0.47" conf="default" />
         <dependency org="org.apache.tomcat.embed" name="tomcat-embed-core" rev="7.0.47" conf="default" />
         <dependency org="org.apache.tomcat" name="tomcat-jasper" rev="7.0.47" conf="default" />
+        <dependency org="javax.servlet" name="javax.servlet-api" rev="3.0.1" conf="provided->default" />
     </dependencies>
 </ivy-module>

--- a/restx-server-tomcat/pom.xml
+++ b/restx-server-tomcat/pom.xml
@@ -14,7 +14,6 @@
     <name>restx-server-tomcat</name>
 
     <properties>
-        <servlet-api.version>3.0.1</servlet-api.version>
         <embedded.tomcat.version>7.0.47</embedded.tomcat.version>
     </properties>
 
@@ -26,12 +25,6 @@
         <dependency>
             <groupId>io.restx</groupId>
             <artifactId>restx-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Tomcat -->
@@ -49,6 +42,12 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper</artifactId>
             <version>${embedded.tomcat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/restx-shell-manager/module.ivy
+++ b/restx-shell-manager/module.ivy
@@ -15,7 +15,7 @@
     </publications>
     <dependencies>
         <dependency org="io.restx" name="restx-shell" rev="latest.integration" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.3.3" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
         <dependency org="org.apache.ivy" name="ivy" rev="2.3.0" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />
         <dependency org="org.assertj" name="assertj-core" rev="1.6.0" conf="test->default" />

--- a/restx-specs-server/pom.xml
+++ b/restx-specs-server/pom.xml
@@ -33,14 +33,17 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.kevinsawicki</groupId>
             <artifactId>http-request</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -5,10 +5,10 @@
     "slf4j-api.version": "1.7.5",
     "logback.version": "1.0.13",
 
-    "guava.version": "17.0",
+    "guava.version": "18.0",
     "joda-time.version": "2.3",
 
-    "jackson.version": "2.3.3",
+    "jackson.version": "2.8.10",
 
     "mustache.version": "1.8",
     "http-request.version": "5.5",
@@ -30,7 +30,7 @@
 
     "mongo-java-driver.version": "2.11.3",
     "bson4jackson.version": "2.3.1",
-    "jongo.version": "1.0",
+    "jongo.version": "1.3.0",
 
     "ivy.version": "2.3.0",
 


### PR DESCRIPTION
This parsed module descriptor (with no variables/files interpolations) will be used when writing module descriptor (particularly during 'deps add'), in order to change as few stuff as possible.

In the meantime, generating `fragments` (fixing #189) and `properties/@files` nodes when generating new `md.restx.json` file and introduced unit tests checking discrepancies between md.restx.json file and pom.xml/module.ivy descriptors (see #171)