### PR TITLE
Fixing Mongo id generation regression in a v0.35.1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
         <!-- Mongo modules -->
         <mongo-java-driver.version>3.4.0</mongo-java-driver.version>
-        <bson4jackson.version>2.8.0</bson4jackson.version>
+        <bson4jackson.version>2.7.0</bson4jackson.version>
         <jongo.version>1.3.0</jongo.version>
         <de.flapdoodle.embed.version>1.42</de.flapdoodle.embed.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <!-- Mongo modules -->
         <mongo-java-driver.version>2.11.3</mongo-java-driver.version>
         <bson4jackson.version>2.3.1</bson4jackson.version>
-        <jongo.version>1.0</jongo.version>
+        <jongo.version>1.1</jongo.version>
         <de.flapdoodle.embed.version>1.42</de.flapdoodle.embed.version>
 
         <!-- Test libs -->

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <!-- Mongo modules -->
         <mongo-java-driver.version>2.11.3</mongo-java-driver.version>
         <bson4jackson.version>2.3.1</bson4jackson.version>
-        <jongo.version>1.3.0</jongo.version>
+        <jongo.version>1.0</jongo.version>
         <de.flapdoodle.embed.version>1.42</de.flapdoodle.embed.version>
 
         <!-- Test libs -->

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
             </dependency>
             <dependency>
                 <groupId>io.restx</groupId>
