### PR TITLE
Query params complex type deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,11 @@
                 <artifactId>restx-md-fragments</artifactId>
                 <version>${restx.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.restx</groupId>
+                <artifactId>restx-samplest-custom-types-testing</artifactId>
+                <version>${restx.version}</version>
+            </dependency>
 
             <!-- Jackson -->
             <dependency>
@@ -576,6 +581,7 @@
         <module>restx-server-tomcat</module>
         <module>restx-server-simple</module>
         <module>restx-server-testing</module>
+        <module>restx-samplest-custom-types-testing</module>
         <module>restx-samplest</module>
         <module>restx-validation</module>
         <module>restx-webjars</module>

--- a/restx-classloader/src/main/java/restx/classloader/processor/ColdClassesAnnotationProcessor.java
+++ b/restx-classloader/src/main/java/restx/classloader/processor/ColdClassesAnnotationProcessor.java
@@ -31,6 +31,7 @@ public class ColdClassesAnnotationProcessor extends RestxAbstractProcessor {
 	private final ColdClassesAnnotationProcessor.ColdClassesDeclaration coldClassesDeclaration;
 
 	public ColdClassesAnnotationProcessor() {
+		super();
 		this.coldClassesDeclaration = new ColdClassesDeclaration();
 	}
 

--- a/restx-common/src/main/java/restx/common/AggregateType.java
+++ b/restx-common/src/main/java/restx/common/AggregateType.java
@@ -1,66 +1,83 @@
 package restx.common;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
 
-import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
+import java.lang.reflect.Array;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Created by fcamblor on 13/05/16.
  */
-public enum AggregateType {
-    ITERABLE() {
+public interface AggregateType {
+    class ITERABLE implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
-            return matchesParameterizedFQCN(Iterable.class, fqcn);
+            return Types.matchesParameterizedFQCN(Iterable.class, fqcn);
         }
 
         @Override
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return values;
         }
-    },
-    LIST() {
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Collections.emptyList();
+        }
+    }
+    class LIST implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
-            return matchesParameterizedFQCN(List.class, fqcn);
+            return Types.matchesParameterizedFQCN(List.class, fqcn);
         }
 
         @Override
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return values;
         }
-    },
-    SET() {
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Collections.emptyList();
+        }
+    }
+    class SET implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
-            return matchesParameterizedFQCN(Set.class, fqcn);
+            return Types.matchesParameterizedFQCN(Set.class, fqcn);
         }
 
         @Override
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return Sets.newHashSet(values);
         }
-    },
-    COLLECTION() {
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Collections.emptySet();
+        }
+    }
+    class COLLECTION implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
-            return matchesParameterizedFQCN(Collection.class, fqcn);
+            return Types.matchesParameterizedFQCN(Collection.class, fqcn);
         }
 
         @Override
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return values;
         }
