### PR TITLE
Configuring type descriptors in service loaders

### DIFF
--- a/restx-classloader/src/main/java/restx/classloader/processor/ColdClassesAnnotationProcessor.java
+++ b/restx-classloader/src/main/java/restx/classloader/processor/ColdClassesAnnotationProcessor.java
@@ -31,6 +31,7 @@ public class ColdClassesAnnotationProcessor extends RestxAbstractProcessor {
 	private final ColdClassesAnnotationProcessor.ColdClassesDeclaration coldClassesDeclaration;
 
 	public ColdClassesAnnotationProcessor() {
+		super();
 		this.coldClassesDeclaration = new ColdClassesDeclaration();
 	}
 

--- a/restx-common/src/main/java/restx/common/AggregateType.java
+++ b/restx-common/src/main/java/restx/common/AggregateType.java
@@ -1,66 +1,83 @@
 package restx.common;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
 
-import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
+import java.lang.reflect.Array;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Created by fcamblor on 13/05/16.
  */
-public enum AggregateType {
-    ITERABLE() {
+public interface AggregateType {
+    class ITERABLE implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
-            return matchesParameterizedFQCN(Iterable.class, fqcn);
+            return Types.matchesParameterizedFQCN(Iterable.class, fqcn);
         }
 
         @Override
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return values;
         }
-    },
-    LIST() {
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Collections.emptyList();
+        }
+    }
+    class LIST implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
-            return matchesParameterizedFQCN(List.class, fqcn);
+            return Types.matchesParameterizedFQCN(List.class, fqcn);
         }
 
         @Override
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return values;
         }
-    },
-    SET() {
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Collections.emptyList();
+        }
+    }
+    class SET implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
-            return matchesParameterizedFQCN(Set.class, fqcn);
+            return Types.matchesParameterizedFQCN(Set.class, fqcn);
         }
 
         @Override
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return Sets.newHashSet(values);
         }
-    },
-    COLLECTION() {
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Collections.emptySet();
+        }
+    }
+    class COLLECTION implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
-            return matchesParameterizedFQCN(Collection.class, fqcn);
+            return Types.matchesParameterizedFQCN(Collection.class, fqcn);
         }
 
         @Override
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return values;
         }
-    },
-    ARRAY() {
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Collections.emptySet();
+        }
+    }
+    class ARRAY implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
             return fqcn.endsWith("[]");
@@ -70,36 +87,15 @@ public enum AggregateType {
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return values.toArray(ObjectArrays.newArray(itemClass, values.size()));
         }
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Array.newInstance(itemClass, 0);
+        }
     };
 
-    public static Optional<AggregateType> fromType(String fqcn) {
-        for(AggregateType aggregateType : values()){
-            if(aggregateType.isApplicableTo(fqcn)) {
-                return Optional.of(aggregateType);
-            }
-        }
 
-        return Optional.absent();
-    }
-
-    public abstract boolean isApplicableTo(String fqcn);
-    public abstract <T> Object createFrom(List values, Class<T> itemClass);
-
-    protected static boolean matchesParameterizedFQCN(Class c, String fqcn) {
-        return fqcn.startsWith(c.getCanonicalName());
-    }
-
-    public static boolean isAggregate(String fqcn) {
-        return fromType(fqcn).isPresent();
-    }
-
-    public static Class aggregatedTypeOf(Type type) {
-        if(type instanceof ParameterizedType) {
-            return (Class)((ParameterizedType)type).getActualTypeArguments()[0];
-        } else if(type instanceof Class && ((Class)type).isArray()){
-            return ((Class)type).getComponentType();
-        } else {
-            throw new IllegalArgumentException("Call to aggregatedTypeOf() is not supported for type : "+type);
-        }
-    }
+    boolean isApplicableTo(String fqcn);
+    <T> Object createFrom(List values, Class<T> itemClass);
+    <T> Object immutableEmptyInstance(Class<T> itemClass);
 }