+                <artifactId>restx-jongo-specs-tests</artifactId>
+                <version>${restx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.restx</groupId>
                 <artifactId>restx-specs-tests-java8</artifactId>
                 <version>${restx.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
         <el.api.version>2.2</el.api.version>
 
         <!-- Mongo modules -->
-        <mongo-java-driver.version>3.4.0</mongo-java-driver.version>
-        <bson4jackson.version>2.7.0</bson4jackson.version>
+        <mongo-java-driver.version>2.11.3</mongo-java-driver.version>
+        <bson4jackson.version>2.3.1</bson4jackson.version>
         <jongo.version>1.3.0</jongo.version>
         <de.flapdoodle.embed.version>1.42</de.flapdoodle.embed.version>
 

--- a/restx-jongo-java8/src/main/java/restx/jongo/BsonJSR310Module.java
+++ b/restx-jongo-java8/src/main/java/restx/jongo/BsonJSR310Module.java
@@ -1,14 +1,13 @@
 package restx.jongo;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import de.undercouch.bson4jackson.BsonGenerator;
+import de.undercouch.bson4jackson.serializers.BsonSerializer;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -18,20 +17,14 @@ public class BsonJSR310Module extends SimpleModule {
     public BsonJSR310Module() {
         super("BsonJSR310Module");
 
-        addSerializer(Instant.class, new JsonSerializer<Instant>() {
+        addSerializer(Instant.class, new BsonSerializer<Instant>() {
             @Override
-            public void serialize(Instant date, JsonGenerator gen, SerializerProvider provider)
+            public void serialize(Instant date, BsonGenerator bsonGenerator, SerializerProvider serializerProvider)
                     throws IOException {
                 if (date == null) {
-                    provider.defaultSerializeNull(gen);
+                    serializerProvider.defaultSerializeNull(bsonGenerator);
                 } else {
-                    long epochMillis = date.toEpochMilli();
-                    if (gen instanceof BsonGenerator) {
-                        BsonGenerator bgen = (BsonGenerator)gen;
-                        bgen.writeDateTime(new Date(epochMillis));
-                    } else {
-                        gen.writeNumber(epochMillis);
-                    }
+                    bsonGenerator.writeDateTime(new Date(date.toEpochMilli()));
                 }
             }
         });

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/GivenJongoCollectionRunner.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/GivenJongoCollectionRunner.java
@@ -38,75 +38,83 @@ public class GivenJongoCollectionRunner implements GivenRunner<GivenJongoCollect
     }
 
     public GivenCleaner run(final GivenJongoCollection given, final ImmutableMap<String, String> params) {
-        MongoClientURI mongoClientURI = new MongoClientURI(
-                checkNotNull(params.get(DB_URI),
-                        DB_URI + " param is required"));
-        Jongo jongo = new Jongo(new MongoClient(mongoClientURI).getDB(mongoClientURI.getDatabase()));
         try {
-            Stopwatch stopwatch = Stopwatch.createStarted();
-            MongoCollection collection = jongo.getCollection(given.getCollection());
-            Iterable<String> items = Splitter.on("\n").trimResults().omitEmptyStrings().split(given.getData());
-            int count = 0;
-            for (String item : items) {
-                collection.insert(item);
-                count++;
-            }
-            System.out.printf("imported %s[%d] -- %s%n", given.getCollection(), count, stopwatch.stop().toString());
-        } finally {
-            jongo.getDatabase().getMongo().close();
-        }
-
-        final UnmodifiableIterator<String> it = given.getSequence().iterator();
-        final CollectionSequence iteratingSequence = new CollectionSequence() {
-            @Override
-            public Optional<String> next() {
-                return it.hasNext() ? Optional.of(it.next()) : Optional.<String>absent();
-            }
-        };
-
-        final SingleNameFactoryMachine<ComponentCustomizerEngine> customizerMachine =
-                new SingleNameFactoryMachine<>(0, new StdMachineEngine<ComponentCustomizerEngine>(
-                    Name.of(ComponentCustomizerEngine.class, "JongoCollectionSequenceSupplierOf"
-                                                                        + given.getCollection()),
-                    BoundlessComponentBox.FACTORY) {
-            @Override
-            public BillOfMaterials getBillOfMaterial() {
-                return BillOfMaterials.of();
-            }
-
-            @Override
-            protected ComponentCustomizerEngine doNewComponent(final SatisfiedBOM satisfiedBOM) {
-                return new SingleComponentNameCustomizerEngine<JongoCollection>(
-                                                    0, Name.of(JongoCollection.class, given.getCollection())) {
-                    @Override
-                    public NamedComponent<JongoCollection> customize(NamedComponent<JongoCollection> namedComponent) {
-                        if (namedComponent.getName().getName().equals(given.getCollection())) {
-                            return new NamedComponent<>(namedComponent.getName(),
-                                    new SequencedJongoCollection(namedComponent.getComponent(),iteratingSequence));
-                        } else {
-                            return namedComponent;
-                        }
-
-                    }
-                };
-            }
-        });
-        final Factory.LocalMachines localMachines = threadLocal();
-        localMachines.addMachine(customizerMachine);
-
-        return new GivenCleaner() {
-            @Override
-            public void cleanUp() {
-                localMachines.removeMachine(customizerMachine);
-                MongoClientURI mongoClientURI = new MongoClientURI(
-                        checkNotNull(params.get(DB_URI),
-                                DB_URI + " param is required"));
-                Jongo jongo = new Jongo(new MongoClient(mongoClientURI).getDB(mongoClientURI.getDatabase()));
+            MongoClientURI mongoClientURI = new MongoClientURI(
+                    checkNotNull(params.get(DB_URI),
+                            DB_URI + " param is required"));
+            Jongo jongo = new Jongo(new MongoClient(mongoClientURI).getDB(mongoClientURI.getDatabase()));
+            try {
                 Stopwatch stopwatch = Stopwatch.createStarted();
-                jongo.getCollection(given.getCollection()).drop();
-                System.out.printf("dropped %s -- %s%n", given.getCollection(), stopwatch.stop().toString());
+                MongoCollection collection = jongo.getCollection(given.getCollection());
+                Iterable<String> items = Splitter.on("\n").trimResults().omitEmptyStrings().split(given.getData());
+                int count = 0;
+                for (String item : items) {
+                    collection.insert(item);
+                    count++;
+                }
+                System.out.printf("imported %s[%d] -- %s%n", given.getCollection(), count, stopwatch.stop().toString());
+            } finally {
+                jongo.getDatabase().getMongo().close();
             }
-        };
+
+            final UnmodifiableIterator<String> it = given.getSequence().iterator();
+            final CollectionSequence iteratingSequence = new CollectionSequence() {
+                @Override
+                public Optional<String> next() {
+                    return it.hasNext() ? Optional.of(it.next()) : Optional.<String>absent();
+                }
+            };
+
+            final SingleNameFactoryMachine<ComponentCustomizerEngine> customizerMachine =
+                    new SingleNameFactoryMachine<>(0, new StdMachineEngine<ComponentCustomizerEngine>(
+                        Name.of(ComponentCustomizerEngine.class, "JongoCollectionSequenceSupplierOf"
+                                                                            + given.getCollection()),
+                        BoundlessComponentBox.FACTORY) {
+                @Override
+                public BillOfMaterials getBillOfMaterial() {
+                    return BillOfMaterials.of();
+                }
+
+                @Override
+                protected ComponentCustomizerEngine doNewComponent(final SatisfiedBOM satisfiedBOM) {
+                    return new SingleComponentNameCustomizerEngine<JongoCollection>(
+                                                        0, Name.of(JongoCollection.class, given.getCollection())) {
+                        @Override
+                        public NamedComponent<JongoCollection> customize(NamedComponent<JongoCollection> namedComponent) {
+                            if (namedComponent.getName().getName().equals(given.getCollection())) {
+                                return new NamedComponent<>(namedComponent.getName(),
+                                        new SequencedJongoCollection(namedComponent.getComponent(),iteratingSequence));
+                            } else {
+                                return namedComponent;
+                            }
+
+                        }
+                    };
+                }
+            });
+            final Factory.LocalMachines localMachines = threadLocal();
+            localMachines.addMachine(customizerMachine);
+
+            return new GivenCleaner() {
+                @Override
+                public void cleanUp() {
+                    try {
+                        localMachines.removeMachine(customizerMachine);
+                        MongoClientURI mongoClientURI = new MongoClientURI(
+                                checkNotNull(params.get(DB_URI),
+                                        DB_URI + " param is required"));
+                        Jongo jongo = new Jongo(new MongoClient(mongoClientURI).getDB(mongoClientURI.getDatabase()));
+                        Stopwatch stopwatch = Stopwatch.createStarted();
+                        jongo.getCollection(given.getCollection()).drop();
+                        System.out.printf("dropped %s -- %s%n", given.getCollection(), stopwatch.stop().toString());
+                    } catch (UnknownHostException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            };
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static interface CollectionSequence {

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/GivenJongoCollectionSpecRuleSupplier.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/GivenJongoCollectionSpecRuleSupplier.java
@@ -63,7 +63,11 @@ public class GivenJongoCollectionSpecRuleSupplier implements GivenSpecRuleSuppli
         @Override
         public void onTearDown(Factory.LocalMachines localMachines) {
             System.out.println("dropping database " + uri + "/" + db);
-            new MongoClient(new MongoClientURI(uri)).dropDatabase(db);
+            try {
+                new MongoClient(new MongoClientURI(uri)).dropDatabase(db);
+            } catch (UnknownHostException e) {
+                throw new IllegalStateException("got unknown host exception while contacting mongo db on localhost", e);
+            }
         }
     }
 }

--- a/restx-jongo/module.ivy
+++ b/restx-jongo/module.ivy
@@ -24,7 +24,7 @@
         <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
         <dependency org="de.undercouch" name="bson4jackson" rev="2.3.1" conf="default" />
         <dependency org="org.mongodb" name="mongo-java-driver" rev="2.11.3" conf="default" />
-        <dependency org="org.jongo" name="jongo" rev="1.3.0" conf="default" />
+        <dependency org="org.jongo" name="jongo" rev="1.0" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />
         <dependency org="org.assertj" name="assertj-core" rev="1.6.0" conf="test->default" />

--- a/restx-jongo/module.ivy
+++ b/restx-jongo/module.ivy
@@ -24,7 +24,7 @@
         <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
         <dependency org="de.undercouch" name="bson4jackson" rev="2.3.1" conf="default" />
         <dependency org="org.mongodb" name="mongo-java-driver" rev="2.11.3" conf="default" />
-        <dependency org="org.jongo" name="jongo" rev="1.0" conf="default" />
+        <dependency org="org.jongo" name="jongo" rev="1.1" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />
         <dependency org="org.assertj" name="assertj-core" rev="1.6.0" conf="test->default" />

--- a/restx-jongo/module.ivy
+++ b/restx-jongo/module.ivy
@@ -22,7 +22,7 @@
         <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.8.10" conf="default" />
         <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
         <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
-        <dependency org="de.undercouch" name="bson4jackson" rev="2.8.0" conf="default" />
+        <dependency org="de.undercouch" name="bson4jackson" rev="2.7.0" conf="default" />
         <dependency org="org.mongodb" name="mongo-java-driver" rev="3.4.0" conf="default" />
         <dependency org="org.jongo" name="jongo" rev="1.3.0" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />

--- a/restx-jongo/module.ivy
+++ b/restx-jongo/module.ivy
@@ -22,8 +22,8 @@
         <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.8.10" conf="default" />
         <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
         <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
-        <dependency org="de.undercouch" name="bson4jackson" rev="2.7.0" conf="default" />
-        <dependency org="org.mongodb" name="mongo-java-driver" rev="3.4.0" conf="default" />
+        <dependency org="de.undercouch" name="bson4jackson" rev="2.3.1" conf="default" />
+        <dependency org="org.mongodb" name="mongo-java-driver" rev="2.11.3" conf="default" />
         <dependency org="org.jongo" name="jongo" rev="1.3.0" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />

--- a/restx-jongo/src/main/java/restx/jackson/BsonJodaTimeModule.java
+++ b/restx-jongo/src/main/java/restx/jackson/BsonJodaTimeModule.java
@@ -1,15 +1,13 @@
 package restx.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import de.undercouch.bson4jackson.BsonGenerator;
-import org.joda.time.DateMidnight;
+import de.undercouch.bson4jackson.serializers.BsonSerializer;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -25,31 +23,25 @@ public class BsonJodaTimeModule extends SimpleModule {
     public BsonJodaTimeModule() {
         super("BsonJodaTimeModule");
 
-        addSerializer(org.joda.time.DateMidnight.class, new JsonSerializer<DateMidnight>() {
+        addSerializer(org.joda.time.DateMidnight.class, new BsonSerializer<org.joda.time.DateMidnight>() {
             @Override
-            public void serialize(org.joda.time.DateMidnight date, JsonGenerator gen, SerializerProvider provider)
+            public void serialize(org.joda.time.DateMidnight date, BsonGenerator bsonGenerator, SerializerProvider serializerProvider)
                     throws IOException {
                 if (date == null) {
-                    provider.defaultSerializeNull(gen);
-                } else if (gen instanceof BsonGenerator) {
-                    BsonGenerator bgen = (BsonGenerator)gen;
-                    bgen.writeDateTime(date.toDate());
+                    serializerProvider.defaultSerializeNull(bsonGenerator);
                 } else {
-                    gen.writeNumber(date.getMillis());
+                    bsonGenerator.writeDateTime(date.toDate());
                 }
             }
         });
-        addSerializer(DateTime.class, new JsonSerializer<DateTime>() {
+        addSerializer(DateTime.class, new BsonSerializer<DateTime>() {
             @Override
-            public void serialize(DateTime date, JsonGenerator gen, SerializerProvider provider)
+            public void serialize(DateTime date, BsonGenerator bsonGenerator, SerializerProvider serializerProvider)
                     throws IOException {
                 if (date == null) {
-                    provider.defaultSerializeNull(gen);
-                } else if (gen instanceof BsonGenerator) {
-                    BsonGenerator bgen = (BsonGenerator)gen;
-                    bgen.writeDateTime(date.toDate());
+                    serializerProvider.defaultSerializeNull(bsonGenerator);
                 } else {
-                    gen.writeNumber(date.getMillis());
+                    bsonGenerator.writeDateTime(date.toDate());
                 }
             }
         });

--- a/restx-samplest/md.restx.json
+++ b/restx-samplest/md.restx.json
@@ -19,6 +19,7 @@
             "io.restx:restx-validation:${restx.version}",
             "io.restx:restx-core-annotation-processor:${restx.version}",
             "io.restx:restx-factory:${restx.version}",
+            "io.restx:restx-jongo:${restx.version}",
             "io.restx:restx-factory-admin:${restx.version}",
             "io.restx:restx-monitor-codahale:${restx.version}",
             "io.restx:restx-monitor-admin:${restx.version}",
@@ -34,6 +35,7 @@
         ],
         "test": [
             "io.restx:restx-specs-tests:${restx.version}",
+            "io.restx:restx-jongo-specs-tests:${restx.version}",
             "junit:junit:${junit.version}"
         ]
     }

--- a/restx-samplest/module.ivy
+++ b/restx-samplest/module.ivy
@@ -18,6 +18,7 @@
         <dependency org="io.restx" name="restx-validation" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-core-annotation-processor" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
+        <dependency org="io.restx" name="restx-jongo" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-factory-admin" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-monitor-codahale" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-monitor-admin" rev="latest.integration" conf="default" />
@@ -29,6 +30,7 @@
         <dependency org="ch.qos.logback" name="logback-classic" rev="1.0.13" conf="default" />
         <dependency org="io.restx" name="restx-barbarywatch" rev="latest.integration" conf="runtime->default" />
         <dependency org="io.restx" name="restx-specs-tests" rev="latest.integration" conf="test->default" />
+        <dependency org="io.restx" name="restx-jongo-specs-tests" rev="latest.integration" conf="test->default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />
     </dependencies>
 </ivy-module>

--- a/restx-samplest/pom.xml
+++ b/restx-samplest/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
         <dependency>
             <groupId>io.restx</groupId>
+            <artifactId>restx-jongo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.restx</groupId>
             <artifactId>restx-factory-admin</artifactId>
         </dependency>
         <dependency>
@@ -74,6 +78,11 @@
         <dependency>
             <groupId>io.restx</groupId>
             <artifactId>restx-specs-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.restx</groupId>
+            <artifactId>restx-jongo-specs-tests</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/restx-samplest/src/main/java/samplest/AppModule.java
+++ b/restx-samplest/src/main/java/samplest/AppModule.java
@@ -59,4 +59,8 @@ public class AppModule {
         }, securitySettings);
     }
 
+    @Provides @Named("mongo.db") String mongoDb() {
+        return "testing-mongo";
+    }
+
 }

--- a/restx-samplest/src/main/java/samplest/jongo/MongoResource.java
+++ b/restx-samplest/src/main/java/samplest/jongo/MongoResource.java
@@ -1,0 +1,87 @@
+package samplest.jongo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.bson.types.ObjectId;
+import org.jongo.marshall.jackson.oid.Id;
+import org.jongo.marshall.jackson.oid.MongoId;
+import org.jongo.marshall.jackson.oid.MongoObjectId;
+import restx.annotations.POST;
+import restx.annotations.RestxResource;
+import restx.factory.Component;
+import restx.jongo.JongoCollection;
+import restx.security.PermitAll;
+
+import javax.inject.Named;
+
+@RestxResource @Component
+public class MongoResource {
+    public static class ObjectWithIdAnnotation {
+        // @Id // 0.34 -> OK ; 0.35 -> KO!
+        @MongoId @JsonProperty("_id") // 0.35 -> KO!
+        private String id;
+        private String label;
+
+        public String getId() { return id; }
+        public void setId(String id) { this.id = id; }
+        public String getLabel() { return label; }
+        public void setLabel(String label) { this.label = label; }
+    }
+    public static class ObjectWithObjectIdAnnotation {
+        // @org.jongo.marshall.jackson.oid.ObjectId @Id // 0.34 -> OK ; 0.35 -> KO!
+        @MongoId @MongoObjectId @JsonProperty("_id") // 0.35 -> KO!
+        private String id;
+        private String label;
+
+        public String getId() { return id; }
+        public void setId(String id) { this.id = id; }
+        public String getLabel() { return label; }
+        public void setLabel(String label) { this.label = label; }
+    }
+    public static class ObjectWithObjectIdType {
+        // @Id // 0.34 -> OK ; 0.35 -> OK
+        @MongoId @JsonProperty("_id") // 0.35 -> OK
+        private ObjectId id;
+        private String label;
+
+        public String getId() { return id.toString(); }
+        public void setId(ObjectId id) { this.id = id; }
+        public String getLabel() { return label; }
+        public void setLabel(String label) { this.label = label; }
+    }
+
+    private final JongoCollection objectWithIdAnnotationCollection;
+    private final JongoCollection objectWithObjectIdAnnotationCollection;
+    private final JongoCollection objectWithObjectIdTypeCollection;
+
+    public MongoResource(
+            @Named("objectWithIdAnnotationCollection") JongoCollection objectWithIdAnnotationCollection,
+            @Named("objectWithObjectIdAnnotationCollection") JongoCollection objectWithObjectIdAnnotationCollection,
+            @Named("objectWithObjectIdTypeCollection") JongoCollection objectWithObjectIdTypeCollection) {
+        this.objectWithIdAnnotationCollection = objectWithIdAnnotationCollection;
+        this.objectWithObjectIdAnnotationCollection = objectWithObjectIdAnnotationCollection;
+        this.objectWithObjectIdTypeCollection = objectWithObjectIdTypeCollection;
+    }
+
+    @POST("/mongo/objectsWithIdAnnotation")
+    @PermitAll
+    public ObjectWithIdAnnotation createFoo(ObjectWithIdAnnotation foo) {
+        this.objectWithIdAnnotationCollection.get().insert(foo);
+        return foo;
+    }
+
+    @POST("/mongo/objectsWithObjectIdAnnotation")
+    @PermitAll
+    public ObjectWithObjectIdAnnotation createObjectWithObjectIdAnnotation(ObjectWithObjectIdAnnotation objectWithObjectIdAnnotation) {
+        this.objectWithObjectIdAnnotationCollection.get().insert(objectWithObjectIdAnnotation);
+        return objectWithObjectIdAnnotation;
+    }
+
+    @POST("/mongo/objectsWithObjectIdType")
+    @PermitAll
+    public ObjectWithObjectIdType createObjectWithObjectId(ObjectWithObjectIdType objectWithObjectIdType) {
+        this.objectWithObjectIdTypeCollection.get().insert(objectWithObjectIdType);
+        return objectWithObjectIdType;
+    }
+
+
+}

--- a/restx-samplest/src/main/java/samplest/jongo/MongoResource.java
+++ b/restx-samplest/src/main/java/samplest/jongo/MongoResource.java
@@ -3,8 +3,6 @@ package samplest.jongo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bson.types.ObjectId;
 import org.jongo.marshall.jackson.oid.Id;
-import org.jongo.marshall.jackson.oid.MongoId;
-import org.jongo.marshall.jackson.oid.MongoObjectId;
 import restx.annotations.POST;
 import restx.annotations.RestxResource;
 import restx.factory.Component;
@@ -17,7 +15,7 @@ import javax.inject.Named;
 public class MongoResource {
     public static class ObjectWithIdAnnotation {
         // @Id // 0.34 -> OK ; 0.35 -> KO!
-        @MongoId @JsonProperty("_id") // 0.35 -> KO!
+        @Id @JsonProperty("_id") // 0.35 -> KO!
         private String id;
         private String label;
 
@@ -28,7 +26,7 @@ public class MongoResource {
     }
     public static class ObjectWithObjectIdAnnotation {
         // @org.jongo.marshall.jackson.oid.ObjectId @Id // 0.34 -> OK ; 0.35 -> KO!
-        @MongoId @MongoObjectId @JsonProperty("_id") // 0.35 -> KO!
+        @Id @org.jongo.marshall.jackson.oid.ObjectId @JsonProperty("_id") // 0.35 -> KO!
         private String id;
         private String label;
 
@@ -39,7 +37,7 @@ public class MongoResource {
     }
     public static class ObjectWithObjectIdType {
         // @Id // 0.34 -> OK ; 0.35 -> OK
-        @MongoId @JsonProperty("_id") // 0.35 -> OK
+        @Id @JsonProperty("_id") // 0.35 -> OK
         private ObjectId id;
         private String label;
 

--- a/restx-samplest/src/main/resources/specs/mongo/objectsWithIdAnnotation_persistence.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/mongo/objectsWithIdAnnotation_persistence.spec.yaml
@@ -1,0 +1,11 @@
+title: objectsWithIdAnnotation persistence
+given:
+  - time: 2018-02-07T17:01:21.795+02:00
+  - collection: objectWithIdAnnotationCollection
+    sequence: 5167cec5856107c479739654
+wts:
+  - when: |
+       POST mongo/objectsWithIdAnnotation
+       {"label": "FOO"}
+    then: |
+       {"_id":"5167cec5856107c479739654","label": "FOO"}

--- a/restx-samplest/src/main/resources/specs/mongo/objectsWithObjectIdAnnotation_persistence.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/mongo/objectsWithObjectIdAnnotation_persistence.spec.yaml
@@ -1,0 +1,11 @@
+title: objectsWithObjectIdAnnotation persistence
+given:
+  - time: 2018-02-07T17:01:21.795+02:00
+  - collection: objectWithObjectIdAnnotationCollection
+    sequence: 5167cec5856107c479739654
+wts:
+  - when: |
+       POST mongo/objectsWithObjectIdAnnotation
+       {"label": "BAR"}
+    then: |
+       {"_id":"5167cec5856107c479739654","label": "BAR"}

--- a/restx-samplest/src/main/resources/specs/mongo/objectsWithObjectIdType_persistence.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/mongo/objectsWithObjectIdType_persistence.spec.yaml
@@ -1,0 +1,11 @@
+title: objectsWithObjectId persistence
+given:
+  - time: 2018-02-07T17:01:21.795+02:00
+  - collection: objectWithObjectIdTypeCollection
+    sequence: 5167cec5856107c479739654
+wts:
+  - when: |
+       POST mongo/objectsWithObjectIdType
+       {"label": "BLAH"}
+    then: |
+       {"_id":"5167cec5856107c479739654","label": "BLAH"}

--- a/restx-samplest/src/test/java/samplest/jongo/MongoResourceSpecsTest.java
+++ b/restx-samplest/src/test/java/samplest/jongo/MongoResourceSpecsTest.java
@@ -1,0 +1,10 @@
+package samplest.jongo;
+
+import org.junit.runner.RunWith;
+import restx.tests.FindSpecsIn;
+import restx.jongo.specs.tests.MongoRestxSpecTestsRunner;
+
+@RunWith(MongoRestxSpecTestsRunner.class)
+@FindSpecsIn("specs/mongo")
+public class MongoResourceSpecsTest {
+}

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -27,8 +27,8 @@
     "metrics.version": "3.1.0",
     "javax.inject.version": "1",
 
-    "mongo-java-driver.version": "3.4.0",
-    "bson4jackson.version": "2.7.0",
+    "mongo-java-driver.version": "2.11.3",
+    "bson4jackson.version": "2.3.1",
     "jongo.version": "1.3.0",
 
     "servlet-api.version": "2.5",

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -29,7 +29,7 @@
 
     "mongo-java-driver.version": "2.11.3",
     "bson4jackson.version": "2.3.1",
-    "jongo.version": "1.0",
+    "jongo.version": "1.1",
 
     "servlet-api.version": "2.5",
 

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -29,7 +29,7 @@
 
     "mongo-java-driver.version": "2.11.3",
     "bson4jackson.version": "2.3.1",
-    "jongo.version": "1.3.0",
+    "jongo.version": "1.0",
 
     "servlet-api.version": "2.5",
 

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -28,7 +28,7 @@
     "javax.inject.version": "1",
 
     "mongo-java-driver.version": "3.4.0",
-    "bson4jackson.version": "2.8.0",
+    "bson4jackson.version": "2.7.0",
     "jongo.version": "1.3.0",
 
     "servlet-api.version": "2.5",


### PR DESCRIPTION
PR aiming at rolling back jongo / mongo-java-driver / bson4jackson upgrade occured on 0.35 and which implied a critical regression (see #285) with no workaround at that time.

I'd like to make a 0.35.1 release with this rollback.

Upgrade to jongo 1.3.0 (or maybe 1.4.0) will occur someday, but we need to sort out how jongo will handle bson4jackson 2.7 dependency first as currently, jongo 1.3.0 & bson4jackson 2.8.0 are incompatible)

Dependencies rollback compared to 0.35 will be :
- jongo : 1.3.0 -> 1.1 (I kept 1.0 -> 1.1 upgrade because no regression has been identified on jongo 1.1)
- mongo-java-driver : 3.4.0 -> 2.11.3 (jongo 1.1 is not compatible with mongo java driver 3.x)
- bson4jackson : 2.8.0 -> 2.3.1 (bson4jackson 2.8 & 2.7 are not compatible with jongo 1.1)

