### PR TITLE
#316 Allow restx-factory-annotation-processor maven packaging with JDK 11

### DIFF
--- a/restx-factory-annotation-processor/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
+++ b/restx-factory-annotation-processor/src/main/java/restx/factory/processor/FactoryAnnotationProcessor.java
@@ -6,7 +6,13 @@ import com.google.common.collect.*;
 import com.google.common.io.CharStreams;
 import com.samskivert.mustache.Template;
 import restx.common.processor.RestxAbstractProcessor;
-import restx.factory.*;
+import restx.factory.Alternative;
+import restx.factory.Component;
+import restx.factory.Machine;
+import restx.factory.Module;
+import restx.factory.NamedComponent;
+import restx.factory.Provides;
+import restx.factory.When;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;


### PR DESCRIPTION
Fix #316 