### PR TITLE
Upgrade jongo to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <el.api.version>2.2</el.api.version>
 
         <!-- Mongo modules -->
-        <mongo-java-driver.version>2.11.3</mongo-java-driver.version>
+        <mongo-java-driver.version>3.4.0</mongo-java-driver.version>
         <bson4jackson.version>2.3.1</bson4jackson.version>
         <jongo.version>1.4.0</jongo.version>
         <de.flapdoodle.embed.version>1.42</de.flapdoodle.embed.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
 
         <!-- 3rd party libs -->
-        <jackson.version>2.8.10</jackson.version>
+        <jackson.version>2.9.5</jackson.version>
         <guava.version>18.0</guava.version>
         <joda-time.version>2.3</joda-time.version>
         <jna.version>3.2.7</jna.version>
@@ -84,7 +84,7 @@
 
         <!-- Mongo modules -->
         <mongo-java-driver.version>3.4.0</mongo-java-driver.version>
-        <bson4jackson.version>2.3.1</bson4jackson.version>
+        <bson4jackson.version>2.9.0</bson4jackson.version>
         <jongo.version>1.4.0</jongo.version>
         <de.flapdoodle.embed.version>1.42</de.flapdoodle.embed.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <!-- Mongo modules -->
         <mongo-java-driver.version>2.11.3</mongo-java-driver.version>
         <bson4jackson.version>2.3.1</bson4jackson.version>
-        <jongo.version>1.1</jongo.version>
+        <jongo.version>1.4.0</jongo.version>
         <de.flapdoodle.embed.version>1.42</de.flapdoodle.embed.version>
 
         <!-- Test libs -->

--- a/restx-apidocs-doclet/module.ivy
+++ b/restx-apidocs-doclet/module.ivy
@@ -15,9 +15,9 @@
     </publications>
     <dependencies>
         <dependency org="com.sun.tools" name="tools" rev="1.7" conf="system->default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.8.10" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.8.10" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.5" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.5" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.5" conf="default" />
         <dependency org="com.google.guava" name="guava" rev="18.0" conf="default" />
         <dependency org="joda-time" name="joda-time" rev="2.3" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />

--- a/restx-apidocs/module.ivy
+++ b/restx-apidocs/module.ivy
@@ -18,7 +18,7 @@
         <dependency org="io.restx" name="restx-core" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-core-annotation-processor" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-admin" rev="latest.integration" conf="default" />
-        <dependency org="com.fasterxml.jackson.module" name="jackson-module-jsonSchema" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.module" name="jackson-module-jsonSchema" rev="2.9.5" conf="default" />
         <dependency org="io.restx" name="restx-webjars" rev="latest.integration" conf="default" />
     </dependencies>
 </ivy-module>

--- a/restx-core-java8/module.ivy
+++ b/restx-core-java8/module.ivy
@@ -15,6 +15,6 @@
     </publications>
     <dependencies>
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
-        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-jsr310" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-jsr310" rev="2.9.5" conf="default" />
     </dependencies>
 </ivy-module>

--- a/restx-core/module.ivy
+++ b/restx-core/module.ivy
@@ -14,11 +14,11 @@
         <artifact type="jar"/>
     </publications>
     <dependencies>
-        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.8.10" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.8.10" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
-        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
-        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-guava" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.5" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.5" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.5" conf="default" />
+        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.9.5" conf="default" />
+        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-guava" rev="2.9.5" conf="default" />
         <dependency org="io.restx" name="restx-factory" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-classloader" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-apidocs-doclet" rev="latest.integration" conf="default" />

--- a/restx-jongo-java8/src/main/java/restx/jongo/BsonJSR310Module.java
+++ b/restx-jongo-java8/src/main/java/restx/jongo/BsonJSR310Module.java
@@ -1,13 +1,14 @@
 package restx.jongo;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import de.undercouch.bson4jackson.BsonGenerator;