--- a/restx-common/src/main/java/restx/common/Types.java
+++ b/restx-common/src/main/java/restx/common/Types.java
@@ -8,12 +8,14 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
+import restx.types.AggregateType;
 
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import java.lang.reflect.*;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 /**
  * Date: 23/10/13
@@ -21,13 +23,10 @@ import java.util.Map;
  */
 public class Types {
 
-	public static final ImmutableList<AggregateType> DECLARED_AGGREGATED_TYPES = ImmutableList.of(
-			new AggregateType.ITERABLE(),
-			new AggregateType.ARRAY(),
-			new AggregateType.COLLECTION(),
-			new AggregateType.LIST(),
-			new AggregateType.SET()
-	);
+	public static final ImmutableList<AggregateType> DECLARED_AGGREGATED_TYPES;
+	static {
+		DECLARED_AGGREGATED_TYPES = ImmutableList.copyOf(ServiceLoader.load(AggregateType.class));
+	}
 
     public static ParameterizedType newParameterizedType(final Class<?> rawType, final Type... arguments) {
         return new ParameterizedType() {

--- a/restx-common/src/main/java/restx/common/processor/RestxAbstractProcessor.java
+++ b/restx-common/src/main/java/restx/common/processor/RestxAbstractProcessor.java
@@ -33,6 +33,15 @@ import java.util.Set;
  * Time: 07:50
  */
 public abstract class RestxAbstractProcessor extends AbstractProcessor {
+
+	protected RestxAbstractProcessor() {
+		// Updating current thread's context classloader in order to have
+		// ServiceLoader.load() calls rely on it instead of default classloader during annotation processing
+		// See https://stackoverflow.com/questions/45061170/using-serviceloader-within-an-annotation-processor
+		// This will be particularly useful when calling Types.* utility methods
+		Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+	}
+
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         try {

--- a/restx-common/src/main/java/restx/types/AggregateType.java
+++ b/restx-common/src/main/java/restx/types/AggregateType.java
@@ -1,7 +1,8 @@
-package restx.common;
+package restx.types;
 
 import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
+import restx.common.Types;
 
 import java.lang.reflect.Array;
 import java.util.Collection;

--- a/restx-common/src/main/java/restx/types/AggregateType.java
+++ b/restx-common/src/main/java/restx/types/AggregateType.java
@@ -2,7 +2,6 @@ package restx.types;
 
 import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
-import restx.common.Types;
 
 import java.lang.reflect.Array;
 import java.util.Collection;

--- a/restx-common/src/main/java/restx/types/OptionalTypeDefinition.java
+++ b/restx-common/src/main/java/restx/types/OptionalTypeDefinition.java
@@ -1,0 +1,91 @@
+package restx.types;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Optional;
+
+import java.util.regex.Pattern;
+
+public interface OptionalTypeDefinition {
+    class Matcher {
+        private final boolean isOptionalType;
+        private final String underlyingType;
+        private final Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+        private final Function<String, String> fromNullableExpressionTransformer;
+
+        public Matcher(boolean isOptionalType, String underlyingType,
+                       Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer,
+                       Function<String, String> fromNullableExpressionTransformer) {
+
+            this.isOptionalType = isOptionalType;
+            this.underlyingType = underlyingType;
+            this.currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer = currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+            this.fromNullableExpressionTransformer = fromNullableExpressionTransformer;
+        }
+
+        public boolean isOptionalType() {
+            return isOptionalType;
+        }
+
+        public String getUnderlyingType() {
+            return underlyingType;
+        }
+
+        public Function<String, String> getCurrentOptionalExpressionToGuavaOptionalCodeExpressionTransformer() {
+            return currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+        }
+
+        public Function<String, String> getFromNullableExpressionTransformer() {
+            return fromNullableExpressionTransformer;
+        }
+
+        public static Matcher notOptional(String underlyingType) {
+            return new Matcher(false, underlyingType, null, null);
+        }
+        public static Matcher optionalOf(String underlyingType,
+                                         Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer,
+                                         Function<String, String> fromNullableExpressionTransformer) {
+            return new Matcher(true, underlyingType, currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer, fromNullableExpressionTransformer);
+        }
+    }
+
+    Matcher matches(String type);
+
+    abstract class ClassBasedOptionalTypeDefinition implements OptionalTypeDefinition {
+        private final Pattern optionalRegex;
+        private final Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+        private final Function<String, String> fromNullableExpressionTransformer;
+
+        protected ClassBasedOptionalTypeDefinition(
+                Class clazz,
+                Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer,
+                Function<String, String> fromNullableExpressionTransformer) {
+
+            this.optionalRegex = Pattern.compile("\\Q" + clazz.getName() + "<\\E(.+)>");
+            this.currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer = currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+            this.fromNullableExpressionTransformer = fromNullableExpressionTransformer;
+        }
+
+        public Matcher matches(String type) {
+            java.util.regex.Matcher matcher = this.optionalRegex.matcher(type);
+            if(matcher.matches()) {
+                return Matcher.optionalOf(matcher.group(1), this.currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer, this.fromNullableExpressionTransformer);
+            } else {
+                return Matcher.notOptional(type);
+            }
+        }
+    }
+
+    class GUAVA extends ClassBasedOptionalTypeDefinition {
+        private static final Function<String, String> FROM_NULLABLE_EXPRESSION_TRANSFORMER = new Function<String, String>() {
+            @Override
+            public String apply(String expression) {
+                return "Optional.fromNullable(" + expression + ")";
+            }
+        };
+
+        public GUAVA() {
+            super(Optional.class, Functions.<String>identity(), FROM_NULLABLE_EXPRESSION_TRANSFORMER);
+        }
+    }
+}

--- a/restx-common/src/main/java/restx/types/RawTypesDefinition.java
+++ b/restx-common/src/main/java/restx/types/RawTypesDefinition.java
@@ -1,0 +1,102 @@
+package restx.types;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.joda.time.*;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import java.io.File;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public interface RawTypesDefinition {
+    boolean accepts(Type type);
+    boolean accepts(TypeMirror type, ProcessingEnvironment processingEnvironment);
+
+    class ClassBasedRawTypesDefinition implements RawTypesDefinition {
+        final ImmutableList<Class> acceptableClasses;
+        ImmutableList<TypeMirror> acceptableTypeMirrors = null;
+
+        public ClassBasedRawTypesDefinition(Class... acceptableClasses) {
+            this.acceptableClasses = ImmutableList.copyOf(acceptableClasses);
+        }
+
+        @Override
+        public boolean accepts(final Type type) {
+            if(!(type instanceof Class)) {
+                return false;
+            }
+
+            return Iterables.tryFind(acceptableClasses, new Predicate<Class>() {
+                @Override
+                public boolean apply(Class clazz) {
+                    return clazz.isAssignableFrom((Class)type);
+                }
+            }).isPresent();
+        }
+
+        @Override
+        public boolean accepts(final TypeMirror type, final ProcessingEnvironment processingEnvironment) {
+            if(acceptableTypeMirrors == null) {
+                this.acceptableTypeMirrors = ImmutableList.copyOf(Lists.transform(acceptableClasses, new Function<Class, TypeMirror>() {
+                    @Override
+                    public TypeMirror apply(Class input) {
+                        if(input.isPrimitive()) {
+                            return processingEnvironment.getTypeUtils().getPrimitiveType(TypeKind.valueOf(input.toString().toUpperCase()));
+                        } else {
+                            return processingEnvironment.getElementUtils().getTypeElement(input.getCanonicalName()).asType();
+                        }
+                    }
+                }));
+            }
+
+            return Iterables.tryFind(acceptableTypeMirrors, new Predicate<TypeMirror>() {
+                @Override
+                public boolean apply(TypeMirror acceptableTypeMirror) {
+                    return processingEnvironment.getTypeUtils().isAssignable(acceptableTypeMirror, type);
+                }
+            }).isPresent();
+        }
+    }
+
+    class PrimitiveRawTypesDefinition extends ClassBasedRawTypesDefinition {
+        public PrimitiveRawTypesDefinition() {
+            super(
+                    byte.class, short.class, int.class, long.class, float.class, double.class, boolean.class, char.class,
+                    Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Character.class
+            );
+        }
+    }
+    class CommonJDKRawTypesDefinition extends ClassBasedRawTypesDefinition {
+        public CommonJDKRawTypesDefinition() {
+            super(
+                    String.class, Class.class, Enum.class, File.class, BigDecimal.class, BigInteger.class,
+                    Currency.class, Date.class, Locale.class, TimeZone.class, UUID.class, Charset.class, Path.class,
+                    Pattern.class, URI.class, URL.class
+            );
+        }
+    }
+    class JodaTimeRawTypesDefinition extends ClassBasedRawTypesDefinition {
+        public JodaTimeRawTypesDefinition() {
+            super(
+                    DateTime.class, Instant.class, LocalDate.class, LocalDateTime.class, LocalTime.class, DateTimeZone.class
+            );
+        }
+    }
+}

--- a/restx-common/src/main/java/restx/types/TypeReference.java
+++ b/restx-common/src/main/java/restx/types/TypeReference.java
@@ -1,4 +1,4 @@
-package restx.common;
+package restx.types;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;

--- a/restx-common/src/main/java/restx/types/Types.java
+++ b/restx-common/src/main/java/restx/types/Types.java
@@ -23,8 +23,10 @@ import java.util.ServiceLoader;
 public class Types {
 
 	public static final ImmutableList<AggregateType> DECLARED_AGGREGATED_TYPES;
+	public static final ImmutableList<OptionalTypeDefinition> DECLARED_OPTIONAL_TYPES;
 	static {
 		DECLARED_AGGREGATED_TYPES = ImmutableList.copyOf(ServiceLoader.load(AggregateType.class));
+		DECLARED_OPTIONAL_TYPES = ImmutableList.copyOf(ServiceLoader.load(OptionalTypeDefinition.class));
 	}
 
     public static ParameterizedType newParameterizedType(final Class<?> rawType, final Type... arguments) {
@@ -263,5 +265,17 @@ public class Types {
 	}
 	public static boolean isAggregateType(String fqcn) {
 		return aggregateTypeFrom(fqcn).isPresent();
+	}
+
+	public static OptionalTypeDefinition.Matcher optionalMatchingTypeOf(String fqcn) {
+		OptionalTypeDefinition.Matcher lastMatcher = null;
+		for(OptionalTypeDefinition optionalDefinition: DECLARED_OPTIONAL_TYPES) {
+			lastMatcher = optionalDefinition.matches(fqcn);
+			if(lastMatcher.isOptionalType()) {
+				return lastMatcher;
+			}
+		}
+
+		return lastMatcher;
 	}
 }

--- a/restx-common/src/main/java/restx/types/Types.java
+++ b/restx-common/src/main/java/restx/types/Types.java
@@ -1,4 +1,4 @@
-package restx.common;
+package restx.types;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -8,7 +8,6 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import restx.types.AggregateType;
 
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;

--- a/restx-common/src/main/java/restx/types/Types.java
+++ b/restx-common/src/main/java/restx/types/Types.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
@@ -24,9 +25,11 @@ public class Types {
 
 	public static final ImmutableList<AggregateType> DECLARED_AGGREGATED_TYPES;
 	public static final ImmutableList<OptionalTypeDefinition> DECLARED_OPTIONAL_TYPES;
+	public static final ImmutableList<RawTypesDefinition> DECLARED_RAW_TYPES_DEFINITIONS;
 	static {
 		DECLARED_AGGREGATED_TYPES = ImmutableList.copyOf(ServiceLoader.load(AggregateType.class));
 		DECLARED_OPTIONAL_TYPES = ImmutableList.copyOf(ServiceLoader.load(OptionalTypeDefinition.class));
+		DECLARED_RAW_TYPES_DEFINITIONS = ImmutableList.copyOf(ServiceLoader.load(RawTypesDefinition.class));
 	}
 
     public static ParameterizedType newParameterizedType(final Class<?> rawType, final Type... arguments) {
@@ -277,5 +280,23 @@ public class Types {
 		}
 
 		return lastMatcher;
+	}
+
+	public static boolean isRawType(Type type) {
+		for (RawTypesDefinition rawTypesDefinition : DECLARED_RAW_TYPES_DEFINITIONS) {
+			if (rawTypesDefinition.accepts(type)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public static boolean isRawType(TypeMirror type, ProcessingEnvironment processingEnvironment) {
+		for (RawTypesDefinition rawTypesDefinition : DECLARED_RAW_TYPES_DEFINITIONS) {
+			if (rawTypesDefinition.accepts(type, processingEnvironment)) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/restx-common/src/main/resources/META-INF/services/restx.types.AggregateType
+++ b/restx-common/src/main/resources/META-INF/services/restx.types.AggregateType
@@ -1,0 +1,5 @@
+restx.types.AggregateType$ITERABLE
+restx.types.AggregateType$LIST
+restx.types.AggregateType$SET
+restx.types.AggregateType$COLLECTION
+restx.types.AggregateType$ARRAY

--- a/restx-common/src/main/resources/META-INF/services/restx.types.OptionalTypeDefinition
+++ b/restx-common/src/main/resources/META-INF/services/restx.types.OptionalTypeDefinition
@@ -1,0 +1,1 @@
+restx.types.OptionalTypeDefinition$GUAVA

--- a/restx-common/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
+++ b/restx-common/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
@@ -1,0 +1,3 @@
+restx.types.RawTypesDefinition$PrimitiveRawTypesDefinition
+restx.types.RawTypesDefinition$CommonJDKRawTypesDefinition
+restx.types.RawTypesDefinition$JodaTimeRawTypesDefinition

--- a/restx-common/src/test/java/restx/common/TypesTest.java
+++ b/restx-common/src/test/java/restx/common/TypesTest.java
@@ -1,6 +1,6 @@
 package restx.common;
 
-import static restx.common.Types.isAssignableFrom;
+import static restx.types.Types.isAssignableFrom;
 
 
 import com.google.common.collect.ImmutableList;
@@ -8,6 +8,8 @@ import com.google.common.collect.ImmutableMap;
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.Rule;
 import org.junit.Test;
+import restx.types.TypeReference;
+import restx.types.Types;
 
 import java.util.AbstractList;
 import java.util.AbstractMap;

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
@@ -22,9 +22,8 @@ public class ParameterExpressionBuilder {
     public ParameterExpressionBuilder surroundWithCheckValid(
             RestxAnnotationProcessor.ResourceMethodParameter parameter) {
 
-        boolean isOptionalType = parameter.guavaOptional || parameter.java8Optional;
         // If we don't have any optional type, we should check for non nullity *before* calling checkValid()
-        if(!isOptionalType) {
+        if(!parameter.optionalTypeMatcher.isOptionalType()) {
             // In case we're on an aggregate interface, parameterExpr will always return a non-null value
             // (see createFromMapQueryObjectFromRequest() method) so we don't need to add checkNotNull() check on this
             if(Types.isAggregateType(parameter.type)) {
@@ -46,16 +45,8 @@ public class ParameterExpressionBuilder {
                 validationGroupsExpr.isPresent()?","+validationGroupsExpr.get():""
         );
 
-        if(parameter.guavaOptional) {
-            this.parameterExpr = String.format(
-                    "Optional.fromNullable(%s)",
-                    this.parameterExpr
-            );
-        } else if(parameter.java8Optional) {
-            this.parameterExpr = String.format(
-                    "java.util.Optional.ofNullable(%s)",
-                    this.parameterExpr
-            );
+        if(parameter.optionalTypeMatcher.isOptionalType()) {
+            this.parameterExpr = parameter.optionalTypeMatcher.getFromNullableExpressionTransformer().apply(this.parameterExpr);
         }
 
         return this;

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
@@ -1,7 +1,7 @@
 package restx.annotations.processor;
 
 import com.google.common.base.Optional;
-import restx.common.Types;
+import restx.types.Types;
 import restx.endpoint.EndpointParameterKind;
 
 /**

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
@@ -1,13 +1,8 @@
 package restx.annotations.processor;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.base.Optional;
-import restx.common.AggregateType;
+import restx.common.Types;
 import restx.endpoint.EndpointParameterKind;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author fcamblor
@@ -24,20 +19,6 @@ public class ParameterExpressionBuilder {
         this.kind = kind;
     }
 
-    private static final Map<AggregateType, Function<String, String>> EMPTY_AGGREGATE_FUNCTIONS = new HashMap<AggregateType, Function<String, String>>(){{
-        // These (Function) casts are ugly, I know, but read https://github.com/google/guava/issues/1927
-        put(AggregateType.ITERABLE, (Function) Functions.constant("EMPTY_ITERABLE_SUPPLIER"));
-        put(AggregateType.LIST, (Function) Functions.constant("EMPTY_LIST_SUPPLIER"));
-        put(AggregateType.SET, (Function) Functions.constant("EMPTY_SET_SUPPLIER"));
-        put(AggregateType.COLLECTION, (Function) Functions.constant("EMPTY_COLLECTION_SUPPLIER"));
-        put(AggregateType.ARRAY, new Function<String, String>() {
-            @Override
-            public String apply(String fqcn) {
-                return "Suppliers.ofInstance(new "+fqcn+"{})";
-            }
-        });
-    }};
-
     public ParameterExpressionBuilder surroundWithCheckValid(
             RestxAnnotationProcessor.ResourceMethodParameter parameter) {
 
@@ -46,7 +27,7 @@ public class ParameterExpressionBuilder {
         if(!isOptionalType) {
             // In case we're on an aggregate interface, parameterExpr will always return a non-null value
             // (see createFromMapQueryObjectFromRequest() method) so we don't need to add checkNotNull() check on this
-            if(AggregateType.isAggregate(parameter.type)) {
+            if(Types.isAggregateType(parameter.type)) {
             } else {
                 // If not an iterable type, ensuring target value is set
                 this.parameterExpr = String.format(
@@ -92,25 +73,12 @@ public class ParameterExpressionBuilder {
             RestxAnnotationProcessor.ResourceMethodParameter parameter,
             EndpointParameterKind kind){
 
-        // We should check if target type is an iterable interface : in that case, we should
-        // instantiate an empty iterable instead of null value if data is missing in request
-        Optional<AggregateType> aggregateType = AggregateType.fromType(parameter.type);
-        String emptySupplierParam = "";
-        if(aggregateType.isPresent()) {
-            Function<String, String> fqcnToEmptyAggregateTransformer = EMPTY_AGGREGATE_FUNCTIONS.get(aggregateType.get());
-            if(fqcnToEmptyAggregateTransformer == null) {
-                throw new IllegalStateException("Missing EMPTY_AGGREGATE_FUNCTIONS entry for aggregate type "+aggregateType.get().name());
-            }
-            emptySupplierParam = ", "+fqcnToEmptyAggregateTransformer.apply(parameter.type);
-        }
-
         return new ParameterExpressionBuilder(String.format(
-            "%smapQueryObjectFromRequest(%s.class, \"%s\", request, match, EndpointParameterKind.%s%s)",
+            "%smapQueryObjectFromRequest(%s.class, \"%s\", request, match, EndpointParameterKind.%s)",
             TypeHelper.isParameterizedType(parameter.type)?"("+parameter.type+")":"",
             TypeHelper.rawTypeFrom(parameter.type),
             parameter.reqParamName,
-            kind.name(),
-            emptySupplierParam
+            kind.name()
         ), kind.name());
     }
 }

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -57,6 +57,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
     };
 
     public RestxAnnotationProcessor() {
+        super();
         routerTpl = Mustaches.compile(RestxAnnotationProcessor.class, "RestxRouter.mustache");
     }
 

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/TypeHelper.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/TypeHelper.java
@@ -2,15 +2,12 @@ package restx.annotations.processor;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Date: 23/10/13
@@ -23,8 +20,6 @@ public class TypeHelper {
             Iterable.class.getCanonicalName(), "LIST",
             List.class.getCanonicalName(), "LIST",
             Map.class.getCanonicalName(), "MAP");
-    private static Pattern guavaOptionalPattern = Pattern.compile("\\Q" + Optional.class.getName() + "<\\E(.+)>");
-    private static Pattern java8OptionalPattern = Pattern.compile("\\Qjava.util.Optional<\\E(.+)>");
     private static Set<String> RAW_TYPES_STR = Sets.newHashSet("byte", "short", "int", "long", "float", "double", "boolean", "char");
 
     private static class ParsedType {
@@ -150,51 +145,4 @@ public class TypeHelper {
     static String getTypeReferenceExpressionFor(String type) {
         return RAW_TYPES_STR.contains(type) ? type + ".class" : "new TypeReference<" + type + ">(){}";
     }
-
-    public static class OptionalMatchingType {
-        public enum Type {GUAVA, JAVA8, NONE}
-
-        private final Type optionalType;
-        private final String underlyingType;
-
-        protected OptionalMatchingType(Type optionalType, String underlyingType) {
-            this.optionalType = optionalType;
-            this.underlyingType = underlyingType;
-        }
-
-        public static OptionalMatchingType guava(String underlyingType) {
-            return new OptionalMatchingType(Type.GUAVA, underlyingType);
-        }
-
-        public static OptionalMatchingType java8(String underlyingType) {
-            return new OptionalMatchingType(Type.JAVA8, underlyingType);
-        }
-
-        public static OptionalMatchingType none(String underlyingType) {
-            return new OptionalMatchingType(Type.NONE, underlyingType);
-        }
-
-        public Type getOptionalType() {
-            return optionalType;
-        }
-
-        public String getUnderlyingType() {
-            return underlyingType;
-        }
-    }
-
-    public static OptionalMatchingType optionalMatchingTypeOf(String type) {
-        Matcher guavaOptionalMatcher = guavaOptionalPattern.matcher(type);
-        if (guavaOptionalMatcher.matches()) {
-            return OptionalMatchingType.guava(guavaOptionalMatcher.group(1));
-        }
-
-        Matcher java8OptionalMatcher = java8OptionalPattern.matcher(type);
-        if (java8OptionalMatcher.matches()) {
-            return OptionalMatchingType.java8(java8OptionalMatcher.group(1));
-        }
-
-        return OptionalMatchingType.none(type);
-    }
-
 }

--- a/restx-core-annotation-processor/src/main/java/restx/exceptions/processor/ErrorAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/exceptions/processor/ErrorAnnotationProcessor.java
@@ -33,6 +33,7 @@ public class ErrorAnnotationProcessor extends RestxAbstractProcessor {
     final Template errorDescriptorTpl;
 
     public ErrorAnnotationProcessor() {
+        super();
         errorDescriptorTpl = Mustaches.compile(ErrorAnnotationProcessor.class, "ErrorDescriptor.mustache");
     }
 

--- a/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
+++ b/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
@@ -8,8 +8,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
-import restx.common.Types;
-import restx.common.TypeReference;
+import restx.types.Types;
+import restx.types.TypeReference;
 import restx.*;
 import restx.entity.*;
 import restx.http.*;

--- a/restx-core-java8/src/main/java/restx/types/JDK8OptionalTypeDefinition.java
+++ b/restx-core-java8/src/main/java/restx/types/JDK8OptionalTypeDefinition.java
@@ -1,0 +1,25 @@
+package restx.types;
+
+import com.google.common.base.Function;
+
+import java.util.Optional;
+
+public class JDK8OptionalTypeDefinition extends OptionalTypeDefinition.ClassBasedOptionalTypeDefinition {
+
+    private static final Function<String, String> JDK8_OPTIONAL_EXPRESSION_TO_GUAVA_OPTIONAL_CODE_EXPRESSION = new Function<String, String>() {
+        @Override
+        public String apply(String currentOptionalCodeExpression) {
+            return "Optional.fromNullable(" + currentOptionalCodeExpression + ".orElse(null))";
+        }
+    };
+    private static final Function<String, String> FROM_NULLABLE_EXPRESSION_TRANSFORMER = new Function<String, String>() {
+        @Override
+        public String apply(String expression) {
+            return "java.util.Optional.ofNullable(" + expression + ")";
+        }
+    };
+
+    public JDK8OptionalTypeDefinition() {
+        super(Optional.class, JDK8_OPTIONAL_EXPRESSION_TO_GUAVA_OPTIONAL_CODE_EXPRESSION, FROM_NULLABLE_EXPRESSION_TRANSFORMER);
+    }
+}

--- a/restx-core-java8/src/main/java/restx/types/JDK8RawTypesDefinition.java
+++ b/restx-core-java8/src/main/java/restx/types/JDK8RawTypesDefinition.java
@@ -1,0 +1,12 @@
+package restx.types;
+
+import java.time.*;
+
+public class JDK8RawTypesDefinition extends RawTypesDefinition.ClassBasedRawTypesDefinition {
+    public JDK8RawTypesDefinition() {
+        super(
+                Instant.class, DayOfWeek.class, LocalDate.class, LocalDateTime.class, LocalTime.class,
+                Month.class, Year.class, ZoneId.class
+        );
+    }
+}

--- a/restx-core-java8/src/main/resources/META-INF/services/restx.types.OptionalTypeDefinition
+++ b/restx-core-java8/src/main/resources/META-INF/services/restx.types.OptionalTypeDefinition
@@ -1,0 +1,1 @@
+restx.types.JDK8OptionalTypeDefinition

--- a/restx-core-java8/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
+++ b/restx-core-java8/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
@@ -1,0 +1,1 @@
+restx.types.JDK8RawTypesDefinition

--- a/restx-core/src/main/java/restx/endpoint/EndpointParamDef.java
+++ b/restx-core/src/main/java/restx/endpoint/EndpointParamDef.java
@@ -1,7 +1,7 @@
 package restx.endpoint;
 
 import java.util.Objects;
-import restx.common.TypeReference;
+import restx.types.TypeReference;
 import restx.factory.ParamDef;
 
 /**

--- a/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
@@ -6,7 +6,7 @@ import com.google.common.collect.FluentIterable;
 import restx.RestxRequest;
 import restx.RestxRequestMatch;
 import restx.common.Types;
-import restx.common.AggregateType;
+import restx.types.AggregateType;
 import restx.endpoint.EndpointParamDef;
 import restx.endpoint.EndpointParameterKind;
 import restx.factory.Component;

--- a/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
@@ -5,6 +5,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import restx.RestxRequest;
 import restx.RestxRequestMatch;
+import restx.common.Types;
 import restx.common.AggregateType;
 import restx.endpoint.EndpointParamDef;
 import restx.endpoint.EndpointParameterKind;
@@ -35,12 +36,12 @@ public class BaseTypeAggregateEndpointParameterMapper implements EndpointParamet
             return null;
         }
 
-        final Optional<AggregateType> aggregateType = AggregateType.fromType(endpointParamDef.getRawType().getCanonicalName());
+        final Optional<AggregateType> aggregateType = Types.aggregateTypeFrom(endpointParamDef.getRawType().getCanonicalName());
         if(!aggregateType.isPresent()) {
             throw new IllegalStateException("Called mapRequest() on base type aggregate whereas it is not considered as an aggregate !");
         }
 
-        final Class aggregatedType = AggregateType.aggregatedTypeOf(endpointParamDef.getType());
+        final Class aggregatedType = Types.aggregatedTypeOf(endpointParamDef.getType());
         List convertedValues = FluentIterable.from(values).transform(new Function<String, Object>() {
             @Override
             public Object apply(String requestValue) {
@@ -52,6 +53,6 @@ public class BaseTypeAggregateEndpointParameterMapper implements EndpointParamet
     }
 
     public boolean isBaseTypeAggregateParam(EndpointParamDef endpointParamDef) {
-        return AggregateType.isAggregate(endpointParamDef.getRawType().getCanonicalName());
+        return Types.isAggregateType(endpointParamDef.getRawType().getCanonicalName());
     }
 }

--- a/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
@@ -5,7 +5,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import restx.RestxRequest;
 import restx.RestxRequestMatch;
-import restx.common.Types;
+import restx.types.Types;
 import restx.types.AggregateType;
 import restx.endpoint.EndpointParamDef;
 import restx.endpoint.EndpointParameterKind;

--- a/restx-core/src/main/java/restx/entity/StdEntityRoute.java
+++ b/restx-core/src/main/java/restx/entity/StdEntityRoute.java
@@ -1,7 +1,6 @@
 package restx.entity;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Supplier;
 import restx.*;
 import restx.endpoint.*;
 import restx.endpoint.mappers.EndpointParameterMapper;
@@ -22,31 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Time: 8:10 AM
  */
 public abstract class StdEntityRoute<I,O> extends StdRoute {
-    protected static final Supplier<List> EMPTY_LIST_SUPPLIER = new Supplier<List>() {
-        @Override
-        public List get() {
-            return Collections.emptyList();
-        }
-    };
-    protected static final Supplier<Set> EMPTY_SET_SUPPLIER = new Supplier<Set>() {
-        @Override
-        public Set get() {
-            return Collections.emptySet();
-        }
-    };
-    protected static final Supplier<Iterable> EMPTY_ITERABLE_SUPPLIER = new Supplier<Iterable>() {
-        @Override
-        public Iterable get() {
-            return Collections.emptyList();
-        }
-    };
-    protected static final Supplier<Collection> EMPTY_COLLECTION_SUPPLIER = new Supplier<Collection>() {
-        @Override
-        public Collection get() {
-            return Collections.emptySet();
-        }
-    };
-
     public static class Builder<I,O> {
         protected EntityRequestBodyReader<I> entityRequestBodyReader;
         protected EntityResponseWriter<O> entityResponseWriter;
@@ -217,10 +191,6 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
     }
 
     protected <T> T mapQueryObjectFromRequest(Class<T> targetType, String parameterName, RestxRequest request, RestxRequestMatch match, EndpointParameterKind endpointParameterKind){
-        return mapQueryObjectFromRequest(targetType, parameterName, request, match, endpointParameterKind, null);
-    }
-
-    protected <T> T mapQueryObjectFromRequest(Class<T> targetType, String parameterName, RestxRequest request, RestxRequestMatch match, EndpointParameterKind endpointParameterKind, Supplier<T> nullResultDefaultValueSupplier){
         EndpointParameterMapperAndDef endpointParameterMapperAndDef = cachedQueryParameterMappers.get(parameterName);
         if(endpointParameterMapperAndDef == null) {
             throw new IllegalStateException("No cachedQueryParameterMappers for parameter "+parameterName+" : please provide corresponding ParamDef at instanciation time !");
@@ -231,8 +201,8 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
                 request, match, endpointParameterKind);
 
         // In case we have a null result *and* a null result default value supplier, let's use it
-        if(nullResultDefaultValueSupplier != null && result == null) {
-            result = nullResultDefaultValueSupplier.get();
+        if(result == null && endpointParameterMapperAndDef.endpointParamDef.isAggregateType()) {
+            result = (T) endpointParameterMapperAndDef.endpointParamDef.getAggregateType().immutableEmptyInstance(endpointParameterMapperAndDef.endpointParamDef.getRawType());
         }
 
         return result;

--- a/restx-factory/src/main/java/restx/config/processor/SettingsAnnotationProcessor.java
+++ b/restx-factory/src/main/java/restx/config/processor/SettingsAnnotationProcessor.java
@@ -33,6 +33,7 @@ public class SettingsAnnotationProcessor extends RestxAbstractProcessor {
     final Template settingsConfigTpl;
 
     public SettingsAnnotationProcessor() {
+        super();
         settingsProviderTpl = Mustaches.compile(SettingsAnnotationProcessor.class, "SettingsProvider.mustache");
         settingsConfigTpl = Mustaches.compile(SettingsAnnotationProcessor.class, "SettingsConfig.mustache");
     }

--- a/restx-factory/src/main/java/restx/factory/ParamDef.java
+++ b/restx-factory/src/main/java/restx/factory/ParamDef.java
@@ -1,8 +1,10 @@
 package restx.factory;
 
 import java.util.Objects;
+
 import restx.common.TypeReference;
 import restx.common.Types;
+import restx.common.AggregateType;
 
 import java.lang.reflect.Type;
 
@@ -14,6 +16,7 @@ public class ParamDef<T> {
     private final TypeReference<T> typeRef;
     private final Class<T> primitiveType;
     private final Class rawType;
+    private final AggregateType aggregateType;
 
     public ParamDef(TypeReference<T> typeRef, String name) {
         this(name, typeRef, null);
@@ -32,6 +35,7 @@ public class ParamDef<T> {
         this.typeRef = typeRef;
         this.primitiveType = primitiveType;
         this.rawType = Types.getRawType(getType());
+        this.aggregateType = Types.aggregateTypeFrom(this.rawType.getCanonicalName()).orNull();
     }
 
     public static <T> ParamDef<T> of(TypeReference<T> type, String name) {
@@ -56,6 +60,14 @@ public class ParamDef<T> {
 
     public Class getRawType() {
         return rawType;
+    }
+
+    public boolean isAggregateType() {
+        return this.aggregateType != null;
+    }
+
+    public AggregateType getAggregateType() {
+        return this.aggregateType;
     }
 
     @Override

--- a/restx-factory/src/main/java/restx/factory/ParamDef.java
+++ b/restx-factory/src/main/java/restx/factory/ParamDef.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import restx.common.TypeReference;
 import restx.common.Types;
-import restx.common.AggregateType;
+import restx.types.AggregateType;
 
 import java.lang.reflect.Type;
 

--- a/restx-factory/src/main/java/restx/factory/ParamDef.java
+++ b/restx-factory/src/main/java/restx/factory/ParamDef.java
@@ -2,8 +2,8 @@ package restx.factory;
 
 import java.util.Objects;
 
-import restx.common.TypeReference;
-import restx.common.Types;
+import restx.types.TypeReference;
+import restx.types.Types;
 import restx.types.AggregateType;
 
 import java.lang.reflect.Type;

--- a/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
+++ b/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
@@ -45,6 +45,7 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
     private final FactoryAnnotationProcessor.ServicesDeclaration machinesDeclaration;
 
     public FactoryAnnotationProcessor() {
+        super();
         componentMachineTpl = compile(FactoryAnnotationProcessor.class, "ComponentMachine.mustache");
         conditionalMachineTpl = compile(FactoryAnnotationProcessor.class, "ConditionalMachine.mustache");
         moduleMachineTpl = compile(FactoryAnnotationProcessor.class, "ModuleMachine.mustache");

--- a/restx-jongo/src/main/java/restx/types/JongoRawTypesDefinition.java
+++ b/restx-jongo/src/main/java/restx/types/JongoRawTypesDefinition.java
@@ -1,0 +1,9 @@
+package restx.types;
+
+import org.bson.types.ObjectId;
+
+public class JongoRawTypesDefinition extends RawTypesDefinition.ClassBasedRawTypesDefinition {
+    public JongoRawTypesDefinition() {
+        super(ObjectId.class);
+    }
+}

--- a/restx-jongo/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
+++ b/restx-jongo/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
@@ -1,0 +1,1 @@
+restx.types.JongoRawTypesDefinition

--- a/restx-security-basic/src/main/java/restx/security/FileBasedUserRepository.java
+++ b/restx-security-basic/src/main/java/restx/security/FileBasedUserRepository.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import restx.common.Types;
+import restx.types.Types;
 
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;


### PR DESCRIPTION
This PR aims at removing some hardcoded code regarding types in restx annotation processor, and transform it into pluggable behaviours based on `ServiceLoader`s.

Those type definitions will be shared both at compile time and runtime through the `restx-common` module 's (wondering if I shouldn't create a dedicated `restx-types` module dedicated to this purpose) `restx.types.Types` utility class.

Sharing stuff both at compile time & runtime allows to co-locate code based on type families.


3 type definition families have been defined in this PR :

1.  `Optional`s handling : allows to remove some java8-specific code in `restx-core-annotation-processor` and move it into `restx-core-java8` (and maybe someday into a `restx-kotlin` for optional type support ? - not sure if it is feasible with current interface).
   To provide your own `Optional` type handling, simply provide a `restx.types.OptionalTypeDefinition` implementation declared into a service loader file
   Examples :
```
public class GUAVA extends ClassBasedOptionalTypeDefinition {
    private static final Function<String, String> FROM_NULLABLE_EXPRESSION_TRANSFORMER = new Function<String, String>() {
        @Override
        public String apply(String expression) {
            return "Optional.fromNullable(" + expression + ")";
        }
    };

    public GUAVA() {
        super(Optional.class, Functions.<String>identity(), FROM_NULLABLE_EXPRESSION_TRANSFORMER);
    }
}

public class JDK8OptionalTypeDefinition extends OptionalTypeDefinition.ClassBasedOptionalTypeDefinition {

    private static final Function<String, String> JDK8_OPTIONAL_EXPRESSION_TO_GUAVA_OPTIONAL_CODE_EXPRESSION = new Function<String, String>() {
        @Override
        public String apply(String currentOptionalCodeExpression) {
            return "Optional.fromNullable(" + currentOptionalCodeExpression + ".orElse(null))";
        }
    };
    private static final Function<String, String> FROM_NULLABLE_EXPRESSION_TRANSFORMER = new Function<String, String>() {
        @Override
        public String apply(String expression) {
            return "java.util.Optional.ofNullable(" + expression + ")";
        }
    };

    public JDK8OptionalTypeDefinition() {
        super(Optional.class, JDK8_OPTIONAL_EXPRESSION_TO_GUAVA_OPTIONAL_CODE_EXPRESSION, FROM_NULLABLE_EXPRESSION_TRANSFORMER);
    }
}

```

2.  `AggregateType`s handling : in 0.35, I introduced an `AggregateType` enum which was not ideal from an extensibility perspective. Typically, if we want to support new collections not based on JDK's `Collection` API (Kotlin, I'm looking at you :-)), then this `AggregateType` service loader could be particularly useful.
    To provide your own `AggregateType` type handling, simply provide a `restx.types.AggregateType` implementation declared into a service loader file.
    Examples :
```
    class ITERABLE implements AggregateType {
        @Override
        public boolean isApplicableTo(String fqcn) {
            return Types.matchesParameterizedFQCN(Iterable.class, fqcn);
        }

        @Override
        public <T> Object createFrom(List values, Class<T> itemClass) {
            return values;
        }

        @Override
        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
            return Collections.emptyList();
        }
    }

    class ARRAY implements AggregateType {
        @Override
        public boolean isApplicableTo(String fqcn) {
            return fqcn.endsWith("[]");
        }

        @Override
        public <T> Object createFrom(List values, Class<T> itemClass) {
            return values.toArray(ObjectArrays.newArray(itemClass, values.size()));
        }

        @Override
        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
            return Array.newInstance(itemClass, 0);
        }
    }
```


3. `RawTypesDefinition` is a new interface introduced for future purpose (I'll talk about it in an upcoming PR) and is aimed at defining "raw" types. What I call a "raw" type is mainly an object instance which may be deserialized from a simple `String`.
    I listed types which may be concerned into [this gist](https://gist.github.com/fcamblor/f91fb5d8640a8ca53f7feaa0a9597a0d)
    To provide your own `RawTypesDefinition` type handling, simply provide a `restx.types.RawTypesDefinition` implementation declared into a service loader file.
    Examples :
```
    class CommonJDKRawTypesDefinition extends ClassBasedRawTypesDefinition {
        public CommonJDKRawTypesDefinition() {
            super(
                    String.class, Class.class, Enum.class, File.class, BigDecimal.class, BigInteger.class,
                    Currency.class, Date.class, Locale.class, TimeZone.class, UUID.class, Charset.class, Path.class,
                    Pattern.class, URI.class, URL.class
            );
        }
    }
```

*Important note* : to be able to use `ServiceLoader.load()` during annotation processing, I had to override current thread's context classloader with `AnnotationProcessor`'s classloader  (see 
72f0cd9) as `ServiceLoader.load()` relies on `Thread.currentThread().getContextClassLoader()` internally.

Not sure if it may have some unwanted impacts but currently, didn't see any regression by doing this.