### PR TITLE
Request headers management

### DIFF
--- a/restx-apidocs/src/main/resources/restx/apidocs/js/controllers/OperationController.js
+++ b/restx-apidocs/src/main/resources/restx/apidocs/js/controllers/OperationController.js
@@ -65,6 +65,16 @@ adminApp.controller('OperationController', function OperationController(
         return path;
     }
 
+    function bindHeaders() {
+        return _.chain($scope.operation.parameters)
+            .filter(function(p){ return p.paramType === 'header'; })
+            .reduce(function(headers, param) {
+                headers[param.name] = param.value;
+                return headers;
+            }, {})
+            .value();
+    }
+
     function bodyParamValue(value) {
         var bodyParam = _.find($scope.operation.parameters, function(p) { return p.paramType === 'body' });
         if (value) {
@@ -125,7 +135,7 @@ adminApp.controller('OperationController', function OperationController(
         return {
             httpMethod: $scope.operation.httpMethod,
             path: bindParams($scope.opApi.stdPath),
-            headers: {},
+            headers: bindHeaders(),
             body: bodyParamValue(),
             response: { status: '', body: '' }
         };

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -197,10 +197,18 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
         Set<String> pathParamNamesToMatch = Sets.newHashSet(resourceMethod.pathParamNames);
         for (VariableElement p : annotation.methodElem.getParameters()) {
             Param param = p.getAnnotation(Param.class);
+            HeaderParam reqHeaderAnn = p.getAnnotation(HeaderParam.class);
             String paramName = p.getSimpleName().toString();
-            String reqParamName = p.getSimpleName().toString();
             ResourceMethodParameterKind parameterKind = null;
-            if (param != null) {
+            String reqParamName;
+            if (param == null) {
+                if(reqHeaderAnn != null) {
+                    reqParamName = reqHeaderAnn.value().length() != 0?reqHeaderAnn.value():paramName;
+                    parameterKind = ResourceMethodParameterKind.HEADER;
+                } else {
+                    reqParamName = paramName;
+                }
+            } else {
                 reqParamName = param.value().length() == 0 ? paramName : param.value();
                 if (param.kind() != Param.Kind.DEFAULT) {
                     parameterKind = ResourceMethodParameterKind.valueOf(param.kind().name());

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -638,6 +638,14 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
                         .getParameterExpr();
             }
         },
+        HEADER(true) {
+            public String fetchFromReqCode(ResourceMethodParameter parameter, ResourceMethod method) {
+                return ParameterExpressionBuilder
+                        .createFromMapQueryObjectFromRequest(parameter, EndpointParameterKind.HEADER)
+                        .surroundWithCheckValid(parameter)
+                        .getParameterExpr();
+            }
+        },
         BODY(false) {
             public String fetchFromReqCode(ResourceMethodParameter parameter, ResourceMethod method) {
                 return ParameterExpressionBuilder

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -193,27 +193,49 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
         return combinatorialInterpolatedRoles;
     }
 
+    private Param createParam(final String value, final Param.Kind kind) {
+        return new Param() {
+            @Override
+            public Class<? extends Annotation> annotationType() { return Param.class; }
+            @Override
+            public String value() { return value; }
+            @Override
+            public Kind kind() { return kind; }
+        };
+    }
+
     private void buildResourceMethodParams(ResourceMethodAnnotation annotation, ResourceMethod resourceMethod) {
         Set<String> pathParamNamesToMatch = Sets.newHashSet(resourceMethod.pathParamNames);
         for (VariableElement p : annotation.methodElem.getParameters()) {
             Param param = p.getAnnotation(Param.class);
-            HeaderParam reqHeaderAnn = p.getAnnotation(HeaderParam.class);
-            String paramName = p.getSimpleName().toString();
+            String variableName = p.getSimpleName().toString();
             ResourceMethodParameterKind parameterKind = null;
             String reqParamName;
             if (param == null) {
-                if(reqHeaderAnn != null) {
-                    reqParamName = reqHeaderAnn.value().length() != 0?reqHeaderAnn.value():paramName;
-                    parameterKind = ResourceMethodParameterKind.HEADER;
-                } else {
-                    reqParamName = paramName;
+                final QueryParam queryParamAnn = p.getAnnotation(QueryParam.class);
+                final PathParam pathParamAnn = p.getAnnotation(PathParam.class);
+                final ContextParam contextParamAnn = p.getAnnotation(ContextParam.class);
+                final HeaderParam reqHeaderAnn = p.getAnnotation(HeaderParam.class);
+                if (queryParamAnn != null) {
+                    param = createParam(queryParamAnn.value(), Param.Kind.QUERY);
+                } else if (pathParamAnn != null) {
+                    param = createParam(pathParamAnn.value(), Param.Kind.PATH);
+                } else if (contextParamAnn != null) {
+                    param = createParam(contextParamAnn.value(), Param.Kind.CONTEXT);
+                } else if (reqHeaderAnn != null) {
+                    param = createParam(reqHeaderAnn.value(), Param.Kind.HEADER);
                 }
-            } else {
-                reqParamName = param.value().length() == 0 ? paramName : param.value();
+            }
+
+            if(param != null) {
+                reqParamName = param.value().length() == 0 ? variableName : param.value();
                 if (param.kind() != Param.Kind.DEFAULT) {
                     parameterKind = ResourceMethodParameterKind.valueOf(param.kind().name());
                 }
+            } else {
+                reqParamName = variableName;
             }
+
             if (pathParamNamesToMatch.contains(reqParamName)) {
                 if (parameterKind != null && parameterKind != ResourceMethodParameterKind.PATH) {
                     error(
@@ -240,7 +262,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
 
             resourceMethod.parameters.add(new ResourceMethodParameter(
                 p.asType().toString(),
-                paramName,
+                variableName,
                 reqParamName,
                 parameterKind,
                 validationGroups));

--- a/restx-core/src/main/java/restx/annotations/ContextParam.java
+++ b/restx-core/src/main/java/restx/annotations/ContextParam.java
@@ -1,0 +1,5 @@
+package restx.annotations;
+
+public @interface ContextParam {
+    String value() default "";
+}

--- a/restx-core/src/main/java/restx/annotations/HeaderParam.java
+++ b/restx-core/src/main/java/restx/annotations/HeaderParam.java
@@ -1,0 +1,5 @@
+package restx.annotations;
+
+public @interface HeaderParam {
+    String value() default "";
+}

--- a/restx-core/src/main/java/restx/annotations/Param.java
+++ b/restx-core/src/main/java/restx/annotations/Param.java
@@ -7,7 +7,7 @@ package restx.annotations;
  */
 public @interface Param {
     public static enum Kind {
-        PATH, QUERY, BODY, CONTEXT, DEFAULT
+        PATH, QUERY, BODY, CONTEXT, HEADER, DEFAULT
     }
 
     String value() default "";

--- a/restx-core/src/main/java/restx/annotations/PathParam.java
+++ b/restx-core/src/main/java/restx/annotations/PathParam.java
@@ -1,0 +1,5 @@
+package restx.annotations;
+
+public @interface PathParam {
+    String value() default "";
+}

--- a/restx-core/src/main/java/restx/annotations/QueryParam.java
+++ b/restx-core/src/main/java/restx/annotations/QueryParam.java
@@ -1,0 +1,5 @@
+package restx.annotations;
+
+public @interface QueryParam {
+    String value() default "";
+}

--- a/restx-core/src/main/java/restx/description/OperationParameterDescription.java
+++ b/restx-core/src/main/java/restx/description/OperationParameterDescription.java
@@ -7,7 +7,7 @@ package restx.description;
  */
 public class OperationParameterDescription {
     public static enum ParamType {
-        body, path, query
+        body, path, query, header
     }
 
     public ParamType paramType;

--- a/restx-core/src/main/java/restx/endpoint/EndpointParameterKind.java
+++ b/restx-core/src/main/java/restx/endpoint/EndpointParameterKind.java
@@ -37,6 +37,20 @@ public enum EndpointParameterKind {
                 }
             }).or(Collections.<String>emptyList());
         }
+    }, HEADER {
+        @Override
+        public Optional<String> extractQueryParamStringedValueFor(EndpointParamDef parameter, RestxRequest request, RestxRequestMatch match) {
+            return request.getHeader(parameter.getName());
+        }
+        @Override
+        public List<String> extractQueryParamStringedValuesFor(EndpointParamDef parameter, RestxRequest request, RestxRequestMatch match) {
+            return extractQueryParamStringedValueFor(parameter, request, match).transform(new Function<String, List<String>>() {
+                @Override
+                public List<String> apply(String headerParam) {
+                    return Lists.newArrayList(headerParam);
+                }
+            }).or(Collections.<String>emptyList());
+        }
     };
 
     public abstract Optional<String> extractQueryParamStringedValueFor(EndpointParamDef parameter, RestxRequest request, RestxRequestMatch match);

--- a/restx-samplest/src/main/java/samplest/core/ParametersResource.java
+++ b/restx-samplest/src/main/java/samplest/core/ParametersResource.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.ObjectArrays;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import restx.RestxRequest;
 import restx.annotations.*;
 import restx.factory.Component;
 import restx.security.PermitAll;
@@ -41,9 +42,9 @@ public class ParametersResource {
         }
     }
 
-    @GET("/params/path/{a}/:_b/{c:\\d+}:d")
-    public String pathparams(String a, String _b, String c, String d) {
-        return "a=" + a + " b=" + _b + " c=" + c + " d=" + d;
+    @GET("/params/path/{a}/:_b/{c:\\d+}:d/{e}")
+    public String pathparams(String a, String _b, @Param(kind=Param.Kind.PATH) String c, @Param(kind=Param.Kind.PATH, value="d") String _d, @PathParam String e) {
+        return "a=" + a + " b=" + _b + " c=" + c + " d=" + _d + " e=" + e;
     }
 
     @GET("/params/query/withOptionalString")
@@ -129,5 +130,10 @@ public class ParametersResource {
     @GET("/params/headers")
     public String headerParams(@Param(value = "X-A", kind = Param.Kind.HEADER) String a, @HeaderParam("X-B") Optional<DateTime> b, @HeaderParam Optional<String> Date) {
         return "a=" + a + " b=" + b.orNull() + " date=" + String.valueOf(Date.orNull());
+    }
+
+    @GET("/params/usingAnnotations/{path}")
+    public String paramsUsingAnnotations(@PathParam String path, @QueryParam String query, @ContextParam("request") RestxRequest request) {
+        return "path="+path+" query="+query+" contentType="+request.getContentType();
     }
 }

--- a/restx-samplest/src/main/java/samplest/core/ParametersResource.java
+++ b/restx-samplest/src/main/java/samplest/core/ParametersResource.java
@@ -2,21 +2,16 @@ package samplest.core;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ObjectArrays;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import restx.annotations.GET;
-import restx.annotations.POST;
-import restx.annotations.RestxResource;
+import restx.annotations.*;
 import restx.factory.Component;
 import restx.security.PermitAll;
 
-import javax.validation.constraints.Size;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -129,5 +124,10 @@ public class ParametersResource {
     @GET("/params/optionalArrayedJodaDatesParams")
     public DateTime[] optionalArrayedJodaDatesParams(Optional<DateTime[]> params, Optional<DateTime[]> otherParams) {
         return ObjectArrays.concat(params.or(new DateTime[0]), otherParams.or(new DateTime[0]), DateTime.class);
+    }
+
+    @GET("/params/headers")
+    public String headerParams(@Param(value = "X-A", kind = Param.Kind.HEADER) String a, @Param(value = "X-B", kind = Param.Kind.HEADER) Optional<DateTime> b) {
+        return "a=" + a + " b=" + b.orNull();
     }
 }

--- a/restx-samplest/src/main/java/samplest/core/ParametersResource.java
+++ b/restx-samplest/src/main/java/samplest/core/ParametersResource.java
@@ -127,7 +127,7 @@ public class ParametersResource {
     }
 
     @GET("/params/headers")
-    public String headerParams(@Param(value = "X-A", kind = Param.Kind.HEADER) String a, @Param(value = "X-B", kind = Param.Kind.HEADER) Optional<DateTime> b) {
-        return "a=" + a + " b=" + b.orNull();
+    public String headerParams(@Param(value = "X-A", kind = Param.Kind.HEADER) String a, @HeaderParam("X-B") Optional<DateTime> b, @HeaderParam Optional<String> Date) {
+        return "a=" + a + " b=" + b.orNull() + " date=" + String.valueOf(Date.orNull());
     }
 }

--- a/restx-samplest/src/test/java/samplest/core/ParametersResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/core/ParametersResourceTest.java
@@ -20,9 +20,9 @@ public class ParametersResourceTest {
     @Test
     public void should_return_path_params() throws Exception {
         HttpRequest httpRequest = server.client().authenticatedAs("admin").GET(
-                "/api/params/path/v1/v2/35v4");
+                "/api/params/path/v1/v2/35v4/v5");
         assertThat(httpRequest.code()).isEqualTo(200);
-        assertThat(httpRequest.body().trim()).isEqualTo("a=v1 b=v2 c=35 d=v4");
+        assertThat(httpRequest.body().trim()).isEqualTo("a=v1 b=v2 c=35 d=v4 e=v5");
     }
 
     @Test
@@ -55,5 +55,15 @@ public class ParametersResourceTest {
                 .header("Date", "Tue, 15 Nov 1994 08:12:31 GMT");
 
         assertThat(httpRequest.code()).isEqualTo(500);
+    }
+
+    @Test
+    public void should_params_using_annotations_returns_value() throws Exception {
+        HttpRequest httpRequest = server.client().authenticatedAs("admin")
+                .GET("/api/params/usingAnnotations/blah?query=bleh")
+                .contentType("text/plain");
+
+        assertThat(httpRequest.code()).isEqualTo(200);
+        assertThat(httpRequest.body().trim()).isEqualTo("path=blah query=bleh contentType=text/plain");
     }
 }

--- a/restx-samplest/src/test/java/samplest/core/ParametersResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/core/ParametersResourceTest.java
@@ -24,4 +24,33 @@ public class ParametersResourceTest {
         assertThat(httpRequest.code()).isEqualTo(200);
         assertThat(httpRequest.body().trim()).isEqualTo("a=v1 b=v2 c=35 d=v4");
     }
+
+    @Test
+    public void should_return_header_params() throws Exception {
+        HttpRequest httpRequest = server.client().authenticatedAs("admin")
+                .GET("/api/params/headers")
+                .header("X-A", "aaa")
+                .header("X-B", "2017-09-01T09:07:46Z");
+
+        assertThat(httpRequest.code()).isEqualTo(200);
+        assertThat(httpRequest.body().trim()).isEqualTo("a=aaa b=2017-09-01T09:07:46.000Z");
+    }
+
+    @Test
+    public void should_return_header_params_with_absent_value() throws Exception {
+        HttpRequest httpRequest = server.client().authenticatedAs("admin")
+                .GET("/api/params/headers")
+                .header("X-A", "aaa");
+
+        assertThat(httpRequest.code()).isEqualTo(200);
+        assertThat(httpRequest.body().trim()).isEqualTo("a=aaa b=null");
+    }
+
+    @Test
+    public void should_return_header_params_with_missing_required_value() throws Exception {
+        HttpRequest httpRequest = server.client().authenticatedAs("admin")
+                .GET("/api/params/headers");
+
+        assertThat(httpRequest.code()).isEqualTo(500);
+    }
 }

--- a/restx-samplest/src/test/java/samplest/core/ParametersResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/core/ParametersResourceTest.java
@@ -30,26 +30,29 @@ public class ParametersResourceTest {
         HttpRequest httpRequest = server.client().authenticatedAs("admin")
                 .GET("/api/params/headers")
                 .header("X-A", "aaa")
-                .header("X-B", "2017-09-01T09:07:46Z");
+                .header("X-B", "2017-09-01T09:07:46Z")
+                .header("Date", "Tue, 15 Nov 1994 08:12:31 GMT");
 
         assertThat(httpRequest.code()).isEqualTo(200);
-        assertThat(httpRequest.body().trim()).isEqualTo("a=aaa b=2017-09-01T09:07:46.000Z");
+        assertThat(httpRequest.body().trim()).isEqualTo("a=aaa b=2017-09-01T09:07:46.000Z date=Tue, 15 Nov 1994 08:12:31 GMT");
     }
 
     @Test
     public void should_return_header_params_with_absent_value() throws Exception {
         HttpRequest httpRequest = server.client().authenticatedAs("admin")
                 .GET("/api/params/headers")
-                .header("X-A", "aaa");
+                .header("X-A", "aaa")
+                .header("Date", "Tue, 15 Nov 1994 08:12:31 GMT");
 
         assertThat(httpRequest.code()).isEqualTo(200);
-        assertThat(httpRequest.body().trim()).isEqualTo("a=aaa b=null");
+        assertThat(httpRequest.body().trim()).isEqualTo("a=aaa b=null date=Tue, 15 Nov 1994 08:12:31 GMT");
     }
 
     @Test
     public void should_return_header_params_with_missing_required_value() throws Exception {
         HttpRequest httpRequest = server.client().authenticatedAs("admin")
-                .GET("/api/params/headers");
+                .GET("/api/params/headers")
+                .header("Date", "Tue, 15 Nov 1994 08:12:31 GMT");
 
         assertThat(httpRequest.code()).isEqualTo(500);
     }


### PR DESCRIPTION
PR to fix first part of #101 concerning request headers management

Those request headers will be handled exactly the same (such as `Optional` handling and `Jackson` deserialization) as `PATH` or `QUERY` parameters, following what has been prepared in PR #177 (better query parameters)

2 different forms of definig request header will be available :
- The "short" form, using the all new `@HeaderParam` annotation : 
- The "long" form, using existing `@Param` annotation

Both forms can be shown in samplest's `ParametersResource` :
```
    @GET("/params/headers")
    public String headerParams(@Param(value = "X-A", kind = Param.Kind.HEADER) String a, @HeaderParam("X-B") Optional<DateTime> b, @HeaderParam Optional<String> Date) {
        return "a=" + a + " b=" + b.orNull() + " date=" + String.valueOf(Date.orNull());
    }
```

which will generate following `StdEntityRoute` code :
```
        new StdEntityRoute<Void, java.lang.String>("default#ParametersResource#headerParams",
                readerRegistry.<Void>build(Void.class, Optional.<String>absent()),
                writerRegistry.<java.lang.String>build(java.lang.String.class, Optional.<String>absent()),
                Endpoint.of("GET", "/params/headers"),
                HttpStatus.OK, RestxLogLevel.DEFAULT, pf,
                paramMapperRegistry, new ParamDef[]{
                    ParamDef.of(new TypeReference<java.lang.String>(){}, "X-A"),
                    ParamDef.of(new TypeReference<org.joda.time.DateTime>(){}, "X-B"),
                    ParamDef.of(new TypeReference<java.lang.String>(){}, "Date")
                }) {
            @Override
            protected Optional<java.lang.String> doRoute(RestxRequest request, RestxRequestMatch match, Void body) throws IOException {
                securityManager.check(request, match, open());
                try {
                    return Optional.of(resource.headerParams(
                        /* [HEADER] X-A */ checkValid(validator, checkNotNull(mapQueryObjectFromRequest(java.lang.String.class, "X-A", request, match, EndpointParameterKind.HEADER), "HEADER param <a> is required")),
                        /* [HEADER] X-B */ Optional.fromNullable(checkValid(validator, mapQueryObjectFromRequest(org.joda.time.DateTime.class, "X-B", request, match, EndpointParameterKind.HEADER))),
                        /* [HEADER] Date */ Optional.fromNullable(checkValid(validator, mapQueryObjectFromRequest(java.lang.String.class, "Date", request, match, EndpointParameterKind.HEADER)))
                    ));
                } catch(RuntimeException e) { throw e; }
                  catch(Exception e) { throw new WrappedCheckedException(e); }
            }

            @Override
            protected void describeOperation(OperationDescription operation) {
                super.describeOperation(operation);
                OperationParameterDescription a = new OperationParameterDescription();
                a.name = "X-A";
                a.paramType = OperationParameterDescription.ParamType.header;
                a.dataType = "string";
                a.schemaKey = "";
                a.required = true;
                operation.parameters.add(a);

                OperationParameterDescription b = new OperationParameterDescription();
                b.name = "X-B";
                b.paramType = OperationParameterDescription.ParamType.header;
                b.dataType = "Date";
                b.schemaKey = "org.joda.time.DateTime";
                b.required = false;
                operation.parameters.add(b);

                OperationParameterDescription Date = new OperationParameterDescription();
                Date.name = "Date";
                Date.paramType = OperationParameterDescription.ParamType.header;
                Date.dataType = "string";
                Date.schemaKey = "";
                Date.required = false;
                operation.parameters.add(Date);


                operation.responseClass = "string";
                operation.inEntitySchemaKey = "";
                operation.outEntitySchemaKey = "";
                operation.sourceLocation = "samplest.core.ParametersResource#headerParams(java.lang.String,com.google.common.base.Optional<org.joda.time.DateTime>,com.google.common.base.Optional<java.lang.String>)";
            }
        },
```