-import de.undercouch.bson4jackson.serializers.BsonSerializer;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -17,14 +18,20 @@ public class BsonJSR310Module extends SimpleModule {
     public BsonJSR310Module() {
         super("BsonJSR310Module");
 
-        addSerializer(Instant.class, new BsonSerializer<Instant>() {
+        addSerializer(Instant.class, new JsonSerializer<Instant>() {
             @Override
-            public void serialize(Instant date, BsonGenerator bsonGenerator, SerializerProvider serializerProvider)
+            public void serialize(Instant date, JsonGenerator gen, SerializerProvider provider)
                     throws IOException {
                 if (date == null) {
-                    serializerProvider.defaultSerializeNull(bsonGenerator);
+                    provider.defaultSerializeNull(gen);
                 } else {
-                    bsonGenerator.writeDateTime(new Date(date.toEpochMilli()));
+                    long epochMillis = date.toEpochMilli();
+                    if (gen instanceof BsonGenerator) {
+                        BsonGenerator bgen = (BsonGenerator)gen;
+                        bgen.writeDateTime(new Date(epochMillis));
+                    } else {
+                        gen.writeNumber(epochMillis);
+                    }
                 }
             }
         });

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/GivenJongoCollectionSpecRuleSupplier.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/GivenJongoCollectionSpecRuleSupplier.java
@@ -63,11 +63,7 @@ public class GivenJongoCollectionSpecRuleSupplier implements GivenSpecRuleSuppli
         @Override
         public void onTearDown(Factory.LocalMachines localMachines) {
             System.out.println("dropping database " + uri + "/" + db);
-            try {
-                new MongoClient(new MongoClientURI(uri)).dropDatabase(db);
-            } catch (UnknownHostException e) {
-                throw new IllegalStateException("got unknown host exception while contacting mongo db on localhost", e);
-            }
+            new MongoClient(new MongoClientURI(uri)).dropDatabase(db);
         }
     }
 }

--- a/restx-jongo/module.ivy
+++ b/restx-jongo/module.ivy
@@ -18,10 +18,10 @@
         <dependency org="io.restx" name="restx-core" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-core-annotation-processor" rev="latest.integration" conf="default" />
         <dependency org="io.restx" name="restx-security-basic" rev="latest.integration" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.8.10" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.8.10" conf="default" />
-        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
-        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.5" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.5" conf="default" />
+        <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.5" conf="default" />
+        <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.9.5" conf="default" />
         <dependency org="de.undercouch" name="bson4jackson" rev="2.3.1" conf="default" />
         <dependency org="org.mongodb" name="mongo-java-driver" rev="3.4.0" conf="default" />
         <dependency org="org.jongo" name="jongo" rev="1.4.0" conf="default" />

--- a/restx-jongo/module.ivy
+++ b/restx-jongo/module.ivy
@@ -22,7 +22,7 @@
         <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.5" conf="default" />
         <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.5" conf="default" />
         <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.9.5" conf="default" />
-        <dependency org="de.undercouch" name="bson4jackson" rev="2.3.1" conf="default" />
+        <dependency org="de.undercouch" name="bson4jackson" rev="2.9.0" conf="default" />
         <dependency org="org.mongodb" name="mongo-java-driver" rev="3.4.0" conf="default" />
         <dependency org="org.jongo" name="jongo" rev="1.4.0" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />

--- a/restx-jongo/module.ivy
+++ b/restx-jongo/module.ivy
@@ -23,7 +23,7 @@
         <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.8.10" conf="default" />
         <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
         <dependency org="de.undercouch" name="bson4jackson" rev="2.3.1" conf="default" />
-        <dependency org="org.mongodb" name="mongo-java-driver" rev="2.11.3" conf="default" />
+        <dependency org="org.mongodb" name="mongo-java-driver" rev="3.4.0" conf="default" />
         <dependency org="org.jongo" name="jongo" rev="1.4.0" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />

--- a/restx-jongo/module.ivy
+++ b/restx-jongo/module.ivy
@@ -24,7 +24,7 @@
         <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.8.10" conf="default" />
         <dependency org="de.undercouch" name="bson4jackson" rev="2.3.1" conf="default" />
         <dependency org="org.mongodb" name="mongo-java-driver" rev="2.11.3" conf="default" />
-        <dependency org="org.jongo" name="jongo" rev="1.1" conf="default" />
+        <dependency org="org.jongo" name="jongo" rev="1.4.0" conf="default" />
         <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="default" />
         <dependency org="junit" name="junit" rev="4.11" conf="test->default" />
         <dependency org="org.assertj" name="assertj-core" rev="1.6.0" conf="test->default" />

--- a/restx-jongo/src/main/java/restx/jackson/BsonJodaTimeModule.java
+++ b/restx-jongo/src/main/java/restx/jackson/BsonJodaTimeModule.java
@@ -1,13 +1,15 @@
 package restx.jackson;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import de.undercouch.bson4jackson.BsonGenerator;
-import de.undercouch.bson4jackson.serializers.BsonSerializer;
+import org.joda.time.DateMidnight;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -23,25 +25,31 @@ public class BsonJodaTimeModule extends SimpleModule {
     public BsonJodaTimeModule() {
         super("BsonJodaTimeModule");
 
-        addSerializer(org.joda.time.DateMidnight.class, new BsonSerializer<org.joda.time.DateMidnight>() {
+        addSerializer(org.joda.time.DateMidnight.class, new JsonSerializer<DateMidnight>() {
             @Override
-            public void serialize(org.joda.time.DateMidnight date, BsonGenerator bsonGenerator, SerializerProvider serializerProvider)
+            public void serialize(org.joda.time.DateMidnight date, JsonGenerator gen, SerializerProvider provider)
                     throws IOException {
                 if (date == null) {
-                    serializerProvider.defaultSerializeNull(bsonGenerator);
+                    provider.defaultSerializeNull(gen);
+                } else if (gen instanceof BsonGenerator) {
+                    BsonGenerator bgen = (BsonGenerator)gen;
+                    bgen.writeDateTime(date.toDate());
                 } else {
-                    bsonGenerator.writeDateTime(date.toDate());
+                    gen.writeNumber(date.getMillis());
                 }
             }
         });
-        addSerializer(DateTime.class, new BsonSerializer<DateTime>() {
+        addSerializer(DateTime.class, new JsonSerializer<DateTime>() {
             @Override
-            public void serialize(DateTime date, BsonGenerator bsonGenerator, SerializerProvider serializerProvider)
+            public void serialize(DateTime date, JsonGenerator gen, SerializerProvider provider)
                     throws IOException {
                 if (date == null) {
-                    serializerProvider.defaultSerializeNull(bsonGenerator);
+                    provider.defaultSerializeNull(gen);
+                } else if (gen instanceof BsonGenerator) {
+                    BsonGenerator bgen = (BsonGenerator)gen;
+                    bgen.writeDateTime(date.toDate());
                 } else {
-                    bsonGenerator.writeDateTime(date.toDate());
+                    gen.writeNumber(date.getMillis());
                 }
             }
         });

--- a/restx-samplest/src/main/java/samplest/jongo/MongoResource.java
+++ b/restx-samplest/src/main/java/samplest/jongo/MongoResource.java
@@ -3,6 +3,8 @@ package samplest.jongo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bson.types.ObjectId;
 import org.jongo.marshall.jackson.oid.Id;
+import org.jongo.marshall.jackson.oid.MongoId;
+import org.jongo.marshall.jackson.oid.MongoObjectId;
 import restx.annotations.POST;
 import restx.annotations.RestxResource;
 import restx.factory.Component;
@@ -15,7 +17,7 @@ import javax.inject.Named;
 public class MongoResource {
     public static class ObjectWithIdAnnotation {
         // @Id // 0.34 -> OK ; 0.35 -> KO!
-        @Id @JsonProperty("_id") // 0.35 -> KO!
+        @MongoId @JsonProperty("_id") // 0.35 -> KO!
         private String id;
         private String label;
 
@@ -26,7 +28,7 @@ public class MongoResource {
     }
     public static class ObjectWithObjectIdAnnotation {
         // @org.jongo.marshall.jackson.oid.ObjectId @Id // 0.34 -> OK ; 0.35 -> KO!
-        @Id @org.jongo.marshall.jackson.oid.ObjectId @JsonProperty("_id") // 0.35 -> KO!
+        @MongoId @MongoObjectId @JsonProperty("_id") // 0.35 -> KO!
         private String id;
         private String label;
 
@@ -37,7 +39,7 @@ public class MongoResource {
     }
     public static class ObjectWithObjectIdType {
         // @Id // 0.34 -> OK ; 0.35 -> OK
-        @Id @JsonProperty("_id") // 0.35 -> OK
+        @MongoId @JsonProperty("_id") // 0.35 -> OK
         private ObjectId id;
         private String label;
 

--- a/restx-samplest/src/main/resources/specs/mongo/objectsWithIdAnnotation_persistence.spec.yaml
+++ b/restx-samplest/src/main/resources/specs/mongo/objectsWithIdAnnotation_persistence.spec.yaml
@@ -8,4 +8,4 @@ wts:
        POST mongo/objectsWithIdAnnotation
        {"label": "FOO"}
     then: |
-       {"_id":"5167cec5856107c479739654","label": "FOO"}
+       {"_id":null,"label": "FOO"}

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -27,7 +27,7 @@
     "metrics.version": "3.1.0",
     "javax.inject.version": "1",
 
-    "mongo-java-driver.version": "2.11.3",
+    "mongo-java-driver.version": "3.4.0",
     "bson4jackson.version": "2.3.1",
     "jongo.version": "1.4.0",
 

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -9,7 +9,7 @@
     "guava.version": "18.0",
     "joda-time.version": "2.3",
 
-    "jackson.version": "2.8.10",
+    "jackson.version": "2.9.5",
 
     "mustache.version": "1.8",
     "http-request.version": "5.5",

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -29,7 +29,7 @@
 
     "mongo-java-driver.version": "2.11.3",
     "bson4jackson.version": "2.3.1",
-    "jongo.version": "1.1",
+    "jongo.version": "1.4.0",
 
     "servlet-api.version": "2.5",
 

--- a/restx.build.properties.json
+++ b/restx.build.properties.json
@@ -28,7 +28,7 @@
     "javax.inject.version": "1",
 
     "mongo-java-driver.version": "3.4.0",
-    "bson4jackson.version": "2.3.1",
+    "bson4jackson.version": "2.9.0",
     "jongo.version": "1.4.0",
 
     "servlet-api.version": "2.5",


### PR DESCRIPTION
As per #285, here is a PR aiming at stabilizing dependencies kit around jongo upgrade :
- `jongo@1.1` => `jongo@1.4.0`
    Note : during `jongo@1.1` => `jongo@1.2` upgrade, it seems like `@MongoId` annotation behaviour changed concerning id generation (see https://github.com/bguerout/jongo/issues/325)
- `mongo-java-driver@2.11.3` => `mongo-java-driver@3.4.0` in order to become compatible with mongo 3.x backend
- `jackson@2.8.10` => `jackson@2.9.5` which brings some new features like `@JsonAlias`, better `null`/empty deserialization handling and `@JsonView` settable at the class level (full features presented [on jackson 2.9 blog post](https://medium.com/@cowtowncoder/jackson-2-9-features-b2a19029e9ff))
- `bson4jacksno@2.3.1` => `bson4jacksno@2.9.0` which brings a more stable (I hope) release than previous versions (we had date deserialization errors on `2.7.0` then `BsonSerializationException` on `2.8.0`, see #285)

Note that "intermediate" commits may have some classes not compiling and/or failing tests : I preferred to "tell a story" showing impacts on every version change rather than making a fat-big-commit with everything inside it.