### PR TITLE
Handling annotations metadata generation unsupported cases

### DIFF
--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -170,7 +170,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
                 return PRIMITIVE;
             } else if(String.class.getCanonicalName().equals(componentType.toString())) {
                 return STRING;
-            } else if(Class.class.getCanonicalName().equals(componentType.toString())) {
+            } else if(Class.class.getCanonicalName().equals(TypeHelper.rawTypeFrom(componentType.toString()))) {
                 return CLASS;
             } else {
                 ImmutableList<String> superTypesClassNames = FluentIterable.from(processingEnv.getTypeUtils().directSupertypes(componentType))

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -633,7 +633,10 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
             if(AnnotationFieldKind.ANNOTATION.equals(this.kind)) {
                 return "throw new java.lang.UnsupportedOperationException(\"Unsupported annotation field type\")";
             } else if(isArray) {
-                return String.format("return new %s[]{ %s }", type, Joiner.on(", ").join((List)value));
+                return String.format("return new %s[]{ %s }",
+                        // Arrays cannot be parameterized
+                        TypeHelper.rawTypeFrom(type.toString()),
+                        Joiner.on(", ").join((List)value));
             } else {
                 return "return "+kind.transformSingleValueToExpression(value, this);
             }

--- a/restx-samplest/src/main/java/samplest/annotations/MyAnnotation.java
+++ b/restx-samplest/src/main/java/samplest/annotations/MyAnnotation.java
@@ -33,6 +33,7 @@ public @interface MyAnnotation {
 
     String[] severalStrings();
     Class[] severalClasses();
+    Class<? extends Number>[] severalParameterizedTypeClasses();
     MyEnum[] severalEnums();
 
     MyNestedAnnotation[] severalAnnotations();

--- a/restx-samplest/src/main/java/samplest/annotations/MyAnnotation.java
+++ b/restx-samplest/src/main/java/samplest/annotations/MyAnnotation.java
@@ -16,6 +16,7 @@ public @interface MyAnnotation {
     // Complex types
     String aString();
     Class aClass();
+    Class<? extends Number> aParameterizedTypeClass();
     MyEnum anEnum();
 
     // Another annotation

--- a/restx-samplest/src/main/java/samplest/annotations/MyAnnotation.java
+++ b/restx-samplest/src/main/java/samplest/annotations/MyAnnotation.java
@@ -4,37 +4,40 @@ package samplest.annotations;
 // (https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.6.1)
 public @interface MyAnnotation {
     // primitive types
-    byte aByte();
-    short aShort();
-    int anInt();
-    long aLong();
-    float aFloat();
-    double aDouble();
-    boolean aBool();
-    char aChar();
+    byte aByte() default 121;
+    short aShort() default 321;
+    int anInt() default 321;
+    long aLong() default 321;
+    float aFloat() default 564.321f;
+    double aDouble() default 564.321;
+    boolean aBool() default false;
+    char aChar() default 'B';
 
     // Complex types
-    String aString();
-    Class aClass();
-    Class<? extends Number> aParameterizedTypeClass();
-    MyEnum anEnum();
+    String aString() default "BBB";
+    Class aClass() default String.class;
+    Class<? extends Number> aParameterizedTypeClass() default Integer.class;
+    MyEnum anEnum() default MyEnum.B;
 
     // Another annotation
-    MyNestedAnnotation anAnnotation();
+    MyNestedAnnotation anAnnotation() default @MyNestedAnnotation({ "AAA" });
 
-    byte[] severalBytes();
-    short[] severalShorts();
-    int[] severalInts();
-    long[] severalLongs();
-    float[] severalFloats();
-    double[] severalDoubles();
-    boolean[] severalBools();
-    char[] severalChars();
+    byte[] severalBytes() default { 121, 121 };
+    short[] severalShorts() default { 654, 321 };
+    int[] severalInts() default { 654, 321 };
+    long[] severalLongs() default { 654, 321 };
+    float[] severalFloats() default { 654.321f, 123.456f};
+    double[] severalDoubles() default { 654.321, 123.456};
+    boolean[] severalBools() default { false, true };
+    char[] severalChars() default { 'C', 'B', 'A' };
 
-    String[] severalStrings();
-    Class[] severalClasses();
-    Class<? extends Number>[] severalParameterizedTypeClasses();
-    MyEnum[] severalEnums();
+    String[] severalStrings() default { "CCC", "BBB", "AAA" };
+    Class[] severalClasses() default { String.class, Integer.class };
+    Class<? extends Number>[] severalParameterizedTypeClasses() default { Integer.class, Long.class, Double.class };
+    MyEnum[] severalEnums() default { MyEnum.B, MyEnum.A };
 
-    MyNestedAnnotation[] severalAnnotations();
+    MyNestedAnnotation[] severalAnnotations() default {
+            @MyNestedAnnotation(value={ "AAA", "CCC" }),
+            @MyNestedAnnotation(value={ "BBB", "DDD" })
+    };
 }

--- a/restx-samplest/src/main/java/samplest/core/CoreResource.java
+++ b/restx-samplest/src/main/java/samplest/core/CoreResource.java
@@ -91,6 +91,7 @@ public class CoreResource {
 
             severalStrings={ "AAA{\\\"'$AA", "BBB", "CCC" },
             severalClasses={ Integer.class, String.class },
+            severalParameterizedTypeClasses={ Integer.class, Short.class },
             severalEnums={ MyEnum.A, MyEnum.B },
 
             // Not supported (yet)

--- a/restx-samplest/src/main/java/samplest/core/CoreResource.java
+++ b/restx-samplest/src/main/java/samplest/core/CoreResource.java
@@ -103,4 +103,10 @@ public class CoreResource {
     public String testingAnnotations() {
         return "hello blah";
     }
+
+    @GET("/testingAnnotationsWithDefaultValues")
+    @MyAnnotation
+    public String testingAnnotationsWithDefaultValues() {
+        return "hello blah";
+    }
 }

--- a/restx-samplest/src/main/java/samplest/core/CoreResource.java
+++ b/restx-samplest/src/main/java/samplest/core/CoreResource.java
@@ -73,6 +73,7 @@ public class CoreResource {
             // Complex types
             aString="AAA{\\\"'$AA",
             aClass=CoreResource.class,
+            aParameterizedTypeClass=Long.class,
             anEnum=MyEnum.A,
 
             // Another annotation


### PR DESCRIPTION
0.35 has introduced a new feature allowing to provide endpoint annotation metadata on `RestxResource`s

However, some special cases are not currently handled by annotation processor and result into compilation errors in generated code.

This PR aims at fixing these special cases, particularly :
- Annotation values having a `default` value defined, and relying upon this default value on its declaration (I mean, not re-defining this value when declaring the annotation), for instance :
```
public @interface MyAnnotation {
    int anInt() default 321;
    String aString() default "BBB";
    Class aClass() default String.class;
}
```
   ... then used that way :
```
@RestxResource("/core") @Component
public class CoreResource {
    @GET("/testingAnnotationsWithDefaultValues")
    @MyAnnotation // Relying upon at least 1 default value here
    public String testingAnnotationsWithDefaultValues() {
        return "hello blah";
    }
}
```
- Annotation values having `Parameterized` types : the only case I identified is having an annotation field of type `Class<WhateverHere>`, for instance :
```
public @interface MyAnnotation {
    Class<? extends Number> aParameterizedTypeClass();
}
```
- Annotation values having a `Parameterized` array type : here again, the only case I identified is having an annotation field of type `Class<WhateverHere>[]` (but implementation should not be `Class`-specific), for instance :
```
public @interface MyAnnotation {
    Class<? extends Number>[] severalParameterizedTypeClasses();
}
```
