### PR TITLE
#313 Restx apidocs doclet jdk11 - BREAKING

### DIFF
--- a/restx-apidocs-doclet/pom.xml
+++ b/restx-apidocs-doclet/pom.xml
@@ -16,13 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.sun.tools</groupId>
-            <artifactId>tools</artifactId>
-            <version>${java.version}</version>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
@@ -53,4 +46,24 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jdk8-tools</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../lib/tools.jar</exists>
+                </file>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun.tools</groupId>
+                    <artifactId>tools</artifactId>
+                    <version>${java.version}</version>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/restx-apidocs-doclet/src/main/java/restx/apidocs/doclet/ApidocsDoclet.java
+++ b/restx-apidocs-doclet/src/main/java/restx/apidocs/doclet/ApidocsDoclet.java
@@ -7,7 +7,6 @@ import com.google.common.io.Files;
 import com.sun.javadoc.AnnotationDesc;
 import com.sun.javadoc.AnnotationDesc.ElementValuePair;
 import com.sun.javadoc.ClassDoc;
-import com.sun.javadoc.DocErrorReporter;
 import com.sun.javadoc.Doclet;
 import com.sun.javadoc.LanguageVersion;
 import com.sun.javadoc.MethodDoc;
@@ -166,20 +165,6 @@ public class ApidocsDoclet extends Doclet {
         }
 
         return Standard.optionLength(option);
