### PR TITLE
@ExpiresAfter header being locale dependent

### DIFF
--- a/restx-core/src/main/java/restx/http/ExpiresHeaderFilter.java
+++ b/restx-core/src/main/java/restx/http/ExpiresHeaderFilter.java
@@ -41,7 +41,7 @@ public class ExpiresHeaderFilter extends EntityRelatedFilter {
 
         ExpiresAfter expiresAfterAnn = operationDescription.findAnnotation(ExpiresAfter.class).get();
 
-        Locale currentLocale = currentLocaleResolver.guessLocale(req);
+        Locale currentLocale = Locale.US;
         DateTime expirationDate = DateTime.now().plus(MorePeriods.parsePeriod(expiresAfterAnn.value(), currentLocale));
         String expiresHeaderValue = createRFC1123DateFormat(currentLocale).format(expirationDate.toDate());
 

--- a/restx-core/src/main/java/restx/http/ExpiresHeaderFilter.java
+++ b/restx-core/src/main/java/restx/http/ExpiresHeaderFilter.java
@@ -2,9 +2,8 @@ package restx.http;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
-import org.joda.time.*;
-import org.joda.time.format.PeriodFormatterBuilder;
-import org.joda.time.format.PeriodParser;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import restx.RestxRequest;
 import restx.RestxResponse;
 import restx.StdRoute;
@@ -14,20 +13,17 @@ import restx.description.OperationDescription;
 import restx.description.ResourceDescription;
 import restx.factory.Component;
 
-import javax.inject.Named;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
 @Component
 public class ExpiresHeaderFilter extends EntityRelatedFilter {
-    private CurrentLocaleResolver currentLocaleResolver;
 
-    public ExpiresHeaderFilter(@Named("CurrentLocaleResolver") CurrentLocaleResolver currentLocaleResolver) {
+    public ExpiresHeaderFilter() {
         super(Predicates.<StdRoute>alwaysTrue(), Predicates.<ResourceDescription>alwaysTrue(),
                 new OperationDescription.Matcher().havingAnyAnnotations(ExpiresAfter.class)
         );
-        this.currentLocaleResolver = currentLocaleResolver;
     }
 
     @Override


### PR DESCRIPTION
Expires headers fail when parsing if the Locale is in French so modify for being in US
fix : #294 