### PR TITLE
Response headers management

### DIFF
--- a/restx-admin/src/main/java/restx/exceptions/ErrorDescriptorsRoute.java
+++ b/restx-admin/src/main/java/restx/exceptions/ErrorDescriptorsRoute.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import restx.RestxRequest;
 import restx.RestxRequestMatch;
+import restx.RestxResponse;
 import restx.endpoint.Endpoint;
 import restx.endpoint.EndpointParameterMapperRegistry;
 import restx.admin.AdminModule;
@@ -51,7 +52,7 @@ public class ErrorDescriptorsRoute extends StdJsonProducerEntityRoute {
     }
 
     @Override
-    protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object i) throws IOException {
+    protected Optional<?> doRoute(RestxRequest restxRequest, RestxResponse response, RestxRequestMatch match, Object i) throws IOException {
         securityManager.check(restxRequest, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
         return Optional.of(errorDescriptors.values());
     }

--- a/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
+++ b/restx-apidocs/src/main/java/restx/apidocs/ApiDeclarationRoute.java
@@ -60,7 +60,7 @@ public class ApiDeclarationRoute extends StdJsonProducerEntityRoute {
     }
 
     @Override
-    protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object body) throws IOException {
+    protected Optional<?> doRoute(RestxRequest restxRequest, RestxResponse response, RestxRequestMatch match, Object body) throws IOException {
         securityManager.check(restxRequest, match, permissionFactory.hasRole(AdminModule.RESTX_ADMIN_ROLE));
         String routerName = match.getPathParam("router");
         Optional<NamedComponent<RestxRouter>> router = getRouterByName(factory, routerName);

--- a/restx-apidocs/src/main/java/restx/apidocs/ApiDocsIndexRoute.java
+++ b/restx-apidocs/src/main/java/restx/apidocs/ApiDocsIndexRoute.java
@@ -61,7 +61,7 @@ public class ApiDocsIndexRoute extends StdJsonProducerEntityRoute {
     }
 
     @Override
-    protected Optional<?> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Object i) throws IOException {
+    protected Optional<?> doRoute(RestxRequest restxRequest, RestxResponse response, RestxRequestMatch match, Object i) throws IOException {
         securityManager.check(restxRequest, match, hasRole(AdminModule.RESTX_ADMIN_ROLE));
         return Optional.of(ImmutableMap.builder()
                 .put("apiVersion", "0.1") // TODO

--- a/restx-common/src/main/java/restx/common/MoreAnnotations.java
+++ b/restx-common/src/main/java/restx/common/MoreAnnotations.java
@@ -1,0 +1,15 @@
+package restx.common;
+
+import com.google.common.base.Function;
+
+import java.lang.annotation.Annotation;
+
+public class MoreAnnotations {
+    public static final Function<Annotation, Class<? extends Annotation>> EXTRACT_ANNOTATION_TYPE = new Function<Annotation, Class<? extends Annotation>>() {
+        @Override
+        public Class<? extends Annotation> apply(Annotation input) {
+            return input.annotationType();
+        }
+    };
+
+}

--- a/restx-common/src/main/java/restx/common/MorePeriods.java
+++ b/restx-common/src/main/java/restx/common/MorePeriods.java
@@ -1,0 +1,71 @@
+package restx.common;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.joda.time.MutablePeriod;
+import org.joda.time.Period;
+import org.joda.time.format.PeriodFormatterBuilder;
+import org.joda.time.format.PeriodParser;
+
+import java.util.Locale;
+
+public class MorePeriods {
+
+    private static final PeriodParser PERIOD_PARSER = new PeriodFormatterBuilder()
+                .appendYears().appendSuffix("y").appendSeparatorIfFieldsAfter(" ")
+                .appendMonths().appendSuffix("mo").appendSeparatorIfFieldsAfter(" ")
+                .appendWeeks().appendSuffix("w").appendSeparatorIfFieldsAfter(" ")
+                .appendDays().appendSuffix("d").appendSeparatorIfFieldsAfter(" ")
+                .appendHours().appendSuffix("h").appendSeparatorIfFieldsAfter(" ")
+                .appendMinutes().appendSuffix("m").appendSeparatorIfFieldsAfter(" ")
+                .appendSeconds().appendSuffix("s")
+                .toParser();
+
+    private static class ParseableDurationForLocale {
+        String duration;
+        Locale locale;
+
+        public ParseableDurationForLocale(String duration, Locale locale) {
+            this.duration = duration;
+            this.locale = locale;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ParseableDurationForLocale that = (ParseableDurationForLocale) o;
+
+            if (duration != null ? !duration.equals(that.duration) : that.duration != null) return false;
+            return locale != null ? locale.equals(that.locale) : that.locale == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = duration != null ? duration.hashCode() : 0;
+            result = 31 * result + (locale != null ? locale.hashCode() : 0);
+            return result;
+        }
+    }
+
+    private static final LoadingCache<ParseableDurationForLocale, Period> PARSED_PERIODS_CACHE = CacheBuilder.newBuilder()
+            .maximumSize(200)
+            .build(new CacheLoader<ParseableDurationForLocale, Period>() {
+                @Override
+                public Period load(ParseableDurationForLocale parseableDurationForLocale) throws Exception {
+                    MutablePeriod period = new MutablePeriod();
+                    PERIOD_PARSER.parseInto(period, parseableDurationForLocale.duration, 0, parseableDurationForLocale.locale);
+                    return period.toPeriod();
+                }
+            });
+
+    /**
+     * Parses a period from a string looking like "1y 2mo 1w 2d 1h 2m 10s"
+     */
+    public static Period parsePeriod(String duration, Locale currentLocale){
+        return PARSED_PERIODS_CACHE.getUnchecked(new ParseableDurationForLocale(duration, currentLocale));
+    }
+}

--- a/restx-common/src/main/java/restx/common/Mustaches.java
+++ b/restx-common/src/main/java/restx/common/Mustaches.java
@@ -27,10 +27,23 @@ public class Mustaches {
 
     public static Template compile(String name, CharSource charSource) {
         try (Reader reader = charSource.openBufferedStream()) {
-            return Mustache.compiler().escapeHTML(false).compile(reader);
+            return createCompiler().compile(reader);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static Template compileTemplate(String template) {
+        return createCompiler().compile(template);
+    }
+
+    private static Mustache.Compiler createCompiler() {
+        return Mustache.compiler().escapeHTML(false);
+    }
+
+    public static Template compileTemplateWithSingleBrackets(String templateWithSingleBrackets) {
+        String templateWithDoubleBrackets = templateWithSingleBrackets.replaceAll("\\{", "{{").replaceAll("}", "}}");
+        return compileTemplate(templateWithDoubleBrackets);
     }
 
     public static String execute(Template mustache, Object scope) {

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -757,7 +757,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
         },
         CONTEXT(false) {
             public String fetchFromReqCode(ResourceMethodParameter parameter, ResourceMethod method) {
-                Collection<String> contextParamNames = Arrays.asList("baseUri", "clientAddress", "request", "locale", "locales");
+                Collection<String> contextParamNames = Arrays.asList("baseUri", "clientAddress", "request", "response", "locale", "locales");
                 if (!contextParamNames.contains(parameter.reqParamName)) {
                     throw new IllegalArgumentException("context parameter not known: " + parameter.reqParamName +
                             ". Possible names are: " + Joiner.on(", ").join(contextParamNames));
@@ -765,6 +765,8 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
                 switch (parameter.reqParamName) {
                     case "request":
                         return "request";
+                    case "response":
+                        return "response";
                     case "baseUri":
                         return "request.getBaseUri()";
                     case "clientAddress":

--- a/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
+++ b/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
@@ -72,7 +72,9 @@ public class {{router}} extends RestxRouter {
 
                 operation.responseClass = "{{responseClass}}";
                 operation.inEntitySchemaKey = "{{inEntitySchemaKey}}";
+                operation.inEntityType = {{inEntityType}};
                 operation.outEntitySchemaKey = "{{outEntitySchemaKey}}";
+                operation.outEntityType = {{outEntityType}};
                 operation.sourceLocation = "{{sourceLocation}}";
                 operation.annotations = ImmutableList.<java.lang.annotation.Annotation>builder()
 {{#annotationDescriptions}}

--- a/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
+++ b/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
@@ -56,7 +56,7 @@ public class {{router}} extends RestxRouter {
 {{queryParametersDefinition}}
                 }) {
             @Override
-            protected Optional<{{outEntity}}> doRoute(RestxRequest request, RestxRequestMatch match, {{inEntity}} body) throws IOException {
+            protected Optional<{{outEntity}}> doRoute(RestxRequest request, RestxResponse response, RestxRequestMatch match, {{inEntity}} body) throws IOException {
                 {{securityCheck}}
                 try {
                     {{call}}

--- a/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
+++ b/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
@@ -6,6 +6,8 @@ import com.google.common.base.Optional;
 import com.google.common.base.Suppliers;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import restx.common.Types;
 import restx.common.TypeReference;
 import restx.*;
@@ -25,6 +27,9 @@ import static restx.validation.Validations.checkValid;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+
+import java.util.Arrays;
+
 
 @Component(priority = {{priority}})
 {{condition}}
@@ -69,6 +74,16 @@ public class {{router}} extends RestxRouter {
                 operation.inEntitySchemaKey = "{{inEntitySchemaKey}}";
                 operation.outEntitySchemaKey = "{{outEntitySchemaKey}}";
                 operation.sourceLocation = "{{sourceLocation}}";
+                operation.annotations = ImmutableList.<java.lang.annotation.Annotation>builder()
+{{#annotationDescriptions}}
+                    .add(new {{annotationClass}}() {
+                        public Class<{{annotationClass}}> annotationType() { return {{annotationClass}}.class; }
+{{#annotationFields}}
+                        public {{type}}{{#isArray}}[]{{/isArray}} {{name}}() { {{valueCodeInstanciation}}; }
+{{/annotationFields}}
+                    })
+{{/annotationDescriptions}}
+                    .build();
             }
         },
 {{/routes}}

--- a/restx-core/src/main/java/restx/RestxRouter.java
+++ b/restx-core/src/main/java/restx/RestxRouter.java
@@ -106,7 +106,7 @@ public class RestxRouter {
         public <O> Builder addRoute(String name, Endpoint endpoint, PermissionFactory permissionFactory, Class<O> outputType, final MatchedEntityRoute<Void, O> route) {
             routes.add(new StdJsonProducerEntityRoute<O>(name, outputType, writer.withType(outputType), endpoint, permissionFactory, registry) {
                 @Override
-                protected Optional<O> doRoute(RestxRequest restxRequest, RestxRequestMatch match, Void i) throws IOException {
+                protected Optional<O> doRoute(RestxRequest restxRequest, RestxResponse response, RestxRequestMatch match, Void i) throws IOException {
                     return route.route(restxRequest, match, i);
                 }
             });

--- a/restx-core/src/main/java/restx/annotations/ExpiresAfter.java
+++ b/restx-core/src/main/java/restx/annotations/ExpiresAfter.java
@@ -1,0 +1,5 @@
+package restx.annotations;
+
+public @interface ExpiresAfter {
+    String value();
+}

--- a/restx-core/src/main/java/restx/annotations/LocationHeader.java
+++ b/restx-core/src/main/java/restx/annotations/LocationHeader.java
@@ -1,0 +1,5 @@
+package restx.annotations;
+
+public @interface LocationHeader {
+    String value();
+}

--- a/restx-core/src/main/java/restx/description/OperationDescription.java
+++ b/restx-core/src/main/java/restx/description/OperationDescription.java
@@ -2,12 +2,17 @@ package restx.description;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import restx.common.MoreAnnotations;
 import restx.http.HttpStatus;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -34,6 +39,85 @@ public class OperationDescription {
     public List<OperationReference> relatedOperations = Lists.newArrayList();
     @JsonIgnore
     public ImmutableList<? extends Annotation> annotations;
+
+    public static class Matcher implements Predicate<OperationDescription> {
+        public Predicate<String> httpMethodMatcher = Predicates.alwaysTrue();
+        public Predicate<Type> inEntityTypeMatcher = Predicates.alwaysTrue();
+        public Predicate<Type> outEntityTypeMatcher = Predicates.alwaysTrue();
+        public Predicate<HttpStatus.Descriptor> successStatusMatcher = Predicates.alwaysTrue();
+        public Predicate<ImmutableList<ErrorResponseDescription>> errorResponsesMatcher = Predicates.alwaysTrue();
+        public Predicate<ImmutableList<? extends Annotation>> annotationsMatcher = Predicates.alwaysTrue();
+
+        public Matcher withHttpMethodMatcher(Predicate<String> httpMethodMatcher) {
+            this.httpMethodMatcher = httpMethodMatcher;
+            return this;
+        }
+
+        public Matcher withInEntityTypeMatcher(Predicate<Type> inEntityTypeMatcher) {
+            this.inEntityTypeMatcher = inEntityTypeMatcher;
+            return this;
+        }
+
+        public Matcher withOutEntityTypeMatcher(Predicate<Type> outEntityTypeMatcher) {
+            this.outEntityTypeMatcher = outEntityTypeMatcher;
+            return this;
+        }
+
+        public Matcher withSuccessStatusMatcher(Predicate<HttpStatus.Descriptor> successStatusMatcher) {
+            this.successStatusMatcher = successStatusMatcher;
+            return this;
+        }
+
+        public Matcher withErrorResponsesMatcher(Predicate<ImmutableList<ErrorResponseDescription>> errorResponsesMatcher) {
+            this.errorResponsesMatcher = errorResponsesMatcher;
+            return this;
+        }
+
+        public Matcher withAnnotationsMatcher(Predicate<ImmutableList<? extends Annotation>> annotationsMatcher) {
+            this.annotationsMatcher = annotationsMatcher;
+            return this;
+        }
+
+        public Matcher havingAnyAnnotations(final Class<? extends Annotation>... annotationTypes) {
+            return this.withAnnotationsMatcher(new Predicate<ImmutableList<? extends Annotation>>() {
+                @Override
+                public boolean apply(ImmutableList<? extends Annotation> annotations) {
+                    if(annotations == null) {
+                        return false;
+                    }
+                    return !FluentIterable.from(annotations)
+                            .transform(MoreAnnotations.EXTRACT_ANNOTATION_TYPE)
+                            .filter(Predicates.in(Arrays.asList(annotationTypes)))
+                            .isEmpty();
+                }
+            });
+        }
+
+        public Matcher havingAllAnnotations(final Class<? extends Annotation>... annotationTypes) {
+            return this.withAnnotationsMatcher(new Predicate<ImmutableList<? extends Annotation>>() {
+                @Override
+                public boolean apply(ImmutableList<? extends Annotation> annotations) {
+                    if(annotations == null) {
+                        return false;
+                    }
+                    return FluentIterable.from(annotations)
+                            .transform(MoreAnnotations.EXTRACT_ANNOTATION_TYPE)
+                            .filter(Predicates.in(Arrays.asList(annotationTypes)))
+                            .size() == annotationTypes.length;
+                }
+            });
+        }
+
+        @Override
+        public boolean apply(OperationDescription description) {
+            return httpMethodMatcher.apply(description.httpMethod)
+                && inEntityTypeMatcher.apply(description.inEntityType)
+                && outEntityTypeMatcher.apply(description.outEntityType)
+                && successStatusMatcher.apply(description.successStatus)
+                && errorResponsesMatcher.apply(ImmutableList.copyOf(description.errorResponses))
+                && annotationsMatcher.apply(description.annotations);
+        }
+    }
 
     public Optional<OperationParameterDescription> findBodyParameter() {
         for (OperationParameterDescription parameter : parameters) {

--- a/restx-core/src/main/java/restx/description/OperationDescription.java
+++ b/restx-core/src/main/java/restx/description/OperationDescription.java
@@ -1,9 +1,12 @@
 package restx.description;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import restx.http.HttpStatus;
 
+import java.lang.annotation.Annotation;
 import java.util.List;
 
 /**
@@ -24,6 +27,8 @@ public class OperationDescription {
     public List<OperationParameterDescription> parameters = Lists.newArrayList();
     public List<ErrorResponseDescription> errorResponses = Lists.newArrayList();
     public List<OperationReference> relatedOperations = Lists.newArrayList();
+    @JsonIgnore
+    public ImmutableList<? extends Annotation> annotations;
 
     public Optional<OperationParameterDescription> findBodyParameter() {
         for (OperationParameterDescription parameter : parameters) {
@@ -32,6 +37,15 @@ public class OperationDescription {
             }
         }
 
+        return Optional.absent();
+    }
+
+    public <T extends Annotation> Optional<T> findAnnotation(final Class<T> clazz) {
+        for(Annotation annotation: annotations) {
+            if(clazz.isAssignableFrom(annotation.getClass())) {
+                return Optional.fromNullable((T) annotation);
+            }
+        }
         return Optional.absent();
     }
 }

--- a/restx-core/src/main/java/restx/description/OperationDescription.java
+++ b/restx-core/src/main/java/restx/description/OperationDescription.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Lists;
 import restx.http.HttpStatus;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.List;
 
 /**
@@ -20,7 +21,11 @@ public class OperationDescription {
     public String responseClass;
     public String sourceLocation = "";
     public String inEntitySchemaKey = "";
+    @JsonIgnore
+    public Type inEntityType;
     public String outEntitySchemaKey = "";
+    @JsonIgnore
+    public Type outEntityType;
     public String summary = "";
     public String notes = "";
     public HttpStatus.Descriptor successStatus;

--- a/restx-core/src/main/java/restx/description/ResourceDescription.java
+++ b/restx-core/src/main/java/restx/description/ResourceDescription.java
@@ -1,5 +1,7 @@
 package restx.description;
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
 
 import java.util.List;
@@ -16,4 +18,30 @@ public class ResourceDescription {
 
     public List<OperationDescription> operations = Lists.newArrayList();
 
+    public static class Matcher implements Predicate<ResourceDescription> {
+        private Predicate<String> pathMatcher = Predicates.alwaysTrue();
+        private Predicate<String> stdPathMatcher = Predicates.alwaysTrue();
+        private Predicate<String> descriptionMatcher = Predicates.alwaysTrue();
+
+        public Matcher withPathMatcher(Predicate<String> pathMatcher) {
+            this.pathMatcher = pathMatcher;
+            return this;
+        }
+
+        public Matcher withStdPathMatcher(Predicate<String> stdPathMatcher) {
+            this.stdPathMatcher = stdPathMatcher;
+            return this;
+        }
+
+        public Matcher withDescriptionMatcher(Predicate<String> descriptionMatcher) {
+            this.descriptionMatcher = descriptionMatcher;
+            return this;
+        }
+
+        public boolean apply(ResourceDescription description) {
+            return pathMatcher.apply(description.path)
+                    && stdPathMatcher.apply(description.stdPath)
+                    && descriptionMatcher.apply(description.description);
+        }
+    }
 }

--- a/restx-core/src/main/java/restx/entity/StdEntityRoute.java
+++ b/restx-core/src/main/java/restx/entity/StdEntityRoute.java
@@ -116,7 +116,7 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
                     entityResponseWriter,
                     endpoint, successStatus, logLevel, permissionFactory, registry, queryParameters) {
                 @Override
-                protected Optional<O> doRoute(RestxRequest restxRequest, RestxRequestMatch match, I i) throws IOException {
+                protected Optional<O> doRoute(RestxRequest restxRequest, RestxResponse response, RestxRequestMatch match, I i) throws IOException {
                     return matchedEntityRoute.route(restxRequest, match, i);
                 }
             };
@@ -247,7 +247,7 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
         I input = entityRequestBodyReader.readBody(req, ctx);
         Optional<I> optionalInput = Optional.fromNullable(input);
         lifecycleListener.onEntityInput(this, req, resp, optionalInput);
-        Optional<O> result = doRoute(req, match, input);
+        Optional<O> result = doRoute(req, resp, match, input);
         lifecycleListener.onEntityOutput(this, req, resp, optionalInput, result);
         if (result.isPresent()) {
             entityResponseWriter.sendResponse(getSuccessStatus(), result.get(), req, resp, ctx);
@@ -256,7 +256,7 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
         }
     }
 
-    protected abstract Optional<O> doRoute(RestxRequest restxRequest, RestxRequestMatch match, I i) throws IOException;
+    protected abstract Optional<O> doRoute(RestxRequest restxRequest, RestxResponse restxResponse, RestxRequestMatch match, I i) throws IOException;
 
     // Aliases to permissionFactory allowing to have a more readable generated code through APT
     protected Permission hasRole(String role){ return permissionFactory.hasRole(role); }

--- a/restx-core/src/main/java/restx/http/EntityRelatedFilter.java
+++ b/restx-core/src/main/java/restx/http/EntityRelatedFilter.java
@@ -1,0 +1,104 @@
+package restx.http;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import restx.*;
+import restx.description.OperationDescription;
+import restx.description.ResourceDescription;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public abstract class EntityRelatedFilter implements RestxRouteFilter {
+
+    private final Predicate<StdRoute> routeMatcher;
+    private final Predicate<ResourceDescription> resourceDescriptionMatcher;
+    private final Predicate<OperationDescription> operationDescriptionMatcher;
+
+    public EntityRelatedFilter(Predicate<StdRoute> routeMatcher, Predicate<ResourceDescription> resourceDescriptionMatcher, Predicate<OperationDescription> operationDescriptionMatcher) {
+        this.routeMatcher = routeMatcher;
+        this.resourceDescriptionMatcher = resourceDescriptionMatcher;
+        this.operationDescriptionMatcher = operationDescriptionMatcher;
+    }
+
+    @Override
+    public Optional<RestxHandlerMatch> match(RestxRoute route) {
+        if(!(route instanceof StdRoute)) {
+            return Optional.absent();
+        }
+
+        final StdRoute stdRoute = (StdRoute) route;
+
+        Collection<ResourceDescription> resourceDescriptionColl = stdRoute.describe();
+        if(resourceDescriptionColl.isEmpty()) {
+            return Optional.absent();
+        }
+
+        final ResourceDescription resourceDescription = Iterables.getOnlyElement(resourceDescriptionColl);
+        if(resourceDescription.operations == null || resourceDescription.operations.isEmpty()) {
+            return Optional.absent();
+        }
+
+        final OperationDescription operationDescription = Iterables.getOnlyElement(resourceDescription.operations);
+        if(!matches(stdRoute, resourceDescription, operationDescription)) {
+            return Optional.absent();
+        }
+
+        return Optional.of(new RestxHandlerMatch(new StdRestxRequestMatch("/*"), new RestxHandler() {
+            @Override
+            public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, final RestxContext ctx) throws IOException {
+                ctx.nextHandlerMatch().handle(req, resp, ctx.withListener(new AbstractRouteLifecycleListener() {
+
+                    @Override
+                    public void onBeforeWriteContent(RestxRequest req, RestxResponse resp) {
+                        EntityRelatedFilter.this.onBeforeWriteContent(req, resp, resourceDescription, operationDescription);
+                    }
+
+                    @Override
+                    public void onAfterWriteContent(RestxRequest req, RestxResponse resp) {
+                        EntityRelatedFilter.this.onAfterWriteContent(req, resp, resourceDescription, operationDescription);
+                    }
+
+                    @Override
+                    public void onEntityInput(RestxRoute route, RestxRequest req, RestxResponse resp, Optional<?> input) {
+                        EntityRelatedFilter.this.onEntityInput(stdRoute, req, resp, input, resourceDescription, operationDescription);
+                    }
+
+                    @Override
+                    public void onEntityOutput(RestxRoute route, RestxRequest req, RestxResponse resp, Optional<?> input, Optional<?> output) {
+                        EntityRelatedFilter.this.onEntityOutput(stdRoute, req, resp, input, output, resourceDescription, operationDescription);
+                    }
+                }));
+            }
+        }));
+    }
+
+    protected void onEntityInput(StdRoute stdRoute, RestxRequest req, RestxResponse resp, Optional<?> input,
+                                 ResourceDescription resourceDescription, OperationDescription operationDescription) {
+        // To be overwritten
+    }
+
+    protected void onBeforeWriteContent(RestxRequest req, RestxResponse resp,
+                                        ResourceDescription resourceDescription, OperationDescription operationDescription) {
+        // To be overwritten
+    }
+
+    protected void onEntityOutput(StdRoute stdRoute, RestxRequest req, RestxResponse resp,
+                                  Optional<?> input, Optional<?> output,
+                                  ResourceDescription resourceDescription, OperationDescription operationDescription) {
+        // To be overwritten
+    }
+
+    protected void onAfterWriteContent(RestxRequest req, RestxResponse resp,
+                                       ResourceDescription resourceDescription, OperationDescription operationDescription) {
+        // To be overwritten
+    }
+
+
+    protected boolean matches(StdRoute route, ResourceDescription resourceDescription, OperationDescription operationDescription) {
+        return this.routeMatcher.apply(route)
+                && this.resourceDescriptionMatcher.apply(resourceDescription)
+                && this.operationDescriptionMatcher.apply(operationDescription);
+    }
+}

--- a/restx-core/src/main/java/restx/http/ExpiresHeaderFilter.java
+++ b/restx-core/src/main/java/restx/http/ExpiresHeaderFilter.java
@@ -1,0 +1,62 @@
+package restx.http;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
+import org.joda.time.*;
+import org.joda.time.format.PeriodFormatterBuilder;
+import org.joda.time.format.PeriodParser;
+import restx.RestxRequest;
+import restx.RestxResponse;
+import restx.StdRoute;
+import restx.annotations.ExpiresAfter;
+import restx.description.OperationDescription;
+import restx.description.ResourceDescription;
+import restx.factory.Component;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+@Component
+public class ExpiresHeaderFilter extends EntityRelatedFilter {
+
+    public ExpiresHeaderFilter() {
+        super(Predicates.<StdRoute>alwaysTrue(), Predicates.<ResourceDescription>alwaysTrue(),
+                new OperationDescription.Matcher().havingAnyAnnotations(ExpiresAfter.class)
+        );
+    }
+
+    @Override
+    protected void onEntityOutput(StdRoute stdRoute, RestxRequest req, RestxResponse resp,
+                                  Optional<?> input, Optional<?> output,
+                                  ResourceDescription resourceDescription, OperationDescription operationDescription) {
+
+        if(!output.isPresent()) {
+            return;
+        }
+
+        ExpiresAfter expiresAfterAnn = operationDescription.findAnnotation(ExpiresAfter.class).get();
+
+        PeriodParser parser = new PeriodFormatterBuilder()
+                .appendYears().appendSuffix("y").appendSeparatorIfFieldsAfter(" ")
+                .appendMonths().appendSuffix("mo").appendSeparatorIfFieldsAfter(" ")
+                .appendWeeks().appendSuffix("w").appendSeparatorIfFieldsAfter(" ")
+                .appendDays().appendSuffix("d").appendSeparatorIfFieldsAfter(" ")
+                .appendHours().appendSuffix("h").appendSeparatorIfFieldsAfter(" ")
+                .appendMinutes().appendSuffix("m").appendSeparatorIfFieldsAfter(" ")
+                .appendSeconds().appendSuffix("s")
+                .toParser();
+
+        MutablePeriod period = new MutablePeriod();
+        parser.parseInto(period, expiresAfterAnn.value(), 0, Locale.US);
+        String expiresHeaderValue = createRFC1123DateFormat().format(DateTime.now().plus(period).toDate());
+
+        resp.setHeader("Expires", expiresHeaderValue);
+    }
+
+    public static DateFormat createRFC1123DateFormat() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+        dateFormat.setTimeZone(DateTimeZone.UTC.toTimeZone());
+        return dateFormat;
+    }
+}

--- a/restx-core/src/main/java/restx/http/ExpiresHeaderFilter.java
+++ b/restx-core/src/main/java/restx/http/ExpiresHeaderFilter.java
@@ -14,17 +14,20 @@ import restx.description.OperationDescription;
 import restx.description.ResourceDescription;
 import restx.factory.Component;
 
+import javax.inject.Named;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
 @Component
 public class ExpiresHeaderFilter extends EntityRelatedFilter {
+    private CurrentLocaleResolver currentLocaleResolver;
 
-    public ExpiresHeaderFilter() {
+    public ExpiresHeaderFilter(@Named("CurrentLocaleResolver") CurrentLocaleResolver currentLocaleResolver) {
         super(Predicates.<StdRoute>alwaysTrue(), Predicates.<ResourceDescription>alwaysTrue(),
                 new OperationDescription.Matcher().havingAnyAnnotations(ExpiresAfter.class)
         );
+        this.currentLocaleResolver = currentLocaleResolver;
     }
 
     @Override
@@ -38,7 +41,7 @@ public class ExpiresHeaderFilter extends EntityRelatedFilter {
 
         ExpiresAfter expiresAfterAnn = operationDescription.findAnnotation(ExpiresAfter.class).get();
 
-        Locale currentLocale = Locale.US;
+        Locale currentLocale = currentLocaleResolver.guessLocale(req);
         DateTime expirationDate = DateTime.now().plus(MorePeriods.parsePeriod(expiresAfterAnn.value(), currentLocale));
         String expiresHeaderValue = createRFC1123DateFormat(currentLocale).format(expirationDate.toDate());
 

--- a/restx-core/src/main/java/restx/http/LocationHeaderFilter.java
+++ b/restx-core/src/main/java/restx/http/LocationHeaderFilter.java
@@ -1,0 +1,76 @@
+package restx.http;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.samskivert.mustache.Template;
+import restx.RestxRequest;
+import restx.RestxResponse;
+import restx.StdRoute;
+import restx.annotations.LocationHeader;
+import restx.common.Mustaches;
+import restx.description.OperationDescription;
+import restx.description.ResourceDescription;
+import restx.factory.Component;
+
+import java.io.StringWriter;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Generates a "Location" HTTP header on endpoints having @LocationHeader annotation
+ * URL passed to the annotation will be interpolated with :
+ * - Object properties returned by the endpoint
+ * - special "_currentUri_" targetting current restx uri used for current endpoint
+ * - special "_baseUri_" targetting current base uri, including base API context
+ *
+ * Example usages :
+ * <pre>
+ * \@POST("/foos") @LocationHeader("{_currentUri_}/{id}") // Returns /api/foos/123456 when Foo.id is "123456"
+ * \@POST("/foos") @LocationHeader("{_baseUri_}/foos/{id}") // Same as above
+ * </pre>
+ */
+@Component
+public class LocationHeaderFilter extends EntityRelatedFilter {
+
+    private LoadingCache<String, Template> templatesCache = CacheBuilder.newBuilder()
+            .maximumSize(200)
+            .build(new CacheLoader<String, Template>() {
+                @Override
+                public Template load(String template) throws Exception {
+                    return Mustaches.compileTemplateWithSingleBrackets(template);
+                }
+            });
+
+    public LocationHeaderFilter() {
+        super(Predicates.<StdRoute>alwaysTrue(), Predicates.<ResourceDescription>alwaysTrue(),
+                new OperationDescription.Matcher().havingAnyAnnotations(LocationHeader.class)
+        );
+    }
+
+    @Override
+    protected void onEntityOutput(StdRoute stdRoute, RestxRequest req, RestxResponse resp,
+                                  Optional<?> input, Optional<?> output,
+                                  ResourceDescription resourceDescription, OperationDescription operationDescription) {
+
+        if(!output.isPresent()) {
+            return;
+        }
+
+        LocationHeader locationHeaderAnn = operationDescription.findAnnotation(LocationHeader.class).get();
+        try {
+            StringWriter locationWriter = new StringWriter();
+            templatesCache.get(locationHeaderAnn.value()).execute(output.get(), ImmutableMap.of(
+                    "_baseUri_", req.getBaseUri(),
+                    "_currentUri_", req.getBaseUri()+req.getRestxUri()
+            ), locationWriter);
+
+            resp.setHeader("Location", locationWriter.toString());
+        } catch (ExecutionException e) {
+            Throwables.propagate(e);
+        }
+    }
+}

--- a/restx-samplest/src/main/java/samplest/annotations/MyAnnotation.java
+++ b/restx-samplest/src/main/java/samplest/annotations/MyAnnotation.java
@@ -1,0 +1,38 @@
+package samplest.annotations;
+
+// Annotation aimed at representing every potential values for section 9.6.1 of the JLS
+// (https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.6.1)
+public @interface MyAnnotation {
+    // primitive types
+    byte aByte();
+    short aShort();
+    int anInt();
+    long aLong();
+    float aFloat();
+    double aDouble();
+    boolean aBool();
+    char aChar();
+
+    // Complex types
+    String aString();
+    Class aClass();
+    MyEnum anEnum();
+
+    // Another annotation
+    MyNestedAnnotation anAnnotation();
+
+    byte[] severalBytes();
+    short[] severalShorts();
+    int[] severalInts();
+    long[] severalLongs();
+    float[] severalFloats();
+    double[] severalDoubles();
+    boolean[] severalBools();
+    char[] severalChars();
+
+    String[] severalStrings();
+    Class[] severalClasses();
+    MyEnum[] severalEnums();
+
+    MyNestedAnnotation[] severalAnnotations();
+}

--- a/restx-samplest/src/main/java/samplest/annotations/MyEnum.java
+++ b/restx-samplest/src/main/java/samplest/annotations/MyEnum.java
@@ -1,0 +1,5 @@
+package samplest.annotations;
+
+public enum MyEnum {
+    A,B,C;
+}

--- a/restx-samplest/src/main/java/samplest/annotations/MyNestedAnnotation.java
+++ b/restx-samplest/src/main/java/samplest/annotations/MyNestedAnnotation.java
@@ -1,0 +1,5 @@
+package samplest.annotations;
+
+public @interface MyNestedAnnotation {
+    String[] value();
+}

--- a/restx-samplest/src/main/java/samplest/core/ContextParamsResource.java
+++ b/restx-samplest/src/main/java/samplest/core/ContextParamsResource.java
@@ -1,6 +1,7 @@
 package samplest.core;
 
 import restx.RestxRequest;
+import restx.RestxResponse;
 import restx.annotations.GET;
 import restx.annotations.Param;
 import restx.annotations.RestxResource;
@@ -30,6 +31,14 @@ public class ContextParamsResource {
     @GET("/contextParams/request")
     public String getRequest(@Param(kind = Param.Kind.CONTEXT, value = "request") RestxRequest request) {
         return request.toString();
+    }
+    @PermitAll
+    @GET("/contextParams/response")
+    // response CONTEXT param is discouraged, please avoid it as much as possible as it smells like bad design
+    // particularly if you need to set some header, please have a look to different HeadersFilters around there
+    // which will be the prefered way to implement response headers management in restx
+    public String getResponse(@Param(kind = Param.Kind.CONTEXT, value = "response") RestxResponse response) {
+        return response.toString();
     }
     @PermitAll
     @GET("/contextParams/locale")

--- a/restx-samplest/src/main/java/samplest/core/CoreResource.java
+++ b/restx-samplest/src/main/java/samplest/core/CoreResource.java
@@ -3,6 +3,9 @@ package samplest.core;
 import com.google.common.base.Optional;
 import restx.annotations.*;
 import restx.factory.Component;
+import samplest.annotations.MyAnnotation;
+import samplest.annotations.MyEnum;
+import samplest.annotations.MyNestedAnnotation;
 
 /**
  * Date: 4/1/14
@@ -54,5 +57,48 @@ public class CoreResource {
     @DELETE("/hellomsg")
     public String deleteHello(String who) {
         return "hello "+who;
+    }
+
+    @GET("/testingAnnotations")
+    @MyAnnotation(
+            aByte=123,
+            aShort=123,
+            anInt=123,
+            aLong=123,
+            aFloat=123.456f,
+            aDouble=123.456,
+            aBool=true,
+            aChar='A',
+
+            // Complex types
+            aString="AAA{\\\"'$AA",
+            aClass=CoreResource.class,
+            anEnum=MyEnum.A,
+
+            // Another annotation
+            // Not supported (yet)
+            anAnnotation=@MyNestedAnnotation(value={ "BBB", "CCC" }),
+
+            severalBytes={ 123, 123 },
+            severalShorts={ 123, 456 },
+            severalInts={ 123, 456 },
+            severalLongs={ 123, 456 },
+            severalFloats={ 123.456f, 321.654f},
+            severalDoubles={ 123.456, 321.654 },
+            severalBools={ true, false },
+            severalChars={ 'A', 'B', 'C' },
+
+            severalStrings={ "AAA{\\\"'$AA", "BBB", "CCC" },
+            severalClasses={ Integer.class, String.class },
+            severalEnums={ MyEnum.A, MyEnum.B },
+
+            // Not supported (yet)
+            severalAnnotations={
+                @MyNestedAnnotation(value={ "BBB", "CCC" }),
+                @MyNestedAnnotation(value={ "DDD", "EEE" })
+            }
+    )
+    public String testingAnnotations() {
+        return "hello blah";
     }
 }

--- a/restx-samplest/src/main/java/samplest/core/HeadersResource.java
+++ b/restx-samplest/src/main/java/samplest/core/HeadersResource.java
@@ -1,8 +1,6 @@
 package samplest.core;
 
-import restx.annotations.ExpiresAfter;
-import restx.annotations.GET;
-import restx.annotations.RestxResource;
+import restx.annotations.*;
 import restx.factory.Component;
 
 @RestxResource("/headers") @Component
@@ -14,4 +12,40 @@ public class HeadersResource {
         return "hello";
     }
 
+    public static class Foo {
+        String id;
+        String name;
+
+        public String getId() {
+            return id;
+        }
+
+        Foo setId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Foo setName(String name) {
+            this.name = name;
+            return this;
+        }
+    }
+
+    @POST("/foos")
+    @LocationHeader("{_currentUri_}/{id}")
+    public Foo locationHeader(Foo foo) {
+        foo.setId("123456");
+        return foo;
+    }
+
+    @POST("/foos2")
+    @LocationHeader("{_baseUri_}/headers/foos2/{id}")
+    public Foo locationHeader2(Foo foo) {
+        foo.setId("123456");
+        return foo;
+    }
 }

--- a/restx-samplest/src/main/java/samplest/core/HeadersResource.java
+++ b/restx-samplest/src/main/java/samplest/core/HeadersResource.java
@@ -1,0 +1,17 @@
+package samplest.core;
+
+import restx.annotations.ExpiresAfter;
+import restx.annotations.GET;
+import restx.annotations.RestxResource;
+import restx.factory.Component;
+
+@RestxResource("/headers") @Component
+public class HeadersResource {
+
+    @GET("/expires")
+    @ExpiresAfter("2d 4h")
+    public String expireHeader() {
+        return "hello";
+    }
+
+}

--- a/restx-samplest/src/test/java/samplest/core/ContextParamsTest.java
+++ b/restx-samplest/src/test/java/samplest/core/ContextParamsTest.java
@@ -67,6 +67,14 @@ public class ContextParamsTest {
     }
 
     @Test
+    public void should_access_response() throws Exception {
+        HttpRequest httpRequest = server.client().GET(
+                "/api/contextParams/response");
+        assertThat(httpRequest.code()).isEqualTo(200);
+        assertThat(httpRequest.body().trim()).isEqualTo("[RESTX RESPONSE] OK");
+    }
+
+    @Test
     public void should_access_locale() throws Exception {
         HttpRequest httpRequest = server.client().GET(
                 "/api/contextParams/locale").header("Accept-Language", "fr-FR");

--- a/restx-samplest/src/test/java/samplest/core/HeadersResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/core/HeadersResourceTest.java
@@ -1,0 +1,24 @@
+package samplest.core;
+
+import com.github.kevinsawicki.http.HttpRequest;
+import org.joda.time.DateTime;
+import org.junit.ClassRule;
+import org.junit.Test;
+import restx.tests.RestxServerRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HeadersResourceTest {
+    @ClassRule
+    public static RestxServerRule server = new RestxServerRule();
+
+    @Test
+    public void should_return_expire_header() throws Exception {
+        HttpRequest httpRequest = server.client().authenticatedAs("admin").GET(
+                "/api/headers/expires");
+        assertThat(httpRequest.code()).isEqualTo(200);
+
+        long duration = Math.abs(httpRequest.expires() - DateTime.now().plusDays(2).plusHours(4).getMillis());
+        assertThat(duration).isLessThan(5000);
+    }
+}

--- a/restx-samplest/src/test/java/samplest/core/HeadersResourceTest.java
+++ b/restx-samplest/src/test/java/samplest/core/HeadersResourceTest.java
@@ -21,4 +21,24 @@ public class HeadersResourceTest {
         long duration = Math.abs(httpRequest.expires() - DateTime.now().plusDays(2).plusHours(4).getMillis());
         assertThat(duration).isLessThan(5000);
     }
+
+    @Test
+    public void should_return_location_header_with_current_uri() throws Exception {
+        HttpRequest httpRequest = server.client().authenticatedAs("admin")
+                .POST("/api/headers/foos")
+                .send("{\"name\":\"FOO\"}");
+
+        assertThat(httpRequest.code()).isEqualTo(200);
+        assertThat(httpRequest.location()).isEqualTo(server.getServer().baseUrl()+"/api/headers/foos/123456");
+    }
+
+    @Test
+    public void should_return_location_header_with_base_uri() throws Exception {
+        HttpRequest httpRequest = server.client().authenticatedAs("admin")
+                .POST("/api/headers/foos2")
+                .send("{\"name\":\"FOO\"}");
+
+        assertThat(httpRequest.code()).isEqualTo(200);
+        assertThat(httpRequest.location()).isEqualTo(server.getServer().baseUrl()+"/api/headers/foos2/123456");
+    }
 }


### PR DESCRIPTION
This PR is intended to provide some better response header management (see #101)

3 bigs improvements are concerned by this pull request :

## 1/ Endpoint methods annotation are now described in generated Router's `OperationDescription`

This is something which will bring a lot of flexibility in `RestxFilter` API : in this API, we will be able to have access to `StdEntityRoute.describe()` method allowing to retrieve annotation metadata AT RUNTIME.

It means that if you want to create your own endpoint annotation, you will then be able to implement a `RestxFilter` handling it at runtime.

Have a look at the `ExpiresHeaderFilter` for an example of doing such custom annotation handling.

## 2/ 2 new Headers annotations have been provided in core : `@ExpiresAfter` and `@LocationHeader`

Both annotations are handled as described before :
- A new annotation is made available
- A new `RestxFilter` (subclassing `EntityRelatedFilter` for simpler implementation) is provided allowing to add some behaviour on endpoints having the new annotation

Examples of usages for these annotations can be seen in `HeadersResource` :
```
    @GET("/expires")
    @ExpiresAfter("2d 4h")
    public String expireHeader() {
        return "hello";
    }

    @POST("/foos")
    @LocationHeader("{_currentUri_}/{id}")
    public Foo locationHeader(Foo foo) {
        foo.setId("123456");
        return foo;
    }

    @POST("/foos2")
    @LocationHeader("{_baseUri_}/headers/foos2/{id}")
    public Foo locationHeader2(Foo foo) {
        foo.setId("123456");
        return foo;
    }
```

## 3/ `RestxResponse` can now be inject as `@Param(kind=Kind.CONTEXT value="response")` parameter

This is clearly NOT an encouraged way to handle headers, as you may quickly reach limitations to manipulate response directly in your code.
The preferred way is to implement your own annotation and create your own `RestxFilter` describing behaviour for it.

Particularly, you're tainting your endpoint implementation with restx-specific API, which may be unwanted in terms of framework adherence.

Anyway, it may solve some unforeseen corner cases.