-    }
-
-    /**
-     * Processes the input options by delegating to the standard handler.
-     *
-     * _Javadoc spec requirement._
-     *
-     * @param options input option array
-     * @param errorReporter error handling
-     * @return success
-     */
-    @SuppressWarnings("UnusedDeclaration")
-    public static boolean validOptions(String[][] options, DocErrorReporter errorReporter) {
-        return Standard.validOptions(options, errorReporter);
     }
 
     static enum Options {

--- a/restx-apidocs-doclet/src/main/java/restx/apidocs/doclet/ApidocsDocletRunner.java
+++ b/restx-apidocs-doclet/src/main/java/restx/apidocs/doclet/ApidocsDocletRunner.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.Arrays.asList;
 
@@ -27,13 +28,17 @@ public class ApidocsDocletRunner {
 
 
     public void run() {
-        List<String> javadocargs = new ArrayList<>(asList(new String[] {
-                "-d", targetDir.toAbsolutePath().toString(),
-                "-doclet", "restx.apidocs.doclet.ApidocsDoclet",
-                "-restx-target-dir", targetDir.toAbsolutePath().toString(),
-                "-disable-standard-doclet",
-                "-quiet"
-        }));
+        List<String> javadocargs = new ArrayList<>();
+        String javaSpecificationVersion = System.getProperty("java.specification.version");
+
+        if (isLegacyDocletAvailable(javaSpecificationVersion)) {
+            javadocargs.addAll(asList("-d", targetDir.toAbsolutePath().toString()));
+        }
+
+        javadocargs.addAll(asList("-doclet", "restx.apidocs.doclet.ApidocsDoclet",
+                    "-restx-target-dir", targetDir.toAbsolutePath().toString(),
+                    "-disable-standard-doclet",
+                    "-quiet"));
 
         for (Path source : sources) {
             javadocargs.add(source.toAbsolutePath().toString());
@@ -46,5 +51,10 @@ public class ApidocsDocletRunner {
     public ApidocsDocletRunner addSources(Collection<Path> sources) {
         this.sources.addAll(sources);
         return this;
+    }
+
+    boolean isLegacyDocletAvailable(String javaSpecificationVersion) {
+        return Objects.nonNull(javaSpecificationVersion) && javaSpecificationVersion.startsWith("1.") ||
+                "9".equals(javaSpecificationVersion);
     }
 }

--- a/restx-apidocs-doclet/src/test/java/restx/apidocs/doclet/ApidocsDocletRunnerTest.java
+++ b/restx-apidocs-doclet/src/test/java/restx/apidocs/doclet/ApidocsDocletRunnerTest.java
@@ -1,0 +1,71 @@
+package restx.apidocs.doclet;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class ApidocsDocletRunnerTest {
+
+    @Test
+    public void should_isLegacyDocletAvailable_return_true_when_called_with_1_8() {
+        // Given
+        ApidocsDocletRunner runner = new ApidocsDocletRunner();
+        String javaSpecificationVersion = "1.8";
+
+        // When
+        boolean output = runner.isLegacyDocletAvailable(javaSpecificationVersion);
+
+        // Then
+        Assertions.assertThat(output).isTrue();
+    }
+
+    @Test
+    public void should_isLegacyDocletAvailable_return_true_when_called_with_9() {
+        // Given
+        ApidocsDocletRunner runner = new ApidocsDocletRunner();
+        String javaSpecificationVersion = "9";
+
+        // When
+        boolean output = runner.isLegacyDocletAvailable(javaSpecificationVersion);
+
+        // Then
+        Assertions.assertThat(output).isTrue();
+    }
+
+    @Test
+    public void should_isLegacyDocletAvailable_return_true_when_called_with_1_7() {
+        // Given
+        ApidocsDocletRunner runner = new ApidocsDocletRunner();
+        String javaSpecificationVersion = "1.7";
+
+        // When
+        boolean output = runner.isLegacyDocletAvailable(javaSpecificationVersion);
+
+        // Then
+        Assertions.assertThat(output).isTrue();
+    }
+
+    @Test
+    public void should_isLegacyDocletAvailable_return_true_when_called_with_11() {
+        // Given
+        ApidocsDocletRunner runner = new ApidocsDocletRunner();
+        String javaSpecificationVersion = "11";
+
+        // When
+        boolean output = runner.isLegacyDocletAvailable(javaSpecificationVersion);
+
+        // Then
+        Assertions.assertThat(output).isFalse();
+    }
+
+    @Test
+    public void should_isLegacyDocletAvailable_return_false_when_called_with_null() {
+        // Given
+        ApidocsDocletRunner runner = new ApidocsDocletRunner();
+
+        // When
+        boolean output = runner.isLegacyDocletAvailable(null);
+
+        // Then
+        Assertions.assertThat(output).isFalse();
+    }
+}

--- a/restx-core/src/test/java/restx/apidocs/doclet/ApidocsDocletTest.java
+++ b/restx-core/src/test/java/restx/apidocs/doclet/ApidocsDocletTest.java
@@ -22,7 +22,6 @@ public class ApidocsDocletTest {
     public void should_generate_notes() throws Exception {
         File target = testFolder.newFolder();
         String[] javadocargs = {
-                "-d", testFolder.newFolder().getAbsolutePath(),
                 "-doclet", "restx.apidocs.doclet.ApidocsDoclet",
                 "-restx-target-dir", target.getAbsolutePath(),
                 "-disable-standard-doclet",
@@ -54,21 +53,19 @@ public class ApidocsDocletTest {
     public void should_generate_standard_doc_by_default() throws Exception {
         File dir = testFolder.newFolder();
         String[] javadocargs = {
-                "-d", dir.getAbsolutePath(),
                 "-doclet", "restx.apidocs.doclet.ApidocsDoclet",
                 "-restx-target-dir", dir.getAbsolutePath(),
                 "src/test/resources/test/DocletTestResource.java" };
         com.sun.tools.javadoc.Main.execute(javadocargs);
 
         // should have generated standard javadoc
-        assertThat(new File(dir, "index.html")).exists();
+        assertThat(new File("index.html")).exists();
     }
 
     @Test
     public void should_be_able_to_disable_standard_doclet() throws Exception {
         File dir = testFolder.newFolder();
         String[] javadocargs = {
-                "-d", dir.getAbsolutePath(),
                 "-doclet", "restx.apidocs.doclet.ApidocsDoclet",
                 "-restx-target-dir", dir.getAbsolutePath(),
                 "-disable-standard-doclet",
@@ -83,10 +80,8 @@ public class ApidocsDocletTest {
 
     @Test
     public void should_trace_in_file_when_enabled() throws Exception {
-        File dir = testFolder.newFolder();
         File target = testFolder.newFolder();
         String[] javadocargs = {
-                "-d", dir.getAbsolutePath(),
                 "-doclet", "restx.apidocs.doclet.ApidocsDoclet",
                 "-restx-target-dir", target.getAbsolutePath(),
                 "-restx-enable-trace",


### PR DESCRIPTION
Fix #313.

For a jdk8 user, the only breaking change is the removal of `ApidocsDoclet.validOptions()` from the public API. This method is removed in jdk10 and the new javdoc tool does not have the same options.

Care has been taken to reduce the impact for a jdk9- user by keeping the `-d` flag because it's available but it looks to be removed for the new javadoc tool and a condition had to be set in place to make it work at runtime for jdk11.

Not sure if this solution is convenient for the maintainers, I'm open for improvements and rewrites if some parts are seen as good for merge.