### PR TITLE
apidocs - removing api-docs relatedOperations when targetting 'string' type

### DIFF
--- a/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
+++ b/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
@@ -103,9 +103,11 @@ public class ApiDeclarationRoute extends StdJsonProducerEntityRoute {
                 Set<OperationReference> related = new LinkedHashSet<>(operation.relatedOperations);
 
                 // add related by type
-                related.addAll(operationsByType.get(getTargetType(operation.responseClass)));
+                if(!"string".equals(getTargetType(operation.responseClass))){
+                    related.addAll(operationsByType.get(getTargetType(operation.responseClass)));
+                }
                 Optional<OperationParameterDescription> bodyParameter = operation.findBodyParameter();
-                if (bodyParameter.isPresent()) {
+                if (bodyParameter.isPresent() && !"string".equals(bodyParameter.get().dataType)) {
                     related.addAll(operationsByType.get(getTargetType(bodyParameter.get().dataType)));
                 }
 


### PR DESCRIPTION
On endpoints returning "frequent" types such as `String`, we are generating a lot of noisy `related operations`, for instance :
![image](https://user-images.githubusercontent.com/603815/30004167-7a1e2724-90ca-11e7-9a4c-b5b044da5c67.png)

This PR aims at removing `String` type `related operations` from this screen :
![image](https://user-images.githubusercontent.com/603815/30004183-c4e5e10c-90ca-11e7-9b30-e01b94e925c7.png)