-    },
-    ARRAY() {
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Collections.emptySet();
+        }
+    }
+    class ARRAY implements AggregateType {
         @Override
         public boolean isApplicableTo(String fqcn) {
             return fqcn.endsWith("[]");
@@ -70,36 +87,15 @@ public enum AggregateType {
         public <T> Object createFrom(List values, Class<T> itemClass) {
             return values.toArray(ObjectArrays.newArray(itemClass, values.size()));
         }
+
+        @Override
+        public <T> Object immutableEmptyInstance(Class<T> itemClass) {
+            return Array.newInstance(itemClass, 0);
+        }
     };
 
-    public static Optional<AggregateType> fromType(String fqcn) {
-        for(AggregateType aggregateType : values()){
-            if(aggregateType.isApplicableTo(fqcn)) {
-                return Optional.of(aggregateType);
-            }
-        }
 
-        return Optional.absent();
-    }
-
-    public abstract boolean isApplicableTo(String fqcn);
-    public abstract <T> Object createFrom(List values, Class<T> itemClass);
-
-    protected static boolean matchesParameterizedFQCN(Class c, String fqcn) {
-        return fqcn.startsWith(c.getCanonicalName());
-    }
-
-    public static boolean isAggregate(String fqcn) {
-        return fromType(fqcn).isPresent();
-    }
-
-    public static Class aggregatedTypeOf(Type type) {
-        if(type instanceof ParameterizedType) {
-            return (Class)((ParameterizedType)type).getActualTypeArguments()[0];
-        } else if(type instanceof Class && ((Class)type).isArray()){
-            return ((Class)type).getComponentType();
-        } else {
-            throw new IllegalArgumentException("Call to aggregatedTypeOf() is not supported for type : "+type);
-        }
-    }
+    boolean isApplicableTo(String fqcn);
+    <T> Object createFrom(List values, Class<T> itemClass);
+    <T> Object immutableEmptyInstance(Class<T> itemClass);
 }

--- a/restx-common/src/main/java/restx/common/MoreFunctions.java
+++ b/restx-common/src/main/java/restx/common/MoreFunctions.java
@@ -1,0 +1,14 @@
+package restx.common;
+
+import com.google.common.base.Function;
+
+public class MoreFunctions {
+    public static <A, B extends A> Function<A, B> cast(Class<B> clazz) {
+        return new Function<A, B>() {
+            @Override
+            public B apply(A input) {
+                return (B)input;
+            }
+        };
+    }
+}

--- a/restx-common/src/main/java/restx/common/MoreStrings.java
+++ b/restx-common/src/main/java/restx/common/MoreStrings.java
@@ -25,4 +25,8 @@ public class MoreStrings {
     public static String reindent(String s, int i) {
         return Pattern.compile("^\\s*", Pattern.MULTILINE).matcher(s).replaceAll(Strings.repeat(" ", i));
     }
+
+    public static String lowerFirstLetter(String str) {
+        return str.substring(0, 1).toLowerCase()+str.substring(1);
+    }
 }

--- a/restx-common/src/main/java/restx/common/Types.java
+++ b/restx-common/src/main/java/restx/common/Types.java
@@ -8,12 +8,14 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
+import restx.types.AggregateType;
 
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import java.lang.reflect.*;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 /**
  * Date: 23/10/13
@@ -21,13 +23,10 @@ import java.util.Map;
  */
 public class Types {
 
-	public static final ImmutableList<AggregateType> DECLARED_AGGREGATED_TYPES = ImmutableList.of(
-			new AggregateType.ITERABLE(),
-			new AggregateType.ARRAY(),
-			new AggregateType.COLLECTION(),
-			new AggregateType.LIST(),
-			new AggregateType.SET()
-	);
+	public static final ImmutableList<AggregateType> DECLARED_AGGREGATED_TYPES;
+	static {
+		DECLARED_AGGREGATED_TYPES = ImmutableList.copyOf(ServiceLoader.load(AggregateType.class));
+	}
 
     public static ParameterizedType newParameterizedType(final Class<?> rawType, final Type... arguments) {
         return new ParameterizedType() {

--- a/restx-common/src/main/java/restx/common/processor/RestxAbstractProcessor.java
+++ b/restx-common/src/main/java/restx/common/processor/RestxAbstractProcessor.java
@@ -33,6 +33,15 @@ import java.util.Set;
  * Time: 07:50
  */
 public abstract class RestxAbstractProcessor extends AbstractProcessor {
+
+	protected RestxAbstractProcessor() {
+		// Updating current thread's context classloader in order to have
+		// ServiceLoader.load() calls rely on it instead of default classloader during annotation processing
+		// See https://stackoverflow.com/questions/45061170/using-serviceloader-within-an-annotation-processor
+		// This will be particularly useful when calling Types.* utility methods
+		Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+	}
+
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         try {

--- a/restx-common/src/main/java/restx/types/AggregateType.java
+++ b/restx-common/src/main/java/restx/types/AggregateType.java
@@ -1,7 +1,8 @@
-package restx.common;
+package restx.types;
 
 import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
+import restx.common.Types;
 
 import java.lang.reflect.Array;
 import java.util.Collection;

--- a/restx-common/src/main/java/restx/types/AggregateType.java
+++ b/restx-common/src/main/java/restx/types/AggregateType.java
@@ -2,7 +2,6 @@ package restx.types;
 
 import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Sets;
-import restx.common.Types;
 
 import java.lang.reflect.Array;
 import java.util.Collection;

--- a/restx-common/src/main/java/restx/types/OptionalTypeDefinition.java
+++ b/restx-common/src/main/java/restx/types/OptionalTypeDefinition.java
@@ -1,0 +1,91 @@
+package restx.types;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Optional;
+
+import java.util.regex.Pattern;
+
+public interface OptionalTypeDefinition {
+    class Matcher {
+        private final boolean isOptionalType;
+        private final String underlyingType;
+        private final Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+        private final Function<String, String> fromNullableExpressionTransformer;
+
+        public Matcher(boolean isOptionalType, String underlyingType,
+                       Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer,
+                       Function<String, String> fromNullableExpressionTransformer) {
+
+            this.isOptionalType = isOptionalType;
+            this.underlyingType = underlyingType;
+            this.currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer = currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+            this.fromNullableExpressionTransformer = fromNullableExpressionTransformer;
+        }
+
+        public boolean isOptionalType() {
+            return isOptionalType;
+        }
+
+        public String getUnderlyingType() {
+            return underlyingType;
+        }
+
+        public Function<String, String> getCurrentOptionalExpressionToGuavaOptionalCodeExpressionTransformer() {
+            return currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+        }
+
+        public Function<String, String> getFromNullableExpressionTransformer() {
+            return fromNullableExpressionTransformer;
+        }
+
+        public static Matcher notOptional(String underlyingType) {
+            return new Matcher(false, underlyingType, null, null);
+        }
+        public static Matcher optionalOf(String underlyingType,
+                                         Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer,
+                                         Function<String, String> fromNullableExpressionTransformer) {
+            return new Matcher(true, underlyingType, currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer, fromNullableExpressionTransformer);
+        }
+    }
+
+    Matcher matches(String type);
+
+    abstract class ClassBasedOptionalTypeDefinition implements OptionalTypeDefinition {
+        private final Pattern optionalRegex;
+        private final Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+        private final Function<String, String> fromNullableExpressionTransformer;
+
+        protected ClassBasedOptionalTypeDefinition(
+                Class clazz,
+                Function<String, String> currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer,
+                Function<String, String> fromNullableExpressionTransformer) {
+
+            this.optionalRegex = Pattern.compile("\\Q" + clazz.getName() + "<\\E(.+)>");
+            this.currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer = currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer;
+            this.fromNullableExpressionTransformer = fromNullableExpressionTransformer;
+        }
+
+        public Matcher matches(String type) {
+            java.util.regex.Matcher matcher = this.optionalRegex.matcher(type);
+            if(matcher.matches()) {
+                return Matcher.optionalOf(matcher.group(1), this.currentOptionalExpressionToGuavaOptionalCodeExpressionTransformer, this.fromNullableExpressionTransformer);
+            } else {
+                return Matcher.notOptional(type);
+            }
+        }
+    }
+
+    class GUAVA extends ClassBasedOptionalTypeDefinition {
+        private static final Function<String, String> FROM_NULLABLE_EXPRESSION_TRANSFORMER = new Function<String, String>() {
+            @Override
+            public String apply(String expression) {
+                return "Optional.fromNullable(" + expression + ")";
+            }
+        };
+
+        public GUAVA() {
+            super(Optional.class, Functions.<String>identity(), FROM_NULLABLE_EXPRESSION_TRANSFORMER);
+        }
+    }
+}

--- a/restx-common/src/main/java/restx/types/RawTypesDefinition.java
+++ b/restx-common/src/main/java/restx/types/RawTypesDefinition.java
@@ -99,4 +99,14 @@ public interface RawTypesDefinition {
             );
         }
     }
+    class IsEnumRawTypeDefinition implements RawTypesDefinition {
+        @Override
+        public boolean accepts(Type type) {
+            return Types.isAssignableFrom(Enum.class, type);
+        }
+        @Override
+        public boolean accepts(TypeMirror type, ProcessingEnvironment processingEnvironment) {
+            return Types.isEnum(type, processingEnvironment.getTypeUtils());
+        }
+    }
 }

--- a/restx-common/src/main/java/restx/types/RawTypesDefinition.java
+++ b/restx-common/src/main/java/restx/types/RawTypesDefinition.java
@@ -1,0 +1,102 @@
+package restx.types;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.joda.time.*;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import java.io.File;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public interface RawTypesDefinition {
+    boolean accepts(Type type);
+    boolean accepts(TypeMirror type, ProcessingEnvironment processingEnvironment);
+
+    class ClassBasedRawTypesDefinition implements RawTypesDefinition {
+        final ImmutableList<Class> acceptableClasses;
+        ImmutableList<TypeMirror> acceptableTypeMirrors = null;
+
+        public ClassBasedRawTypesDefinition(Class... acceptableClasses) {
+            this.acceptableClasses = ImmutableList.copyOf(acceptableClasses);
+        }
+
+        @Override
+        public boolean accepts(final Type type) {
+            if(!(type instanceof Class)) {
+                return false;
+            }
+
+            return Iterables.tryFind(acceptableClasses, new Predicate<Class>() {
+                @Override
+                public boolean apply(Class clazz) {
+                    return clazz.isAssignableFrom((Class)type);
+                }
+            }).isPresent();
+        }
+
+        @Override
+        public boolean accepts(final TypeMirror type, final ProcessingEnvironment processingEnvironment) {
+            if(acceptableTypeMirrors == null) {
+                this.acceptableTypeMirrors = ImmutableList.copyOf(Lists.transform(acceptableClasses, new Function<Class, TypeMirror>() {
+                    @Override
+                    public TypeMirror apply(Class input) {
+                        if(input.isPrimitive()) {
+                            return processingEnvironment.getTypeUtils().getPrimitiveType(TypeKind.valueOf(input.toString().toUpperCase()));
+                        } else {
+                            return processingEnvironment.getElementUtils().getTypeElement(input.getCanonicalName()).asType();
+                        }
+                    }
+                }));
+            }
+
+            return Iterables.tryFind(acceptableTypeMirrors, new Predicate<TypeMirror>() {
+                @Override
+                public boolean apply(TypeMirror acceptableTypeMirror) {
+                    return processingEnvironment.getTypeUtils().isAssignable(acceptableTypeMirror, type);
+                }
+            }).isPresent();
+        }
+    }
+
+    class PrimitiveRawTypesDefinition extends ClassBasedRawTypesDefinition {
+        public PrimitiveRawTypesDefinition() {
+            super(
+                    byte.class, short.class, int.class, long.class, float.class, double.class, boolean.class, char.class,
+                    Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Character.class
+            );
+        }
+    }
+    class CommonJDKRawTypesDefinition extends ClassBasedRawTypesDefinition {
+        public CommonJDKRawTypesDefinition() {
+            super(
+                    String.class, Class.class, Enum.class, File.class, BigDecimal.class, BigInteger.class,
+                    Currency.class, Date.class, Locale.class, TimeZone.class, UUID.class, Charset.class, Path.class,
+                    Pattern.class, URI.class, URL.class
+            );
+        }
+    }
+    class JodaTimeRawTypesDefinition extends ClassBasedRawTypesDefinition {
+        public JodaTimeRawTypesDefinition() {
+            super(
+                    DateTime.class, Instant.class, LocalDate.class, LocalDateTime.class, LocalTime.class, DateTimeZone.class
+            );
+        }
+    }
+}

--- a/restx-common/src/main/java/restx/types/TypeReference.java
+++ b/restx-common/src/main/java/restx/types/TypeReference.java
@@ -1,4 +1,4 @@
-package restx.common;
+package restx.types;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;

--- a/restx-common/src/main/java/restx/types/Types.java
+++ b/restx-common/src/main/java/restx/types/Types.java
@@ -23,8 +23,10 @@ import java.util.ServiceLoader;
 public class Types {
 
 	public static final ImmutableList<AggregateType> DECLARED_AGGREGATED_TYPES;
+	public static final ImmutableList<OptionalTypeDefinition> DECLARED_OPTIONAL_TYPES;
 	static {
 		DECLARED_AGGREGATED_TYPES = ImmutableList.copyOf(ServiceLoader.load(AggregateType.class));
+		DECLARED_OPTIONAL_TYPES = ImmutableList.copyOf(ServiceLoader.load(OptionalTypeDefinition.class));
 	}
 
     public static ParameterizedType newParameterizedType(final Class<?> rawType, final Type... arguments) {
@@ -263,5 +265,17 @@ public class Types {
 	}
 	public static boolean isAggregateType(String fqcn) {
 		return aggregateTypeFrom(fqcn).isPresent();
+	}
+
+	public static OptionalTypeDefinition.Matcher optionalMatchingTypeOf(String fqcn) {
+		OptionalTypeDefinition.Matcher lastMatcher = null;
+		for(OptionalTypeDefinition optionalDefinition: DECLARED_OPTIONAL_TYPES) {
+			lastMatcher = optionalDefinition.matches(fqcn);
+			if(lastMatcher.isOptionalType()) {
+				return lastMatcher;
+			}
+		}
+
+		return lastMatcher;
 	}
 }

--- a/restx-common/src/main/java/restx/types/Types.java
+++ b/restx-common/src/main/java/restx/types/Types.java
@@ -1,4 +1,4 @@
-package restx.common;
+package restx.types;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -8,7 +8,6 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import restx.types.AggregateType;
 
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;

--- a/restx-common/src/main/java/restx/types/Types.java
+++ b/restx-common/src/main/java/restx/types/Types.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
@@ -24,9 +25,11 @@ public class Types {
 
 	public static final ImmutableList<AggregateType> DECLARED_AGGREGATED_TYPES;
 	public static final ImmutableList<OptionalTypeDefinition> DECLARED_OPTIONAL_TYPES;
+	public static final ImmutableList<RawTypesDefinition> DECLARED_RAW_TYPES_DEFINITIONS;
 	static {
 		DECLARED_AGGREGATED_TYPES = ImmutableList.copyOf(ServiceLoader.load(AggregateType.class));
 		DECLARED_OPTIONAL_TYPES = ImmutableList.copyOf(ServiceLoader.load(OptionalTypeDefinition.class));
+		DECLARED_RAW_TYPES_DEFINITIONS = ImmutableList.copyOf(ServiceLoader.load(RawTypesDefinition.class));
 	}
 
     public static ParameterizedType newParameterizedType(final Class<?> rawType, final Type... arguments) {
@@ -277,5 +280,23 @@ public class Types {
 		}
 
 		return lastMatcher;
+	}
+
+	public static boolean isRawType(Type type) {
+		for (RawTypesDefinition rawTypesDefinition : DECLARED_RAW_TYPES_DEFINITIONS) {
+			if (rawTypesDefinition.accepts(type)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public static boolean isRawType(TypeMirror type, ProcessingEnvironment processingEnvironment) {
+		for (RawTypesDefinition rawTypesDefinition : DECLARED_RAW_TYPES_DEFINITIONS) {
+			if (rawTypesDefinition.accepts(type, processingEnvironment)) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/restx-common/src/main/java/restx/types/Types.java
+++ b/restx-common/src/main/java/restx/types/Types.java
@@ -307,4 +307,12 @@ public class Types {
 		}
 		return false;
 	}
+
+	public static boolean isParameterizedType(String type) {
+		return type.contains("<");
+	}
+
+	public static String rawTypeFrom(String type) {
+		return isParameterizedType(type)?type.substring(0, type.indexOf("<")):type;
+	}
 }

--- a/restx-common/src/main/java/restx/types/Types.java
+++ b/restx-common/src/main/java/restx/types/Types.java
@@ -282,6 +282,14 @@ public class Types {
 		return lastMatcher;
 	}
 
+	public static boolean isEnum(TypeMirror typeMirror, javax.lang.model.util.Types typeUtils) {
+		TypeMirror firstAncestor = Iterables.getFirst(typeUtils.directSupertypes(typeMirror), null);
+		if(firstAncestor == null) {
+			return false;
+		}
+		return firstAncestor.toString().startsWith("java.lang.Enum<");
+	}
+
 	public static boolean isRawType(Type type) {
 		for (RawTypesDefinition rawTypesDefinition : DECLARED_RAW_TYPES_DEFINITIONS) {
 			if (rawTypesDefinition.accepts(type)) {

--- a/restx-common/src/main/resources/META-INF/services/restx.types.AggregateType
+++ b/restx-common/src/main/resources/META-INF/services/restx.types.AggregateType
@@ -1,0 +1,5 @@
+restx.types.AggregateType$ITERABLE
+restx.types.AggregateType$LIST
+restx.types.AggregateType$SET
+restx.types.AggregateType$COLLECTION
+restx.types.AggregateType$ARRAY

--- a/restx-common/src/main/resources/META-INF/services/restx.types.OptionalTypeDefinition
+++ b/restx-common/src/main/resources/META-INF/services/restx.types.OptionalTypeDefinition
@@ -1,0 +1,1 @@
+restx.types.OptionalTypeDefinition$GUAVA

--- a/restx-common/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
+++ b/restx-common/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
@@ -1,3 +1,4 @@
 restx.types.RawTypesDefinition$PrimitiveRawTypesDefinition
+restx.types.RawTypesDefinition$IsEnumRawTypeDefinition
 restx.types.RawTypesDefinition$CommonJDKRawTypesDefinition
 restx.types.RawTypesDefinition$JodaTimeRawTypesDefinition

--- a/restx-common/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
+++ b/restx-common/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
@@ -1,0 +1,3 @@
+restx.types.RawTypesDefinition$PrimitiveRawTypesDefinition
+restx.types.RawTypesDefinition$CommonJDKRawTypesDefinition
+restx.types.RawTypesDefinition$JodaTimeRawTypesDefinition

--- a/restx-common/src/test/java/restx/common/TypesTest.java
+++ b/restx-common/src/test/java/restx/common/TypesTest.java
@@ -1,6 +1,6 @@
 package restx.common;
 
-import static restx.common.Types.isAssignableFrom;
+import static restx.types.Types.isAssignableFrom;
 
 
 import com.google.common.collect.ImmutableList;
@@ -8,6 +8,8 @@ import com.google.common.collect.ImmutableMap;
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.Rule;
 import org.junit.Test;
+import restx.types.TypeReference;
+import restx.types.Types;
 
 import java.util.AbstractList;
 import java.util.AbstractMap;

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
@@ -22,9 +22,8 @@ public class ParameterExpressionBuilder {
     public ParameterExpressionBuilder surroundWithCheckValid(
             RestxAnnotationProcessor.ResourceMethodParameter parameter) {
 
-        boolean isOptionalType = parameter.guavaOptional || parameter.java8Optional;
         // If we don't have any optional type, we should check for non nullity *before* calling checkValid()
-        if(!isOptionalType) {
+        if(!parameter.optionalTypeMatcher.isOptionalType()) {
             // In case we're on an aggregate interface, parameterExpr will always return a non-null value
             // (see createFromMapQueryObjectFromRequest() method) so we don't need to add checkNotNull() check on this
             if(Types.isAggregateType(parameter.type)) {
@@ -46,16 +45,8 @@ public class ParameterExpressionBuilder {
                 validationGroupsExpr.isPresent()?","+validationGroupsExpr.get():""
         );
 
-        if(parameter.guavaOptional) {
-            this.parameterExpr = String.format(
-                    "Optional.fromNullable(%s)",
-                    this.parameterExpr
-            );
-        } else if(parameter.java8Optional) {
-            this.parameterExpr = String.format(
-                    "java.util.Optional.ofNullable(%s)",
-                    this.parameterExpr
-            );
+        if(parameter.optionalTypeMatcher.isOptionalType()) {
+            this.parameterExpr = parameter.optionalTypeMatcher.getFromNullableExpressionTransformer().apply(this.parameterExpr);
         }
 
         return this;

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
@@ -1,7 +1,7 @@
 package restx.annotations.processor;
 
 import com.google.common.base.Optional;
-import restx.common.Types;
+import restx.types.Types;
 import restx.endpoint.EndpointParameterKind;
 
 /**

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
@@ -1,13 +1,8 @@
 package restx.annotations.processor;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.base.Optional;
-import restx.common.AggregateType;
+import restx.common.Types;
 import restx.endpoint.EndpointParameterKind;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author fcamblor
@@ -24,20 +19,6 @@ public class ParameterExpressionBuilder {
         this.kind = kind;
     }
 
-    private static final Map<AggregateType, Function<String, String>> EMPTY_AGGREGATE_FUNCTIONS = new HashMap<AggregateType, Function<String, String>>(){{
-        // These (Function) casts are ugly, I know, but read https://github.com/google/guava/issues/1927
-        put(AggregateType.ITERABLE, (Function) Functions.constant("EMPTY_ITERABLE_SUPPLIER"));
-        put(AggregateType.LIST, (Function) Functions.constant("EMPTY_LIST_SUPPLIER"));
-        put(AggregateType.SET, (Function) Functions.constant("EMPTY_SET_SUPPLIER"));
-        put(AggregateType.COLLECTION, (Function) Functions.constant("EMPTY_COLLECTION_SUPPLIER"));
-        put(AggregateType.ARRAY, new Function<String, String>() {
-            @Override
-            public String apply(String fqcn) {
-                return "Suppliers.ofInstance(new "+fqcn+"{})";
-            }
-        });
-    }};
-
     public ParameterExpressionBuilder surroundWithCheckValid(
             RestxAnnotationProcessor.ResourceMethodParameter parameter) {
 
@@ -46,7 +27,7 @@ public class ParameterExpressionBuilder {
         if(!isOptionalType) {
             // In case we're on an aggregate interface, parameterExpr will always return a non-null value
             // (see createFromMapQueryObjectFromRequest() method) so we don't need to add checkNotNull() check on this
-            if(AggregateType.isAggregate(parameter.type)) {
+            if(Types.isAggregateType(parameter.type)) {
             } else {
                 // If not an iterable type, ensuring target value is set
                 this.parameterExpr = String.format(
@@ -92,25 +73,12 @@ public class ParameterExpressionBuilder {
             RestxAnnotationProcessor.ResourceMethodParameter parameter,
             EndpointParameterKind kind){
 
-        // We should check if target type is an iterable interface : in that case, we should
-        // instantiate an empty iterable instead of null value if data is missing in request
-        Optional<AggregateType> aggregateType = AggregateType.fromType(parameter.type);
-        String emptySupplierParam = "";
-        if(aggregateType.isPresent()) {
-            Function<String, String> fqcnToEmptyAggregateTransformer = EMPTY_AGGREGATE_FUNCTIONS.get(aggregateType.get());
-            if(fqcnToEmptyAggregateTransformer == null) {
-                throw new IllegalStateException("Missing EMPTY_AGGREGATE_FUNCTIONS entry for aggregate type "+aggregateType.get().name());
-            }
-            emptySupplierParam = ", "+fqcnToEmptyAggregateTransformer.apply(parameter.type);
-        }
-
         return new ParameterExpressionBuilder(String.format(
-            "%smapQueryObjectFromRequest(%s.class, \"%s\", request, match, EndpointParameterKind.%s%s)",
+            "%smapQueryObjectFromRequest(%s.class, \"%s\", request, match, EndpointParameterKind.%s)",
             TypeHelper.isParameterizedType(parameter.type)?"("+parameter.type+")":"",
             TypeHelper.rawTypeFrom(parameter.type),
             parameter.reqParamName,
-            kind.name(),
-            emptySupplierParam
+            kind.name()
         ), kind.name());
     }
 }

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/ParameterExpressionBuilder.java
@@ -66,8 +66,8 @@ public class ParameterExpressionBuilder {
 
         return new ParameterExpressionBuilder(String.format(
             "%smapQueryObjectFromRequest(%s.class, \"%s\", request, match, EndpointParameterKind.%s)",
-            TypeHelper.isParameterizedType(parameter.type)?"("+parameter.type+")":"",
-            TypeHelper.rawTypeFrom(parameter.type),
+            Types.isParameterizedType(parameter.type)?"("+parameter.type+")":"",
+            Types.rawTypeFrom(parameter.type),
             parameter.reqParamName,
             kind.name()
         ), kind.name());

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -178,7 +178,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
                 return PRIMITIVE;
             } else if(String.class.getCanonicalName().equals(componentType.toString())) {
                 return STRING;
-            } else if(Class.class.getCanonicalName().equals(TypeHelper.rawTypeFrom(componentType.toString()))) {
+            } else if(Class.class.getCanonicalName().equals(Types.rawTypeFrom(componentType.toString()))) {
                 return CLASS;
             } else {
                 ImmutableList<String> superTypesClassNames = FluentIterable.from(processingEnv.getTypeUtils().directSupertypes(componentType))
@@ -747,7 +747,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
             } else if(isArray) {
                 return String.format("return new %s[]{ %s }",
                         // Arrays cannot be parameterized
-                        TypeHelper.rawTypeFrom(type.toString()),
+                        Types.rawTypeFrom(type.toString()),
                         Joiner.on(", ").join((List)value));
             } else {
                 return "return "+kind.transformSingleValueToExpression(value, this);

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -57,6 +57,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
     };
 
     public RestxAnnotationProcessor() {
+        super();
         routerTpl = Mustaches.compile(RestxAnnotationProcessor.class, "RestxRouter.mustache");
     }
 

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -384,7 +384,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
             }
 
             resourceMethod.parameters.add(new ResourceMethodParameter(
-                p.asType().toString(),
+                p,
                 variableName,
                 reqParamName,
                 parameterKind,
@@ -731,6 +731,7 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
     }
 
     static class ResourceMethodParameter {
+        final TypeMirror typeMirror;
         final String type;
         final String realType;
         final OptionalTypeDefinition.Matcher optionalTypeMatcher;
@@ -746,8 +747,9 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
             }
         };
 
-        private ResourceMethodParameter(String type, String name, String reqParamName, ResourceMethodParameterKind kind, String[] validationGroupsFQNs) {
-            this.realType = type;
+        private ResourceMethodParameter(VariableElement element, String name, String reqParamName, ResourceMethodParameterKind kind, String[] validationGroupsFQNs) {
+            this.typeMirror = element.asType();
+            this.realType = this.typeMirror.toString();
 
             this.optionalTypeMatcher = Types.optionalMatchingTypeOf(this.realType);
             this.type = optionalTypeMatcher.getUnderlyingType();

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/RestxAnnotationProcessor.java
@@ -602,18 +602,18 @@ public class RestxAnnotationProcessor extends RestxAbstractProcessor {
             String propertyName = MoreStrings.lowerFirstLetter(setter.getSimpleName().toString().substring("set".length()));
             String propertyPath = path+(path.isEmpty()?"":".")+propertyName;
 
-            if(Types.isRawType(propertyType, processingEnv)) {
-                // Current setter represents a RAW type => no special handling here
-            } else if(Types.isAggregateType(propertyType.toString())) {
+            if(Types.isAggregateType(propertyType.toString())) {
                 TypeMirror aggregateType = Types.aggregatedTypeOf(propertyType);
                 // Aggregates of RAW types should be handled with ParamDef.SpecialParamHandling.ARRAYS
-                if(Types.isRawType(aggregateType, processingEnv)) {
+                if (Types.isRawType(aggregateType, processingEnv)) {
                     specialParamHandlingDeclarations.add(String.format(".put(\"%s\", ParamDef.SpecialParamHandling.ARRAYS)", propertyPath));
                 // Aggregates of COMPLEX types should not be supported
                 // Note that it will throw an error ONLY if request param contains a key targetting your Aggregate<COMPLEX> type
                 } else {
                     specialParamHandlingDeclarations.add(String.format(".put(\"%s\", ParamDef.SpecialParamHandling.UNSUPPORTED)", propertyPath));
                 }
+            } else if(Types.isRawType(propertyType, processingEnv)) {
+                // Current setter represents a RAW type => no special handling here
             } else if(isComplexType(propertyType)) {
                 // Current setter represents a COMPLEX type => calling fillSpecialParamsHandlingDeclarations() on nested node
                 fillSpecialParamsHandlingDeclarations(specialParamHandlingDeclarations, propertyType, propertyPath, depth+1);

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/TypeHelper.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/TypeHelper.java
@@ -6,6 +6,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import restx.types.Types;
 
 import java.util.*;
 
@@ -132,14 +133,6 @@ public class TypeHelper {
 
     static String getTypeExpressionFor(String type) {
         return getTypeExpressionFor(parseParameterizedType(type));
-    }
-
-    static boolean isParameterizedType(String type) {
-        return type.contains("<");
-    }
-
-    static String rawTypeFrom(String type) {
-        return isParameterizedType(type)?type.substring(0, type.indexOf("<")):type;
     }
 
     static String getTypeReferenceExpressionFor(String type) {

--- a/restx-core-annotation-processor/src/main/java/restx/annotations/processor/TypeHelper.java
+++ b/restx-core-annotation-processor/src/main/java/restx/annotations/processor/TypeHelper.java
@@ -2,15 +2,12 @@ package restx.annotations.processor;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Date: 23/10/13
@@ -23,8 +20,6 @@ public class TypeHelper {
             Iterable.class.getCanonicalName(), "LIST",
             List.class.getCanonicalName(), "LIST",
             Map.class.getCanonicalName(), "MAP");
-    private static Pattern guavaOptionalPattern = Pattern.compile("\\Q" + Optional.class.getName() + "<\\E(.+)>");
-    private static Pattern java8OptionalPattern = Pattern.compile("\\Qjava.util.Optional<\\E(.+)>");
     private static Set<String> RAW_TYPES_STR = Sets.newHashSet("byte", "short", "int", "long", "float", "double", "boolean", "char");
 
     private static class ParsedType {
@@ -150,51 +145,4 @@ public class TypeHelper {
     static String getTypeReferenceExpressionFor(String type) {
         return RAW_TYPES_STR.contains(type) ? type + ".class" : "new TypeReference<" + type + ">(){}";
     }
-
-    public static class OptionalMatchingType {
-        public enum Type {GUAVA, JAVA8, NONE}
-
-        private final Type optionalType;
-        private final String underlyingType;
-
-        protected OptionalMatchingType(Type optionalType, String underlyingType) {
-            this.optionalType = optionalType;
-            this.underlyingType = underlyingType;
-        }
-
-        public static OptionalMatchingType guava(String underlyingType) {
-            return new OptionalMatchingType(Type.GUAVA, underlyingType);
-        }
-
-        public static OptionalMatchingType java8(String underlyingType) {
-            return new OptionalMatchingType(Type.JAVA8, underlyingType);
-        }
-
-        public static OptionalMatchingType none(String underlyingType) {
-            return new OptionalMatchingType(Type.NONE, underlyingType);
-        }
-
-        public Type getOptionalType() {
-            return optionalType;
-        }
-
-        public String getUnderlyingType() {
-            return underlyingType;
-        }
-    }
-
-    public static OptionalMatchingType optionalMatchingTypeOf(String type) {
-        Matcher guavaOptionalMatcher = guavaOptionalPattern.matcher(type);
-        if (guavaOptionalMatcher.matches()) {
-            return OptionalMatchingType.guava(guavaOptionalMatcher.group(1));
-        }
-
-        Matcher java8OptionalMatcher = java8OptionalPattern.matcher(type);
-        if (java8OptionalMatcher.matches()) {
-            return OptionalMatchingType.java8(java8OptionalMatcher.group(1));
-        }
-
-        return OptionalMatchingType.none(type);
-    }
-
 }

--- a/restx-core-annotation-processor/src/main/java/restx/exceptions/processor/ErrorAnnotationProcessor.java
+++ b/restx-core-annotation-processor/src/main/java/restx/exceptions/processor/ErrorAnnotationProcessor.java
@@ -33,6 +33,7 @@ public class ErrorAnnotationProcessor extends RestxAbstractProcessor {
     final Template errorDescriptorTpl;
 
     public ErrorAnnotationProcessor() {
+        super();
         errorDescriptorTpl = Mustaches.compile(ErrorAnnotationProcessor.class, "ErrorDescriptor.mustache");
     }
 

--- a/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
+++ b/restx-core-annotation-processor/src/main/resources/restx/annotations/processor/RestxRouter.mustache
@@ -8,8 +8,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
-import restx.common.Types;
-import restx.common.TypeReference;
+import restx.types.Types;
+import restx.types.TypeReference;
 import restx.*;
 import restx.entity.*;
 import restx.http.*;

--- a/restx-core-java8/src/main/java/restx/types/JDK8OptionalTypeDefinition.java
+++ b/restx-core-java8/src/main/java/restx/types/JDK8OptionalTypeDefinition.java
@@ -1,0 +1,25 @@
+package restx.types;
+
+import com.google.common.base.Function;
+
+import java.util.Optional;
+
+public class JDK8OptionalTypeDefinition extends OptionalTypeDefinition.ClassBasedOptionalTypeDefinition {
+
+    private static final Function<String, String> JDK8_OPTIONAL_EXPRESSION_TO_GUAVA_OPTIONAL_CODE_EXPRESSION = new Function<String, String>() {
+        @Override
+        public String apply(String currentOptionalCodeExpression) {
+            return "Optional.fromNullable(" + currentOptionalCodeExpression + ".orElse(null))";
+        }
+    };
+    private static final Function<String, String> FROM_NULLABLE_EXPRESSION_TRANSFORMER = new Function<String, String>() {
+        @Override
+        public String apply(String expression) {
+            return "java.util.Optional.ofNullable(" + expression + ")";
+        }
+    };
+
+    public JDK8OptionalTypeDefinition() {
+        super(Optional.class, JDK8_OPTIONAL_EXPRESSION_TO_GUAVA_OPTIONAL_CODE_EXPRESSION, FROM_NULLABLE_EXPRESSION_TRANSFORMER);
+    }
+}

--- a/restx-core-java8/src/main/java/restx/types/JDK8RawTypesDefinition.java
+++ b/restx-core-java8/src/main/java/restx/types/JDK8RawTypesDefinition.java
@@ -1,0 +1,12 @@
+package restx.types;
+
+import java.time.*;
+
+public class JDK8RawTypesDefinition extends RawTypesDefinition.ClassBasedRawTypesDefinition {
+    public JDK8RawTypesDefinition() {
+        super(
+                Instant.class, DayOfWeek.class, LocalDate.class, LocalDateTime.class, LocalTime.class,
+                Month.class, Year.class, ZoneId.class
+        );
+    }
+}

--- a/restx-core-java8/src/main/resources/META-INF/services/restx.types.OptionalTypeDefinition
+++ b/restx-core-java8/src/main/resources/META-INF/services/restx.types.OptionalTypeDefinition
@@ -1,0 +1,1 @@
+restx.types.JDK8OptionalTypeDefinition

--- a/restx-core-java8/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
+++ b/restx-core-java8/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
@@ -1,0 +1,1 @@
+restx.types.JDK8RawTypesDefinition

--- a/restx-core/src/main/java/restx/converters/MainStringConverter.java
+++ b/restx-core/src/main/java/restx/converters/MainStringConverter.java
@@ -1,6 +1,5 @@
 package restx.converters;
 
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import restx.factory.Component;
@@ -27,10 +26,6 @@ public class MainStringConverter {
         } else {
             return Optional.absent();
         }
-    }
-
-    public boolean canDeserialize(JavaType javaType) {
-        return mapper.canDeserialize(javaType);
     }
 
     public <T> T convert(String value, Class<T> toClass) {

--- a/restx-core/src/main/java/restx/endpoint/EndpointParamDef.java
+++ b/restx-core/src/main/java/restx/endpoint/EndpointParamDef.java
@@ -1,7 +1,7 @@
 package restx.endpoint;
 
 import java.util.Objects;
-import restx.common.TypeReference;
+import restx.types.TypeReference;
 import restx.factory.ParamDef;
 
 /**

--- a/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
@@ -6,7 +6,7 @@ import com.google.common.collect.FluentIterable;
 import restx.RestxRequest;
 import restx.RestxRequestMatch;
 import restx.common.Types;
-import restx.common.AggregateType;
+import restx.types.AggregateType;
 import restx.endpoint.EndpointParamDef;
 import restx.endpoint.EndpointParameterKind;
 import restx.factory.Component;

--- a/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
@@ -5,6 +5,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import restx.RestxRequest;
 import restx.RestxRequestMatch;
+import restx.common.Types;
 import restx.common.AggregateType;
 import restx.endpoint.EndpointParamDef;
 import restx.endpoint.EndpointParameterKind;
@@ -35,12 +36,12 @@ public class BaseTypeAggregateEndpointParameterMapper implements EndpointParamet
             return null;
         }
 
-        final Optional<AggregateType> aggregateType = AggregateType.fromType(endpointParamDef.getRawType().getCanonicalName());
+        final Optional<AggregateType> aggregateType = Types.aggregateTypeFrom(endpointParamDef.getRawType().getCanonicalName());
         if(!aggregateType.isPresent()) {
             throw new IllegalStateException("Called mapRequest() on base type aggregate whereas it is not considered as an aggregate !");
         }
 
-        final Class aggregatedType = AggregateType.aggregatedTypeOf(endpointParamDef.getType());
+        final Class aggregatedType = Types.aggregatedTypeOf(endpointParamDef.getType());
         List convertedValues = FluentIterable.from(values).transform(new Function<String, Object>() {
             @Override
             public Object apply(String requestValue) {
@@ -52,6 +53,6 @@ public class BaseTypeAggregateEndpointParameterMapper implements EndpointParamet
     }
 
     public boolean isBaseTypeAggregateParam(EndpointParamDef endpointParamDef) {
-        return AggregateType.isAggregate(endpointParamDef.getRawType().getCanonicalName());
+        return Types.isAggregateType(endpointParamDef.getRawType().getCanonicalName());
     }
 }

--- a/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
@@ -51,8 +51,4 @@ public class BaseTypeAggregateEndpointParameterMapper implements EndpointParamet
 
         return (T) aggregateType.get().createFrom(convertedValues, aggregatedType);
     }
-
-    public boolean isBaseTypeAggregateParam(EndpointParamDef endpointParamDef) {
-        return Types.isAggregateType(endpointParamDef.getRawType().getCanonicalName());
-    }
 }

--- a/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeAggregateEndpointParameterMapper.java
@@ -5,7 +5,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import restx.RestxRequest;
 import restx.RestxRequestMatch;
-import restx.common.Types;
+import restx.types.Types;
 import restx.types.AggregateType;
 import restx.endpoint.EndpointParamDef;
 import restx.endpoint.EndpointParameterKind;

--- a/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/BaseTypeEndpointParameterMapper.java
@@ -1,6 +1,5 @@
 package restx.endpoint.mappers;
 
-import com.fasterxml.jackson.databind.type.SimpleType;
 import com.google.common.base.Optional;
 import restx.RestxRequest;
 import restx.RestxRequestMatch;
@@ -44,9 +43,5 @@ public class BaseTypeEndpointParameterMapper implements EndpointParameterMapper 
                 return null;
             }
         }
-    }
-
-    public boolean isBaseTypeParam(EndpointParamDef endpointParamDef) {
-        return converter.canDeserialize(SimpleType.construct(endpointParamDef.getRawType()));
     }
 }

--- a/restx-core/src/main/java/restx/endpoint/mappers/ComplexTypeEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/ComplexTypeEndpointParameterMapper.java
@@ -1,14 +1,19 @@
 package restx.endpoint.mappers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import restx.RestxRequest;
 import restx.RestxRequestMatch;
 import restx.endpoint.EndpointParamDef;
 import restx.endpoint.EndpointParameterKind;
 import restx.factory.Component;
+import restx.factory.ParamDef;
 import restx.jackson.FrontObjectMapperFactory;
 
 import javax.inject.Named;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author fcamblor
@@ -28,6 +33,48 @@ public class ComplexTypeEndpointParameterMapper implements EndpointParameterMapp
             RestxRequest request,
             RestxRequestMatch match, EndpointParameterKind parameterKind) {
 
-        throw new IllegalArgumentException("Complex type deserialization on query parameters is not supported yet");
+        return (T) converter.convertValue(buildHierarchicalMapFrom(request.getQueryParams(), endpointParamDef.getParamValuesHandlings()), endpointParamDef.getRawType());
+    }
+
+    /**
+     * Creates a "hierarchical map" from request parameters; this map should be easily deserializable to a target class by jackson afterwards
+     * Also, note that this method will take a ParamValuesHandlings input to know if a given hierarchical map node should be
+     * considered as an iterable (array) of values or not
+     *
+     * For instance :
+     * - queryParams = { "foo": ["baz"], "foo2.bar2": ["baz2"], "foo3.bar3": ["baz3"] }
+     * - paramValuesHandlings = { "foo3.bar3": ARRAY }
+     *
+     * will be transformed into following hierarchical map :
+     * {
+     *     "foo": "baz",
+     *     "foo2": { "bar2": "baz2" },
+     *     "foo3": { "bar3": ["baz3"] }
+     * }
+     */
+    private static Map<String, Object> buildHierarchicalMapFrom(ImmutableMap<String, ImmutableList<String>> queryParams, ParamDef.ParamValuesHandlings paramValuesHandlings) {
+        Map<String, Object> hierarchicalMap = new HashMap<>();
+
+        for(String paramFullPath: queryParams.keySet()) {
+            Map<String, Object> currentNode = hierarchicalMap;
+            StringBuilder currentPathSB = new StringBuilder("");
+            for(String pathChunk: paramFullPath.split("\\.")) {
+                currentPathSB.append(pathChunk);
+                String currentPath = currentPathSB.toString();
+                // Leaf
+                if(paramFullPath.equals(currentPath)) {
+                    paramValuesHandlings.fillNode(currentNode, pathChunk, queryParams.get(currentPath), currentPath);
+                // Not a leaf
+                } else {
+                    if(!currentNode.containsKey(currentPath)) {
+                        currentNode.put(currentPath, new HashMap<String, Object>());
+                    }
+                    currentNode = (Map<String, Object>) currentNode.get(currentPath);
+                }
+                currentPathSB.append(".");
+            }
+        }
+
+        return hierarchicalMap;
     }
 }

--- a/restx-core/src/main/java/restx/endpoint/mappers/ComplexTypeEndpointParameterMapper.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/ComplexTypeEndpointParameterMapper.java
@@ -30,9 +30,4 @@ public class ComplexTypeEndpointParameterMapper implements EndpointParameterMapp
 
         throw new IllegalArgumentException("Complex type deserialization on query parameters is not supported yet");
     }
-
-    public boolean isComplexTypeParam(EndpointParamDef endpointParamDef) {
-        // Everything is a complex type
-        return true;
-    }
 }

--- a/restx-core/src/main/java/restx/endpoint/mappers/DefaultEndpointParameterMapperFactory.java
+++ b/restx-core/src/main/java/restx/endpoint/mappers/DefaultEndpointParameterMapperFactory.java
@@ -3,6 +3,7 @@ package restx.endpoint.mappers;
 import com.google.common.base.Optional;
 import restx.endpoint.EndpointParamDef;
 import restx.factory.Component;
+import restx.types.Types;
 
 /**
  * @author fcamblor
@@ -28,14 +29,14 @@ public class DefaultEndpointParameterMapperFactory implements EndpointParameterM
     public Optional<? extends EndpointParameterMapper> getEndpointParameterMapperFor(EndpointParamDef endpointParamDef) {
         // First option : we're on an aggregate (eg Array | Iterable) of "base" types
         // => we should call BaseTypeAggregateEndpointParameterMapper
-        if(baseTypeAggregateEndpointParameterMapper.isBaseTypeAggregateParam(endpointParamDef)) {
+        if(Types.isAggregateType(endpointParamDef.getRawType().getCanonicalName())) {
             return Optional.of(baseTypeAggregateEndpointParameterMapper);
         // Second option : we're on a "base type" (eg a raw type, a Boxing type, or some type considered as "basic" such
         // as Date or joda dates)
-        } else if(baseTypeEndpointParameterMapper.isBaseTypeParam(endpointParamDef)) {
+        } else if(Types.isRawType(endpointParamDef.getType())) {
             return Optional.of(baseTypeEndpointParameterMapper);
-        // Third option : we're on a "complex type", that is to say a POJO which should be filled with request params
-        } else if(complexTypeEndpointParameterMapper.isComplexTypeParam(endpointParamDef)){
+        // Third option : we're on a "complex type", eg a POJO which should be filled with request params
+        } else if(!Types.isRawType(endpointParamDef.getType())){
             return Optional.of(complexTypeEndpointParameterMapper);
         } else {
             return Optional.absent();

--- a/restx-core/src/main/java/restx/entity/StdEntityRoute.java
+++ b/restx-core/src/main/java/restx/entity/StdEntityRoute.java
@@ -1,7 +1,6 @@
 package restx.entity;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Supplier;
 import restx.*;
 import restx.endpoint.*;
 import restx.endpoint.mappers.EndpointParameterMapper;
@@ -22,31 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Time: 8:10 AM
  */
 public abstract class StdEntityRoute<I,O> extends StdRoute {
-    protected static final Supplier<List> EMPTY_LIST_SUPPLIER = new Supplier<List>() {
-        @Override
-        public List get() {
-            return Collections.emptyList();
-        }
-    };
-    protected static final Supplier<Set> EMPTY_SET_SUPPLIER = new Supplier<Set>() {
-        @Override
-        public Set get() {
-            return Collections.emptySet();
-        }
-    };
-    protected static final Supplier<Iterable> EMPTY_ITERABLE_SUPPLIER = new Supplier<Iterable>() {
-        @Override
-        public Iterable get() {
-            return Collections.emptyList();
-        }
-    };
-    protected static final Supplier<Collection> EMPTY_COLLECTION_SUPPLIER = new Supplier<Collection>() {
-        @Override
-        public Collection get() {
-            return Collections.emptySet();
-        }
-    };
-
     public static class Builder<I,O> {
         protected EntityRequestBodyReader<I> entityRequestBodyReader;
         protected EntityResponseWriter<O> entityResponseWriter;
@@ -217,10 +191,6 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
     }
 
     protected <T> T mapQueryObjectFromRequest(Class<T> targetType, String parameterName, RestxRequest request, RestxRequestMatch match, EndpointParameterKind endpointParameterKind){
-        return mapQueryObjectFromRequest(targetType, parameterName, request, match, endpointParameterKind, null);
-    }
-
-    protected <T> T mapQueryObjectFromRequest(Class<T> targetType, String parameterName, RestxRequest request, RestxRequestMatch match, EndpointParameterKind endpointParameterKind, Supplier<T> nullResultDefaultValueSupplier){
         EndpointParameterMapperAndDef endpointParameterMapperAndDef = cachedQueryParameterMappers.get(parameterName);
         if(endpointParameterMapperAndDef == null) {
             throw new IllegalStateException("No cachedQueryParameterMappers for parameter "+parameterName+" : please provide corresponding ParamDef at instanciation time !");
@@ -231,8 +201,8 @@ public abstract class StdEntityRoute<I,O> extends StdRoute {
                 request, match, endpointParameterKind);
 
         // In case we have a null result *and* a null result default value supplier, let's use it
-        if(nullResultDefaultValueSupplier != null && result == null) {
-            result = nullResultDefaultValueSupplier.get();
+        if(result == null && endpointParameterMapperAndDef.endpointParamDef.isAggregateType()) {
+            result = (T) endpointParameterMapperAndDef.endpointParamDef.getAggregateType().immutableEmptyInstance(endpointParameterMapperAndDef.endpointParamDef.getRawType());
         }
 
         return result;

--- a/restx-factory/src/main/java/restx/config/processor/SettingsAnnotationProcessor.java
+++ b/restx-factory/src/main/java/restx/config/processor/SettingsAnnotationProcessor.java
@@ -33,6 +33,7 @@ public class SettingsAnnotationProcessor extends RestxAbstractProcessor {
     final Template settingsConfigTpl;
 
     public SettingsAnnotationProcessor() {
+        super();
         settingsProviderTpl = Mustaches.compile(SettingsAnnotationProcessor.class, "SettingsProvider.mustache");
         settingsConfigTpl = Mustaches.compile(SettingsAnnotationProcessor.class, "SettingsConfig.mustache");
     }

--- a/restx-factory/src/main/java/restx/factory/ParamDef.java
+++ b/restx-factory/src/main/java/restx/factory/ParamDef.java
@@ -1,8 +1,10 @@
 package restx.factory;
 
 import java.util.Objects;
+
 import restx.common.TypeReference;
 import restx.common.Types;
+import restx.common.AggregateType;
 
 import java.lang.reflect.Type;
 
@@ -14,6 +16,7 @@ public class ParamDef<T> {
     private final TypeReference<T> typeRef;
     private final Class<T> primitiveType;
     private final Class rawType;
+    private final AggregateType aggregateType;
 
     public ParamDef(TypeReference<T> typeRef, String name) {
         this(name, typeRef, null);
@@ -32,6 +35,7 @@ public class ParamDef<T> {
         this.typeRef = typeRef;
         this.primitiveType = primitiveType;
         this.rawType = Types.getRawType(getType());
+        this.aggregateType = Types.aggregateTypeFrom(this.rawType.getCanonicalName()).orNull();
     }
 
     public static <T> ParamDef<T> of(TypeReference<T> type, String name) {
@@ -56,6 +60,14 @@ public class ParamDef<T> {
 
     public Class getRawType() {
         return rawType;
+    }
+
+    public boolean isAggregateType() {
+        return this.aggregateType != null;
+    }
+
+    public AggregateType getAggregateType() {
+        return this.aggregateType;
     }
 
     @Override

--- a/restx-factory/src/main/java/restx/factory/ParamDef.java
+++ b/restx-factory/src/main/java/restx/factory/ParamDef.java
@@ -1,7 +1,11 @@
 package restx.factory;
 
+import java.util.Map;
 import java.util.Objects;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import restx.types.TypeReference;
 import restx.types.Types;
 import restx.types.AggregateType;
@@ -12,38 +16,89 @@ import java.lang.reflect.Type;
  * @author fcamblor
  */
 public class ParamDef<T> {
+    public interface SpecialParamHandling {
+        SpecialParamHandling ARRAYS = new SpecialParamHandling() {
+            @Override
+            public Object extractValueFrom(ImmutableList<String> values, String fullPath) {
+                return values.toArray(new String[0]);
+            }
+        };
+        SpecialParamHandling UNSUPPORTED = new SpecialParamHandling() {
+            @Override
+            public Object extractValueFrom(ImmutableList<String> values, String fullPath) {
+                throw new IllegalArgumentException("Unsupported array of complex type for query parameter "+fullPath);
+            }
+        };
+
+        Object extractValueFrom(ImmutableList<String> values, String fullPath);
+    }
+
+    public static class ParamValuesHandlings {
+        public static final ParamValuesHandlings WITHOUT_SPECIAL_PARAMS = new ParamValuesHandlings();
+
+        final ImmutableMap<String, SpecialParamHandling> pathSpecialParamsHandlig;
+
+        protected ParamValuesHandlings() {
+            this(ImmutableMap.<String, SpecialParamHandling>of());
+        }
+
+        public ParamValuesHandlings(ImmutableMap<String, SpecialParamHandling> pathSpecialParamsHandlig) {
+            this.pathSpecialParamsHandlig = pathSpecialParamsHandlig;
+        }
+
+        public void fillNode(Map<String, Object> currentNode, String fieldName, ImmutableList<String> values, String fullPath) {
+            Object value;
+            if(!pathSpecialParamsHandlig.containsKey(fullPath)) {
+                value = Iterables.getOnlyElement(values);
+            } else {
+                value = pathSpecialParamsHandlig.get(fullPath).extractValueFrom(values, fullPath);
+            }
+            currentNode.put(fieldName, value);
+        }
+    }
+
     private final String name;
     private final TypeReference<T> typeRef;
     private final Class<T> primitiveType;
     private final Class rawType;
     private final AggregateType aggregateType;
+    private final ParamValuesHandlings paramValuesHandlings;
 
     public ParamDef(TypeReference<T> typeRef, String name) {
-        this(name, typeRef, null);
+        this(name, typeRef, null, ParamValuesHandlings.WITHOUT_SPECIAL_PARAMS);
     }
 
     public ParamDef(Class<T> primitiveType, String name) {
-        this(name, null, primitiveType);
+        this(name, null, primitiveType, ParamValuesHandlings.WITHOUT_SPECIAL_PARAMS);
     }
 
     protected ParamDef(ParamDef other) {
-        this(other.name, other.typeRef, other.primitiveType);
+        this(other.name, other.typeRef, other.primitiveType, other.paramValuesHandlings);
     }
 
-    protected ParamDef(String name, TypeReference<T> typeRef, Class<T> primitiveType) {
+    protected ParamDef(String name, TypeReference<T> typeRef, Class<T> primitiveType, ParamValuesHandlings paramValuesHandlings) {
         this.name = name;
         this.typeRef = typeRef;
         this.primitiveType = primitiveType;
         this.rawType = Types.getRawType(getType());
         this.aggregateType = Types.aggregateTypeFrom(this.rawType.getCanonicalName()).orNull();
+        this.paramValuesHandlings = paramValuesHandlings;
     }
 
     public static <T> ParamDef<T> of(TypeReference<T> type, String name) {
-        return new ParamDef(type, name);
+        return new ParamDef(name, type, null, ParamValuesHandlings.WITHOUT_SPECIAL_PARAMS);
+    }
+
+    public static <T> ParamDef<T> of(TypeReference<T> type, String name, ImmutableMap<String, SpecialParamHandling> pathSpecialParamsHandlig) {
+        return new ParamDef(name, type, null, new ParamValuesHandlings(pathSpecialParamsHandlig));
     }
 
     public static <T> ParamDef<T> of(Class<T> rawType, String name) {
-        return new ParamDef(rawType, name);
+        return new ParamDef(name, null, rawType, ParamValuesHandlings.WITHOUT_SPECIAL_PARAMS);
+    }
+
+    public static <T> ParamDef<T> of(Class<T> rawType, String name, ImmutableMap<String, SpecialParamHandling> pathSpecialParamsHandlig) {
+        return new ParamDef(name, null, rawType, new ParamValuesHandlings(pathSpecialParamsHandlig));
     }
 
     public String getName() {
@@ -68,6 +123,10 @@ public class ParamDef<T> {
 
     public AggregateType getAggregateType() {
         return this.aggregateType;
+    }
+
+    public ParamValuesHandlings getParamValuesHandlings() {
+        return paramValuesHandlings;
     }
 
     @Override

--- a/restx-factory/src/main/java/restx/factory/ParamDef.java
+++ b/restx-factory/src/main/java/restx/factory/ParamDef.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import restx.common.TypeReference;
 import restx.common.Types;
-import restx.common.AggregateType;
+import restx.types.AggregateType;
 
 import java.lang.reflect.Type;
 

--- a/restx-factory/src/main/java/restx/factory/ParamDef.java
+++ b/restx-factory/src/main/java/restx/factory/ParamDef.java
@@ -2,8 +2,8 @@ package restx.factory;
 
 import java.util.Objects;
 
-import restx.common.TypeReference;
-import restx.common.Types;
+import restx.types.TypeReference;
+import restx.types.Types;
 import restx.types.AggregateType;
 
 import java.lang.reflect.Type;

--- a/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
+++ b/restx-factory/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
@@ -45,6 +45,7 @@ public class FactoryAnnotationProcessor extends RestxAbstractProcessor {
     private final FactoryAnnotationProcessor.ServicesDeclaration machinesDeclaration;
 
     public FactoryAnnotationProcessor() {
+        super();
         componentMachineTpl = compile(FactoryAnnotationProcessor.class, "ComponentMachine.mustache");
         conditionalMachineTpl = compile(FactoryAnnotationProcessor.class, "ConditionalMachine.mustache");
         moduleMachineTpl = compile(FactoryAnnotationProcessor.class, "ModuleMachine.mustache");

--- a/restx-jongo/src/main/java/restx/types/JongoRawTypesDefinition.java
+++ b/restx-jongo/src/main/java/restx/types/JongoRawTypesDefinition.java
@@ -1,0 +1,9 @@
+package restx.types;
+
+import org.bson.types.ObjectId;
+
+public class JongoRawTypesDefinition extends RawTypesDefinition.ClassBasedRawTypesDefinition {
+    public JongoRawTypesDefinition() {
+        super(ObjectId.class);
+    }
+}

--- a/restx-jongo/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
+++ b/restx-jongo/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
@@ -1,0 +1,1 @@
+restx.types.JongoRawTypesDefinition

--- a/restx-samplest-custom-types-testing/md.restx.json
+++ b/restx-samplest-custom-types-testing/md.restx.json
@@ -1,0 +1,14 @@
+{
+    "parent": "io.restx:restx-parent:${restx.version}",
+    "module": "io.restx:restx-samplest-custom-types-testing:${restx.version}",
+
+    "properties": {
+      "@files": ["../restx.build.properties.json"]
+    },
+
+    "dependencies": {
+        "compile": [
+            "io.restx:restx-common:${restx.version}"
+        ]
+    }
+}

--- a/restx-samplest-custom-types-testing/module.ivy
+++ b/restx-samplest-custom-types-testing/module.ivy
@@ -1,0 +1,19 @@
+<ivy-module version="2.0" xmlns:ea="http://www.easyant.org">
+    <info organisation="io.restx" module="restx-samplest-custom-types-testing" revision="0.36" status="integration">
+        <ea:build organisation="org.apache.easyant.buildtypes" module="build-std-java" revision="0.9"
+            compile.java.source.version="1.7"
+            compile.java.target.version="1.7"
+        />
+    </info>
+    <configurations>
+        <conf name="default"/>
+        <conf name="runtime"/>
+        <conf name="test"/>
+    </configurations>
+    <publications>
+        <artifact type="jar"/>
+    </publications>
+    <dependencies>
+        <dependency org="io.restx" name="restx-common" rev="latest.integration" conf="default" />
+    </dependencies>
+</ivy-module>

--- a/restx-samplest-custom-types-testing/pom.xml
+++ b/restx-samplest-custom-types-testing/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.restx</groupId>
+        <artifactId>restx-parent</artifactId>
+        <version>0.36-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>restx-samplest-custom-types-testing</artifactId>
+    <name>restx-samplest-custom-types-testing</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.restx</groupId>
+            <artifactId>restx-common</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/restx-samplest-custom-types-testing/src/main/java/samplest/types/CustomRawTypeDefinition.java
+++ b/restx-samplest-custom-types-testing/src/main/java/samplest/types/CustomRawTypeDefinition.java
@@ -1,0 +1,9 @@
+package samplest.types;
+
+import restx.types.RawTypesDefinition;
+
+public class CustomRawTypeDefinition extends RawTypesDefinition.FQCNBasedRawTypesDefinition {
+    public CustomRawTypeDefinition() {
+        super("samplest.models.MyCustomValueClass");
+    }
+}

--- a/restx-samplest-custom-types-testing/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
+++ b/restx-samplest-custom-types-testing/src/main/resources/META-INF/services/restx.types.RawTypesDefinition
@@ -1,0 +1,1 @@
+samplest.types.CustomRawTypeDefinition

--- a/restx-samplest/md.restx.json
+++ b/restx-samplest/md.restx.json
@@ -28,6 +28,7 @@
             "io.restx:restx-apidocs:${restx.version}",
             "io.restx:restx-specs-admin:${restx.version}",
             "io.restx:restx-i18n-admin:${restx.version}",
+            "io.restx:restx-samplest-custom-types-testing:${restx.version}",
             "ch.qos.logback:logback-classic:${logback.version}"
         ],
         "runtime": [

--- a/restx-samplest/module.ivy
+++ b/restx-samplest/module.ivy
@@ -27,6 +27,7 @@
         <dependency org="io.restx" name="restx-apidocs" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-specs-admin" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-i18n-admin" rev="latest.integration" conf="default" />
+        <dependency org="io.restx" name="restx-samplest-custom-types-testing" rev="latest.integration" conf="default" />
         <dependency org="ch.qos.logback" name="logback-classic" rev="1.0.13" conf="default" />
         <dependency org="io.restx" name="restx-barbarywatch" rev="latest.integration" conf="runtime->default" />
         <dependency org="io.restx" name="restx-specs-tests" rev="latest.integration" conf="test->default" />

--- a/restx-samplest/pom.xml
+++ b/restx-samplest/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>restx-i18n-admin</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.restx</groupId>
+            <artifactId>restx-samplest-custom-types-testing</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>

--- a/restx-samplest/src/main/java/samplest/core/ParametersResource.java
+++ b/restx-samplest/src/main/java/samplest/core/ParametersResource.java
@@ -2,6 +2,7 @@ package samplest.core;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ObjectArrays;
 import org.joda.time.DateTime;
@@ -10,9 +11,12 @@ import restx.RestxRequest;
 import restx.annotations.*;
 import restx.factory.Component;
 import restx.security.PermitAll;
+import samplest.models.AllRawTypesCriteria;
+import samplest.models.SearchCriteria;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -125,6 +129,21 @@ public class ParametersResource {
     @GET("/params/optionalArrayedJodaDatesParams")
     public DateTime[] optionalArrayedJodaDatesParams(Optional<DateTime[]> params, Optional<DateTime[]> otherParams) {
         return ObjectArrays.concat(params.or(new DateTime[0]), otherParams.or(new DateTime[0]), DateTime.class);
+    }
+
+    @GET("/params/complexParams")
+    public SearchCriteria.ConcreteSearchCriteria complexParams(SearchCriteria.ConcreteSearchCriteria criteria) {
+        return criteria;
+    }
+
+    @GET("/params/allRawTypesCriteria")
+    public AllRawTypesCriteria allRawTypesCriteria(AllRawTypesCriteria criteria) {
+        return criteria;
+    }
+
+    @GET("/params/multipleComplexParams")
+    public Map<String, Object> complexParams(SearchCriteria.ConcreteSearchCriteria criteria, AllRawTypesCriteria anotherCriteria, Optional<String> v1) {
+        return ImmutableMap.of("criteria", criteria, "v1", v1, "allRawTypesCriteria", anotherCriteria);
     }
 
     @GET("/params/headers")

--- a/restx-samplest/src/main/java/samplest/models/AllRawTypesCriteria.java
+++ b/restx-samplest/src/main/java/samplest/models/AllRawTypesCriteria.java
@@ -1,0 +1,368 @@
+package samplest.models;
+
+import org.joda.time.*;
+
+import javax.validation.constraints.Size;
+import java.io.File;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class AllRawTypesCriteria {
+    enum MyEnum { foo, bar }
+
+    @Size(min=3,max=10)
+    String str;
+
+    Class clazz;
+    MyEnum myEnum;
+    File file;
+    BigDecimal bigDecimal;
+    BigInteger bigInteger;
+
+    Currency currency;
+    Date date;
+    Locale locale;
+    TimeZone timeZone;
+    UUID uuid;
+    Charset charset;
+    Path path;
+
+    Pattern pattern;
+    URI uri;
+    URL url;
+
+    DateTime jodaDateTime;
+    Instant jodaInstant;
+    LocalDate jodaLocalDate;
+    LocalDateTime jodaLocalDateTime;
+    LocalTime jodaLocalTime;
+    DateTimeZone jodaTimeZone;
+
+    byte aByte;
+    short aShort;
+    int anInt;
+    long aLong;
+    float aFloat;
+    double aDouble;
+    boolean aBoolean;
+    char aChar;
+
+    Byte aByteWrapper;
+    Short aShortWrapper;
+    Integer anIntegerWrapper;
+    Long aLongWrapper;
+    Float aFloatWrapper;
+    Double aDoubleWrapper;
+    Boolean aBooleanWrapper;
+    Character aCharacterWrapper;
+
+    public String getStr() {
+        return str;
+    }
+
+    public void setStr(String str) {
+        this.str = str;
+    }
+
+    public Class getClazz() {
+        return clazz;
+    }
+
+    public void setClazz(Class clazz) {
+        this.clazz = clazz;
+    }
+
+    public MyEnum getMyEnum() {
+        return myEnum;
+    }
+
+    public void setMyEnum(MyEnum myEnum) {
+        this.myEnum = myEnum;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public void setFile(File file) {
+        this.file = file;
+    }
+
+    public BigDecimal getBigDecimal() {
+        return bigDecimal;
+    }
+
+    public void setBigDecimal(BigDecimal bigDecimal) {
+        this.bigDecimal = bigDecimal;
+    }
+
+    public BigInteger getBigInteger() {
+        return bigInteger;
+    }
+
+    public void setBigInteger(BigInteger bigInteger) {
+        this.bigInteger = bigInteger;
+    }
+
+    public Currency getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(Currency currency) {
+        this.currency = currency;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public Locale getLocale() {
+        return locale;
+    }
+
+    public void setLocale(Locale locale) {
+        this.locale = locale;
+    }
+
+    public TimeZone getTimeZone() {
+        return timeZone;
+    }
+
+    public void setTimeZone(TimeZone timeZone) {
+        this.timeZone = timeZone;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public Charset getCharset() {
+        return charset;
+    }
+
+    public void setCharset(Charset charset) {
+        this.charset = charset;
+    }
+
+    public Path getPath() {
+        return path;
+    }
+
+    public void setPath(Path path) {
+        this.path = path;
+    }
+
+    public Pattern getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    public void setUrl(URL url) {
+        this.url = url;
+    }
+
+    public DateTime getJodaDateTime() {
+        return jodaDateTime;
+    }
+
+    public void setJodaDateTime(DateTime jodaDateTime) {
+        this.jodaDateTime = jodaDateTime;
+    }
+
+    public Instant getJodaInstant() {
+        return jodaInstant;
+    }
+
+    public void setJodaInstant(Instant jodaInstant) {
+        this.jodaInstant = jodaInstant;
+    }
+
+    public LocalDate getJodaLocalDate() {
+        return jodaLocalDate;
+    }
+
+    public void setJodaLocalDate(LocalDate jodaLocalDate) {
+        this.jodaLocalDate = jodaLocalDate;
+    }
+
+    public LocalDateTime getJodaLocalDateTime() {
+        return jodaLocalDateTime;
+    }
+
+    public void setJodaLocalDateTime(LocalDateTime jodaLocalDateTime) {
+        this.jodaLocalDateTime = jodaLocalDateTime;
+    }
+
+    public LocalTime getJodaLocalTime() {
+        return jodaLocalTime;
+    }
+
+    public void setJodaLocalTime(LocalTime jodaLocalTime) {
+        this.jodaLocalTime = jodaLocalTime;
+    }
+
+    public DateTimeZone getJodaTimeZone() {
+        return jodaTimeZone;
+    }
+
+    public void setJodaTimeZone(DateTimeZone jodaTimeZone) {
+        this.jodaTimeZone = jodaTimeZone;
+    }
+
+    public byte getaByte() {
+        return aByte;
+    }
+
+    public void setaByte(byte aByte) {
+        this.aByte = aByte;
+    }
+
+    public short getaShort() {
+        return aShort;
+    }
+
+    public void setaShort(short aShort) {
+        this.aShort = aShort;
+    }
+
+    public int getAnInt() {
+        return anInt;
+    }
+
+    public void setAnInt(int anInt) {
+        this.anInt = anInt;
+    }
+
+    public long getaLong() {
+        return aLong;
+    }
+
+    public void setaLong(long aLong) {
+        this.aLong = aLong;
+    }
+
+    public float getaFloat() {
+        return aFloat;
+    }
+
+    public void setaFloat(float aFloat) {
+        this.aFloat = aFloat;
+    }
+
+    public double getaDouble() {
+        return aDouble;
+    }
+
+    public void setaDouble(double aDouble) {
+        this.aDouble = aDouble;
+    }
+
+    public boolean isaBoolean() {
+        return aBoolean;
+    }
+
+    public void setaBoolean(boolean aBoolean) {
+        this.aBoolean = aBoolean;
+    }
+
+    public char getaChar() {
+        return aChar;
+    }
+
+    public void setaChar(char aChar) {
+        this.aChar = aChar;
+    }
+
+    public Byte getaByteWrapper() {
+        return aByteWrapper;
+    }
+
+    public void setaByteWrapper(Byte aByteWrapper) {
+        this.aByteWrapper = aByteWrapper;
+    }
+
+    public Short getaShortWrapper() {
+        return aShortWrapper;
+    }
+
+    public void setaShortWrapper(Short aShortWrapper) {
+        this.aShortWrapper = aShortWrapper;
+    }
+
+    public Integer getAnIntegerWrapper() {
+        return anIntegerWrapper;
+    }
+
+    public void setAnIntegerWrapper(Integer anIntegerWrapper) {
+        this.anIntegerWrapper = anIntegerWrapper;
+    }
+
+    public Long getaLongWrapper() {
+        return aLongWrapper;
+    }
+
+    public void setaLongWrapper(Long aLongWrapper) {
+        this.aLongWrapper = aLongWrapper;
+    }
+
+    public Float getaFloatWrapper() {
+        return aFloatWrapper;
+    }
+
+    public void setaFloatWrapper(Float aFloatWrapper) {
+        this.aFloatWrapper = aFloatWrapper;
+    }
+
+    public Double getaDoubleWrapper() {
+        return aDoubleWrapper;
+    }
+
+    public void setaDoubleWrapper(Double aDoubleWrapper) {
+        this.aDoubleWrapper = aDoubleWrapper;
+    }
+
+    public Boolean getaBooleanWrapper() {
+        return aBooleanWrapper;
+    }
+
+    public void setaBooleanWrapper(Boolean aBooleanWrapper) {
+        this.aBooleanWrapper = aBooleanWrapper;
+    }
+
+    public Character getaCharacterWrapper() {
+        return aCharacterWrapper;
+    }
+
+    public void setaCharacterWrapper(Character aCharacterWrapper) {
+        this.aCharacterWrapper = aCharacterWrapper;
+    }
+}

--- a/restx-samplest/src/main/java/samplest/models/AllRawTypesCriteria.java
+++ b/restx-samplest/src/main/java/samplest/models/AllRawTypesCriteria.java
@@ -1,5 +1,6 @@
 package samplest.models;
 
+import org.bson.types.ObjectId;
 import org.joda.time.*;
 
 import javax.validation.constraints.Size;
@@ -36,6 +37,8 @@ public class AllRawTypesCriteria {
     Pattern pattern;
     URI uri;
     URL url;
+
+    ObjectId objectId;
 
     DateTime jodaDateTime;
     Instant jodaInstant;
@@ -236,6 +239,17 @@ public class AllRawTypesCriteria {
 
     public void setJodaTimeZone(DateTimeZone jodaTimeZone) {
         this.jodaTimeZone = jodaTimeZone;
+    }
+
+    public String getObjectId() {
+        if(objectId == null) {
+            return null;
+        }
+        return objectId.toString();
+    }
+
+    public void setObjectId(ObjectId objectId) {
+        this.objectId = objectId;
     }
 
     public byte getaByte() {

--- a/restx-samplest/src/main/java/samplest/models/MyCustomValueClass.java
+++ b/restx-samplest/src/main/java/samplest/models/MyCustomValueClass.java
@@ -1,0 +1,49 @@
+package samplest.models;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+@JsonDeserialize(using = MyCustomValueClass.Deserializer.class)
+@JsonSerialize(using = MyCustomValueClass.Serializer.class)
+public final class MyCustomValueClass<T> {
+    String value;
+
+    public MyCustomValueClass(String value) {
+        this.value = value;
+    }
+
+    public T getFoo() {
+        return null;
+    }
+
+    public static class Deserializer extends StdDeserializer<MyCustomValueClass> {
+        public Deserializer() {
+            super(MyCustomValueClass.class);
+        }
+
+        @Override
+        public MyCustomValueClass deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+            return new MyCustomValueClass(jsonParser.getValueAsString());
+        }
+    }
+
+    public static class Serializer extends StdSerializer<MyCustomValueClass> {
+        public Serializer() {
+            super(MyCustomValueClass.class);
+        }
+
+        @Override
+        public void serialize(MyCustomValueClass myCustomValueClass, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+            jsonGenerator.writeString(myCustomValueClass.value);
+        }
+    }
+}

--- a/restx-samplest/src/main/java/samplest/models/ParentSearchCriteria.java
+++ b/restx-samplest/src/main/java/samplest/models/ParentSearchCriteria.java
@@ -1,0 +1,13 @@
+package samplest.models;
+
+public class ParentSearchCriteria {
+    String v0;
+
+    public String getV0() {
+        return v0;
+    }
+
+    public void setV0(String v0) {
+        this.v0 = v0;
+    }
+}

--- a/restx-samplest/src/main/java/samplest/models/SearchCriteria.java
+++ b/restx-samplest/src/main/java/samplest/models/SearchCriteria.java
@@ -20,12 +20,14 @@ public class SearchCriteria<T> extends ParentSearchCriteria {
     DateTime v4;
     T v5;
     SearchType v6;
+    MyCustomValueClass<String> v7;
     String[] multipleV5;
     List<String> multipleV6;
     Iterable<String> multipleV7;
     DateTime[] multipleV8;
     SearchType[] multipleV9;
     List<SearchType> multipleV10;
+    List<MyCustomValueClass<String>> multipleV11;
     SearchCriteria<T> nestedCriteria;
     // An iterable/array of "complex" (by "complex", I mean not a "value" type) type should not be mapped
     // and should trigger an error when provided in request params
@@ -143,5 +145,21 @@ public class SearchCriteria<T> extends ParentSearchCriteria {
 
     public void setMultipleV10(List<SearchType> multipleV10) {
         this.multipleV10 = multipleV10;
+    }
+
+    public MyCustomValueClass<String> getV7() {
+        return v7;
+    }
+
+    public void setV7(MyCustomValueClass<String> v7) {
+        this.v7 = v7;
+    }
+
+    public List<MyCustomValueClass<String>> getMultipleV11() {
+        return multipleV11;
+    }
+
+    public void setMultipleV11(List<MyCustomValueClass<String>> multipleV11) {
+        this.multipleV11 = multipleV11;
     }
 }

--- a/restx-samplest/src/main/java/samplest/models/SearchCriteria.java
+++ b/restx-samplest/src/main/java/samplest/models/SearchCriteria.java
@@ -10,16 +10,22 @@ public class SearchCriteria<T> extends ParentSearchCriteria {
     // Declaring a SearchCriteria<BigDecimal> as method parameter doesn't work (Jacksong deserializes node to a String, everytime)
     public static class ConcreteSearchCriteria extends SearchCriteria<BigDecimal> {
     }
+    public enum SearchType {
+        SIMPLE, COMPLEX
+    }
 
     String v1;
     Integer v2;
     BigDecimal v3;
     DateTime v4;
     T v5;
+    SearchType v6;
     String[] multipleV5;
     List<String> multipleV6;
     Iterable<String> multipleV7;
     DateTime[] multipleV8;
+    SearchType[] multipleV9;
+    List<SearchType> multipleV10;
     SearchCriteria<T> nestedCriteria;
     // An iterable/array of "complex" (by "complex", I mean not a "value" type) type should not be mapped
     // and should trigger an error when provided in request params
@@ -113,5 +119,29 @@ public class SearchCriteria<T> extends ParentSearchCriteria {
 
     public void setUnsupportedNestedMultipleCriteria(SearchCriteria<T>[] unsupportedNestedMultipleCriteria) {
         this.unsupportedNestedMultipleCriteria = unsupportedNestedMultipleCriteria;
+    }
+
+    public SearchType getV6() {
+        return v6;
+    }
+
+    public void setV6(SearchType v6) {
+        this.v6 = v6;
+    }
+
+    public SearchType[] getMultipleV9() {
+        return multipleV9;
+    }
+
+    public void setMultipleV9(SearchType[] multipleV9) {
+        this.multipleV9 = multipleV9;
+    }
+
+    public List<SearchType> getMultipleV10() {
+        return multipleV10;
+    }
+
+    public void setMultipleV10(List<SearchType> multipleV10) {
+        this.multipleV10 = multipleV10;
     }
 }

--- a/restx-samplest/src/main/java/samplest/models/SearchCriteria.java
+++ b/restx-samplest/src/main/java/samplest/models/SearchCriteria.java
@@ -1,0 +1,117 @@
+package samplest.models;
+
+import org.joda.time.DateTime;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class SearchCriteria<T> extends ParentSearchCriteria {
+
+    // Declaring a SearchCriteria<BigDecimal> as method parameter doesn't work (Jacksong deserializes node to a String, everytime)
+    public static class ConcreteSearchCriteria extends SearchCriteria<BigDecimal> {
+    }
+
+    String v1;
+    Integer v2;
+    BigDecimal v3;
+    DateTime v4;
+    T v5;
+    String[] multipleV5;
+    List<String> multipleV6;
+    Iterable<String> multipleV7;
+    DateTime[] multipleV8;
+    SearchCriteria<T> nestedCriteria;
+    // An iterable/array of "complex" (by "complex", I mean not a "value" type) type should not be mapped
+    // and should trigger an error when provided in request params
+    // To reference such nested entry, we should use a syntax like "unsupportedNestedMultipleCriteria[0].v1=foo"
+    // and we don't want to allow such syntax in query params
+    SearchCriteria<T>[] unsupportedNestedMultipleCriteria;
+
+    public String getV1() {
+        return v1;
+    }
+
+    public void setV1(String v1) {
+        this.v1 = v1;
+    }
+
+    public Integer getV2() {
+        return v2;
+    }
+
+    public void setV2(Integer v2) {
+        this.v2 = v2;
+    }
+
+    public BigDecimal getV3() {
+        return v3;
+    }
+
+    public void setV3(BigDecimal v3) {
+        this.v3 = v3;
+    }
+
+    public DateTime getV4() {
+        return v4;
+    }
+
+    public void setV4(DateTime v4) {
+        this.v4 = v4;
+    }
+
+    public T getV5() {
+        return v5;
+    }
+
+    public void setV5(T v5) {
+        this.v5 = v5;
+    }
+
+    public String[] getMultipleV5() {
+        return multipleV5;
+    }
+
+    public void setMultipleV5(String[] multipleV5) {
+        this.multipleV5 = multipleV5;
+    }
+
+    public List<String> getMultipleV6() {
+        return multipleV6;
+    }
+
+    public void setMultipleV6(List<String> multipleV6) {
+        this.multipleV6 = multipleV6;
+    }
+
+    public Iterable<String> getMultipleV7() {
+        return multipleV7;
+    }
+
+    public void setMultipleV7(Iterable<String> multipleV7) {
+        this.multipleV7 = multipleV7;
+    }
+
+    public DateTime[] getMultipleV8() {
+        return multipleV8;
+    }
+
+    public void setMultipleV8(DateTime[] multipleV8) {
+        this.multipleV8 = multipleV8;
+    }
+
+    public SearchCriteria<T> getNestedCriteria() {
+        return nestedCriteria;
+    }
+
+    public void setNestedCriteria(SearchCriteria<T> nestedCriteria) {
+        this.nestedCriteria = nestedCriteria;
+    }
+
+    public SearchCriteria<T>[] getUnsupportedNestedMultipleCriteria() {
+        return unsupportedNestedMultipleCriteria;
+    }
+
+    public void setUnsupportedNestedMultipleCriteria(SearchCriteria<T>[] unsupportedNestedMultipleCriteria) {
+        this.unsupportedNestedMultipleCriteria = unsupportedNestedMultipleCriteria;
+    }
+}

--- a/restx-samplest/src/main/resources/specs/parameters/all_raw_types_criteria_as_query_param_values.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/parameters/all_raw_types_criteria_as_query_param_values.spec.yaml
@@ -1,0 +1,28 @@
+title: All Raw Types Criteria as Query Param Values
+given:
+  - time: 2014-12-24T17:01:21.795+02:00
+wts:
+  - when: |
+       GET params/allRawTypesCriteria?str=aaa&clazz=java.lang.String&myEnum=foo&file=/tmp/foo&bigDecimal=123.45&bigInteger=123
+    then: |
+       {"str":"aaa","clazz":"java.lang.String","file":"/tmp/foo","bigDecimal":123.45,"bigInteger":123}
+  - when: |
+       GET params/allRawTypesCriteria?currency=EUR&date=2018-02-20T16:39:20.123Z&locale=fr_FR&timeZone=UTC&uuid=56f71fcc-42d3-422f-9458-8ad37fc4a0b5&charset=UTF-8&path=/tmp/foo
+    then: |
+       {"currency":"EUR","date":"2018-02-20T16:39:20.123+0000","locale":"fr_FR","timeZone":"UTC","uuid":"56f71fcc-42d3-422f-9458-8ad37fc4a0b5","charset":"UTF-8","path":"file:///tmp/foo"}
+  - when: |
+       GET params/allRawTypesCriteria?pattern=[a-zA-Z0-9]*&uri=http://www.restx.io&url=http://www.restx.io
+    then: |
+       {"pattern":"[a-zA-Z0-9]*","uri":"http://www.restx.io","url":"http://www.restx.io"}
+  - when: |
+       GET params/allRawTypesCriteria?jodaDateTime=2018-02-20T17:39:20.123%2B0100&jodaInstant=2018-02-20T17:39:20.123%2B0100&jodaLocalDate=2018-02-20&jodaLocalDateTime=2018-02-20T16:39:20.123&jodaLocalTime=16:39:20.123&jodaTimeZone=Europe/Paris
+    then: |
+       {"jodaDateTime":"2018-02-20T16:39:20.123Z","jodaInstant":"2018-02-20T16:39:20.123Z","jodaLocalDate":"2018-02-20","jodaLocalDateTime":"2018-02-20T16:39:20.123","jodaLocalTime":"16:39:20.123","jodaTimeZone":"Europe/Paris"}
+  - when: |
+       GET params/allRawTypesCriteria?aByte=123&aShort=123&anInt=123&aLong=123&aFloat=123.45&aDouble=123.45&aBoolean=false&aChar=Z
+    then: |
+       {"aByte":123,"aShort":123,"anInt":123,"aLong":123,"aFloat":123.45,"aDouble":123.45,"aBoolean":false,"aChar":"Z"}
+  - when: |
+       GET params/allRawTypesCriteria?aByteWrapper=123&aShortWrapper=123&anIntegerWrapper=123&aLongWrapper=123&aFloatWrapper=123.45&aDoubleWrapper=123.45&aBooleanWrapper=false&aCharacterWrapper=Z
+    then: |
+       {"aByteWrapper":123,"aShortWrapper":123,"anIntegerWrapper":123,"aLongWrapper":123,"aFloatWrapper":123.45,"aDoubleWrapper":123.45,"aBooleanWrapper":false,"aCharacterWrapper":"Z"}

--- a/restx-samplest/src/main/resources/specs/parameters/all_raw_types_criteria_as_query_param_values.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/parameters/all_raw_types_criteria_as_query_param_values.spec.yaml
@@ -19,6 +19,10 @@ wts:
     then: |
        {"jodaDateTime":"2018-02-20T16:39:20.123Z","jodaInstant":"2018-02-20T16:39:20.123Z","jodaLocalDate":"2018-02-20","jodaLocalDateTime":"2018-02-20T16:39:20.123","jodaLocalTime":"16:39:20.123","jodaTimeZone":"Europe/Paris"}
   - when: |
+       GET params/allRawTypesCriteria?objectId=5167cec5856107c479739654
+    then: |
+       {"objectId":"5167cec5856107c479739654"}
+  - when: |
        GET params/allRawTypesCriteria?aByte=123&aShort=123&anInt=123&aLong=123&aFloat=123.45&aDouble=123.45&aBoolean=false&aChar=Z
     then: |
        {"aByte":123,"aShort":123,"anInt":123,"aLong":123,"aFloat":123.45,"aDouble":123.45,"aBoolean":false,"aChar":"Z"}

--- a/restx-samplest/src/main/resources/specs/parameters/complex_pojo_for_query_param_values.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/parameters/complex_pojo_for_query_param_values.spec.yaml
@@ -3,21 +3,21 @@ given:
   - time: 2014-12-24T17:01:21.795+02:00
 wts:
   - when: |
-       GET params/complexParams?v0=aaa&v1=aaa&v2=123&v3=456&v4=2018-02-12T23:42:31.795Z&v5=789&v6=SIMPLE
+       GET params/complexParams?v0=aaa&v1=aaa&v2=123&v3=456&v4=2018-02-12T23:42:31.795Z&v5=789&v6=SIMPLE&v7=blah
     then: |
-       {"v0":"aaa","v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789, "v6": "SIMPLE"}
+       {"v0":"aaa","v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789, "v6": "SIMPLE", "v7":"blah"}
   - when: |
-       GET params/complexParams?multipleV5=bbb&multipleV5=ccc&multipleV6=ddd&multipleV7=eee&multipleV8=2018-02-12T23:42:31.795Z&multipleV9=COMPLEX&multipleV10=COMPLEX
+       GET params/complexParams?multipleV5=bbb&multipleV5=ccc&multipleV6=ddd&multipleV7=eee&multipleV8=2018-02-12T23:42:31.795Z&multipleV9=COMPLEX&multipleV10=COMPLEX&multipleV11=blah
     then: |
-       {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"], "multipleV9": ["COMPLEX"], "multipleV10": ["COMPLEX"]}
+       {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"], "multipleV9": ["COMPLEX"], "multipleV10": ["COMPLEX"], "multipleV11": ["blah"]}
   - when: |
-       GET params/complexParams?nestedCriteria.v0=aaa&nestedCriteria.v1=aaa&nestedCriteria.v2=123&nestedCriteria.v3=456&nestedCriteria.v4=2018-02-12T23:42:31.795Z&nestedCriteria.v5=789&nestedCriteria.v6=SIMPLE
+       GET params/complexParams?nestedCriteria.v0=aaa&nestedCriteria.v1=aaa&nestedCriteria.v2=123&nestedCriteria.v3=456&nestedCriteria.v4=2018-02-12T23:42:31.795Z&nestedCriteria.v5=789&nestedCriteria.v6=SIMPLE&nestedCriteria.v7=blah
     then: |
-       { "nestedCriteria": {"v0":"aaa", "v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789, "v6": "SIMPLE"} }
+       { "nestedCriteria": {"v0":"aaa", "v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789, "v6": "SIMPLE", "v7": "blah"} }
   - when: |
-       GET params/complexParams?nestedCriteria.multipleV5=bbb&nestedCriteria.multipleV5=ccc&nestedCriteria.multipleV6=ddd&nestedCriteria.multipleV7=eee&nestedCriteria.multipleV8=2018-02-12T23:42:31.795Z&nestedCriteria.multipleV9=COMPLEX&nestedCriteria.multipleV10=COMPLEX
+       GET params/complexParams?nestedCriteria.multipleV5=bbb&nestedCriteria.multipleV5=ccc&nestedCriteria.multipleV6=ddd&nestedCriteria.multipleV7=eee&nestedCriteria.multipleV8=2018-02-12T23:42:31.795Z&nestedCriteria.multipleV9=COMPLEX&nestedCriteria.multipleV10=COMPLEX&nestedCriteria.multipleV11=blah
     then: |
-       { "nestedCriteria": {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"], "multipleV9": ["COMPLEX"], "multipleV10": ["COMPLEX"]} }
+       { "nestedCriteria": {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"], "multipleV9": ["COMPLEX"], "multipleV10": ["COMPLEX"], "multipleV11": ["blah"]} }
   - when: |
        GET params/multipleComplexParams?v0=aaa&v1=bbb&str=ccc
     then: |

--- a/restx-samplest/src/main/resources/specs/parameters/complex_pojo_for_query_param_values.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/parameters/complex_pojo_for_query_param_values.spec.yaml
@@ -1,0 +1,29 @@
+title: Complex POJO for Query Param Values
+given:
+  - time: 2014-12-24T17:01:21.795+02:00
+wts:
+  - when: |
+       GET params/complexParams?v0=aaa&v1=aaa&v2=123&v3=456&v4=2018-02-12T23:42:31.795Z&v5=789
+    then: |
+       {"v0":"aaa","v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789}
+  - when: |
+       GET params/complexParams?multipleV5=bbb&multipleV5=ccc&multipleV6=ddd&multipleV7=eee&multipleV8=2018-02-12T23:42:31.795Z
+    then: |
+       {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"]}
+  - when: |
+       GET params/complexParams?nestedCriteria.v0=aaa&nestedCriteria.v1=aaa&nestedCriteria.v2=123&nestedCriteria.v3=456&nestedCriteria.v4=2018-02-12T23:42:31.795Z&nestedCriteria.v5=789
+    then: |
+       { "nestedCriteria": {"v0":"aaa", "v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789} }
+  - when: |
+       GET params/complexParams?nestedCriteria.multipleV5=bbb&nestedCriteria.multipleV5=ccc&nestedCriteria.multipleV6=ddd&nestedCriteria.multipleV7=eee&nestedCriteria.multipleV8=2018-02-12T23:42:31.795Z
+    then: |
+       { "nestedCriteria": {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"]} }
+  - when: |
+       GET params/multipleComplexParams?v0=aaa&v1=bbb&str=ccc
+    then: |
+       { "criteria":{"v0":"aaa","v1":"bbb"}, "v1":"bbb", "allRawTypesCriteria":{"str":"ccc"} }
+  - when: |
+       GET params/complexParams?unknownProperty=foo
+    then: |
+       200
+       {}

--- a/restx-samplest/src/main/resources/specs/parameters/complex_pojo_for_query_param_values.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/parameters/complex_pojo_for_query_param_values.spec.yaml
@@ -3,21 +3,21 @@ given:
   - time: 2014-12-24T17:01:21.795+02:00
 wts:
   - when: |
-       GET params/complexParams?v0=aaa&v1=aaa&v2=123&v3=456&v4=2018-02-12T23:42:31.795Z&v5=789
+       GET params/complexParams?v0=aaa&v1=aaa&v2=123&v3=456&v4=2018-02-12T23:42:31.795Z&v5=789&v6=SIMPLE
     then: |
-       {"v0":"aaa","v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789}
+       {"v0":"aaa","v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789, "v6": "SIMPLE"}
   - when: |
-       GET params/complexParams?multipleV5=bbb&multipleV5=ccc&multipleV6=ddd&multipleV7=eee&multipleV8=2018-02-12T23:42:31.795Z
+       GET params/complexParams?multipleV5=bbb&multipleV5=ccc&multipleV6=ddd&multipleV7=eee&multipleV8=2018-02-12T23:42:31.795Z&multipleV9=COMPLEX&multipleV10=COMPLEX
     then: |
-       {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"]}
+       {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"], "multipleV9": ["COMPLEX"], "multipleV10": ["COMPLEX"]}
   - when: |
-       GET params/complexParams?nestedCriteria.v0=aaa&nestedCriteria.v1=aaa&nestedCriteria.v2=123&nestedCriteria.v3=456&nestedCriteria.v4=2018-02-12T23:42:31.795Z&nestedCriteria.v5=789
+       GET params/complexParams?nestedCriteria.v0=aaa&nestedCriteria.v1=aaa&nestedCriteria.v2=123&nestedCriteria.v3=456&nestedCriteria.v4=2018-02-12T23:42:31.795Z&nestedCriteria.v5=789&nestedCriteria.v6=SIMPLE
     then: |
-       { "nestedCriteria": {"v0":"aaa", "v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789} }
+       { "nestedCriteria": {"v0":"aaa", "v1": "aaa", "v2": 123, "v3": 456, "v4": "2018-02-12T23:42:31.795Z", "v5": 789, "v6": "SIMPLE"} }
   - when: |
-       GET params/complexParams?nestedCriteria.multipleV5=bbb&nestedCriteria.multipleV5=ccc&nestedCriteria.multipleV6=ddd&nestedCriteria.multipleV7=eee&nestedCriteria.multipleV8=2018-02-12T23:42:31.795Z
+       GET params/complexParams?nestedCriteria.multipleV5=bbb&nestedCriteria.multipleV5=ccc&nestedCriteria.multipleV6=ddd&nestedCriteria.multipleV7=eee&nestedCriteria.multipleV8=2018-02-12T23:42:31.795Z&nestedCriteria.multipleV9=COMPLEX&nestedCriteria.multipleV10=COMPLEX
     then: |
-       { "nestedCriteria": {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"]} }
+       { "nestedCriteria": {"multipleV5": ["bbb", "ccc"], "multipleV6": ["ddd"], "multipleV7": ["eee"], "multipleV8": ["2018-02-12T23:42:31.795Z"], "multipleV9": ["COMPLEX"], "multipleV10": ["COMPLEX"]} }
   - when: |
        GET params/multipleComplexParams?v0=aaa&v1=bbb&str=ccc
     then: |

--- a/restx-security-basic/src/main/java/restx/security/FileBasedUserRepository.java
+++ b/restx-security-basic/src/main/java/restx/security/FileBasedUserRepository.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import restx.common.Types;
+import restx.types.Types;
 
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;


### PR DESCRIPTION
This PR aims at allowing "Complex type" deserialization with query parameters (see #248). This PR follows what has already been submitted in #287 (we need `RawTypesDefinition` declaration to be able to identify what a "Raw" type is)

tldr; we can pass "complex" objects as query parameters :
- The name of the object is not taken into consideration (this is handled differently than for "raw" types where the variable name must match query parameter name)
- In those "complex" objects, we can nest other "complex" objects (example : `MyNestedClass field`), but NOT aggregates of "complex" objects (example: `MyNestedClass[] fields`)
- In those "complex" objects & nested objects, we can put aggregates of "raw" types (example : `String[] ids`)
- We can have multiple "complex" objects passed at the same resource method
- Query parameters values to target "complex" object is performed through Jackson available deserializers
- Most of the things are done at compile time. We have a small overhead at runtime only when we're working with "complex types", which is due to hierarchical map construction & Jackson deserialization


For the record, I switched the implementation multiple times by reaching some blockers :
- At the beginning, I started to embrace the "compile time" way by trying to generate as much code as possible at compile time
- Then I switched to "run time" implementation because I was not able to identity "Raw types" at compile time (at that moment) and I guessed I would be able to gather this information through `MainStringConverter.objectMapper.canDeserialize(Class)` call. The problem is : this call will return `true` even if target `Class` is *not* a raw type.
- That's why I switched back to a "compile time" implementation based on a new notion which was introduced in #248 : `RawTypesDefinition`

The main idea behind the implementation is to :
1. build a "hierarchical map" from request parameter "flat" map
    Something like :
```
queryParams: foo=baz&foo2.bar2=baz2
```
becoming
```
 {
     "foo": "baz",
     "foo2": { "bar2": "baz2" }
 }
```
2. Give this "hierarchical map" to Jackson with a target class, letting Jackson do the hard deserialization stuff


Complexity on this was about "iterable" types : for instance, if we have following target type :
```
public class SearchCriteria {
    Long[] ids;
    // getters/setters...
}
```
and this request is performed : `GET /search?ids=1`, then in that case I need to identify that even though I only have 1 value of `ids`, I must call a `setIds(new Long[]{ 1 })` value instead of `setIds(1)`

That's why I introduced a new `ParamDef` fields which is called `ParamValuesHandlings` and which is aimed at defining : 
- default behaviour which is based on considering the target field as a "single value" field, meaning that we will call `setXXX(Iterables.getOnlyElement(reqParams.get('xxx')))`
- special cases on query param definition, typically for arrays object nodes in the "hierarchical map", and which will call `setXXX(reqParams.get('xxx').toArray(new String[0]))`


Taking `SearchCriteria` example, something like this will thus be generated on the `Router` side :
```
        new StdEntityRoute<Void, samplest.models.SearchCriteria>("default#ParametersResource#search",
                readerRegistry.<Void>build(Void.class, Optional.<String>absent()),
                writerRegistry.<samplest.models.SearchCriteria>build(samplest.models.SearchCriteria.class, Optional.<String>absent()),
                Endpoint.of("GET", "/search"),
                HttpStatus.OK, RestxLogLevel.DEFAULT, pf,
                paramMapperRegistry, new ParamDef[]{
                    // <-- NEW SEPCIAL PARAM HANDLING DEFINITION BELOW !
                    ParamDef.of(new TypeReference<samplest.models.SearchCriteria>(){}, "criteria", ImmutableMap.<String, ParamDef.SpecialParamHandling>builder()
                      .put("ids", ParamDef.SpecialParamHandling.ARRAYS)
                    .build())
                }) {
            @Override
            protected Optional<samplest.models.SearchCriteria> doRoute(RestxRequest request, RestxResponse response, RestxRequestMatch match, Void body) throws IOException {
                securityManager.check(request, match, open());
                try {
                    return Optional.of(resource.search(
                        /* [QUERY] criteria */ checkValid(validator, checkNotNull(mapQueryObjectFromRequest(samplest.models.SearchCriteria.class, "criteria", request, match, EndpointParameterKind.QUERY), "QUERY param <criteria> is required"))
                    ));
                } catch(RuntimeException e) { throw e; }
                  catch(Exception e) { throw new WrappedCheckedException(e); }
            }
```

So, those special `ParamValuesHandlings` definitions are generated at compile time by introspecting target model type and seeing if a node, on this target type, is an `Aggregate<RawType>` and, in that case, generate this as a special ARRAY node.

I implemented following compile time rules on target type fields :
- if the field is a `RawType`, then don't do anything : query parameter string value will be implicitely mapped to a single value in the hierarchical map passed to jackson
- if the field is an `AggregateType<RawType>` : then generate the `ARRAY` special type handling which will create an array in the hierarchical map, deserialized into the target `AggregateType` by Jackson
- if the field is a `ComplexType` : then process this node's type fields recursively. I limited the maximum recursivity "depth" to 4 in order to avoid infinite loops during annotation processing code generation (particularly when a type is referencing itself in one of its field nodes)
- if the field is an `AggregateType<ComplexType>` : then generate an `UNSUPPORTED` special type handling which will throw an exception if someone references this field through request parameters. For example :
```
public class SearchCriteria {
    SearchCriteria[] nestedCriteria;
    // getters/setters...
}

// then calling /search?nestedCriteria=someValue
// => in that case, and only when we put "nestedCriteria=something" in query parameters, an error will be thrown
```

At runtime, given that we defined this special params :
```
paramValuesHandlings = { "foo3.bar3": ARRAY }
```
when we get following query param map :
```
queryParams: foo=baz&foo2.bar2=baz2&foo3.bar3=baz3
```
then we generated following hierarchical map :
```
 {
     "foo": "baz",
     "foo2": { "bar2": "baz2" },
     "foo3": { "bar3": [ "baz3" ] }
 }
```
which doesn't cost much