### PR TITLE
#312 restx-samplest test fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <junit.toolbox.version>2.3</junit.toolbox.version>
         <assertj-core.version>1.6.0</assertj-core.version>
         <maven-verifier.version>1.4</maven-verifier.version>
-        <mockito.version>1.9.5</mockito.version>
+        <mockito.version>3.3.3</mockito.version>
 
         <!-- Plugins -->
         <maven.javadoc.plugin.version>3.2.0</maven.javadoc.plugin.version>
@@ -457,7 +457,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
             </dependency>
             <dependency>

--- a/restx-jongo-specs-tests/pom.xml
+++ b/restx-jongo-specs-tests/pom.xml
@@ -28,6 +28,15 @@
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/EmbedMongoClientPool.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/EmbedMongoClientPool.java
@@ -1,0 +1,64 @@
+package restx.jongo.specs.tests;
+
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodProcess;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashSet;
+import java.util.Set;
+
+class EmbedMongoClientPool {
+
+    private final Set<Object> clients = new HashSet<>();
+
+    private final MongodExecutable executable;
+    private final Object lock = new Object();
+    private MongodProcess process;
+    private boolean isStarted;
+
+    EmbedMongoClientPool(MongodExecutable executable) {
+        this.executable = executable;
+    }
+
+    void checkIn(Object client) {
+        synchronized (lock) {
+            doCheckIn(client);
+        }
+    }
+
+    private void doCheckIn(Object client) {
+        if (!isStarted) {
+            tryStartExecutable();
+        }
+        clients.add(client);
+    }
+
+    private void tryStartExecutable() {
+        try {
+            process = executable.start();
+            isStarted = true;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    boolean isCheckedIn(Object object) {
+        return clients.contains(object);
+    }
+
+    void checkOut(Object client) {
+        synchronized (lock) {
+            doCheckOut(client);
+        }
+    }
+
+    private void doCheckOut(Object client) {
+        clients.remove(client);
+        if (clients.isEmpty()) {
+            process.stop();
+            executable.stop();
+            isStarted = false;
+        }
+    }
+}

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/EmbedMongoFactory.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/EmbedMongoFactory.java
@@ -1,0 +1,77 @@
+package restx.jongo.specs.tests;
+
+import com.mongodb.MongoClientURI;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.runtime.Network;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+class EmbedMongoFactory {
+
+    private static final Map<Version.Main, PoolKey> keys = new ConcurrentHashMap<>();
+    private static final Map<PoolKey, EmbedMongoClientPool> pools = new ConcurrentHashMap<>();
+
+    private static synchronized void newPoolKey(Version.Main version) throws IOException {
+        if (Objects.isNull(keys.get(version))) {
+            InetAddress addr = Network.getLocalHost();
+            int port = Network.getFreeServerPort(addr);
+            String uri = "mongodb://" + addr.getHostName() + ":" + port;
+
+            MongoClientURI mongoClientURI = new MongoClientURI(uri);
+            PoolKey key = new PoolKey(version, mongoClientURI);
+            keys.put(version, key);
+        }
+    }
+
+    PoolKey getPoolKey(Version.Main version) throws IOException {
+        if (Objects.isNull(keys.get(version))) {
+            newPoolKey(version);
+        }
+        return keys.get(version);
+    }
+
+    synchronized EmbedMongoClientPool getEmbedMongoClientPool(MongodStarter starter, PoolKey key) {
+        EmbedMongoClientPool pool = pools.get(key);
+
+        if (Objects.nonNull(pool)) {
+            return pool;
+        }
+
+        return newPool(starter, key);
+    }
+
+    private EmbedMongoClientPool newPool(MongodStarter starter, PoolKey key) {
+        try {
+            MongodExecutable executable = prepareExecutable(starter, key);
+            EmbedMongoClientPool pool = new EmbedMongoClientPool(executable);
+            pools.put(key, pool);
+            return pool;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private MongodExecutable prepareExecutable(MongodStarter starter, PoolKey key)
+            throws IOException {
+
+        int port = Integer.parseInt(key.getUri().getURI().split(":")[2]);
+        Net net = new Net(port, false);
+
+        IMongodConfig config = new MongodConfigBuilder()
+                .version(key.getVersion())
+                .net(net)
+                .build();
+
+        return starter.prepare(config);
+    }
+}

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/MongoEmbedRule.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/MongoEmbedRule.java
@@ -5,7 +5,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
 
 import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.distribution.Version;

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/MongoEmbedRule.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/MongoEmbedRule.java
@@ -1,24 +1,15 @@
 package restx.jongo.specs.tests;
 
-import java.io.IOException;
-import java.net.InetAddress;
-
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import restx.mongo.MongoModule;
-
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 
-import de.flapdoodle.embed.mongo.MongodExecutable;
-import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
-import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.runtime.Network;
+import restx.mongo.MongoModule;
 
 /**
  * Rule which allows per JVM process : 
@@ -32,26 +23,10 @@ import de.flapdoodle.embed.process.runtime.Network;
 public class MongoEmbedRule implements TestRule {
 
 	// Download / extract mongodb once.
-	private static MongodStarter runtime = MongodStarter.getDefaultInstance();
+	private static final MongodStarter runtime = MongodStarter.getDefaultInstance();
 
-	// Determine uri mongodb connection once
-	private static MongoClientURI mongoClientURI;
-
-	static {
-		try {
-			InetAddress addr = Network.getLocalHost();
-			int port = Network.getFreeServerPort(addr);
-			mongoClientURI = new MongoClientURI(new StringBuilder("mongodb://")
-					.append(addr.getHostName()).append(":").append(port)
-					.toString());
-			System.setProperty(MongoModule.MONGO_URI, mongoClientURI.getURI());
-		} catch (IOException ioe) {
-			throw new RuntimeException(ioe);
-		}
-	}
-	
-
-	private Version.Main mongoVersion;
+	private final EmbedMongoFactory factory;
+	private final Version.Main mongoVersion;
 
 	public MongoEmbedRule() {
 		this(Version.Main.PRODUCTION);
@@ -59,6 +34,7 @@ public class MongoEmbedRule implements TestRule {
 
 	public MongoEmbedRule(Version.Main mongoVersion) {
 		this.mongoVersion = mongoVersion;
+		this.factory = new EmbedMongoFactory();
 	}
 
 	@Override
@@ -67,20 +43,16 @@ public class MongoEmbedRule implements TestRule {
 
 			@Override
 			public void evaluate() throws Throwable {
-				MongodExecutable _mongodExe = runtime
-						.prepare(new MongodConfigBuilder()
-								.version(mongoVersion)
-								.net(new Net(Integer.parseInt(mongoClientURI
-										.getURI().split(":")[2]), false))
-								.build());
-				MongodProcess _mongod = _mongodExe.start();
-				MongoClient mongoClient = new MongoClient(mongoClientURI);
+				PoolKey key = factory.getPoolKey(mongoVersion);
+				System.setProperty(MongoModule.MONGO_URI, key.getUri().getURI());
+				EmbedMongoClientPool pool = factory.getEmbedMongoClientPool(runtime, key);
+				pool.checkIn(this);
+				MongoClient mongoClient = new MongoClient(key.getUri());
 
 				base.evaluate();
 
 				mongoClient.close();
-				_mongod.stop();
-				_mongodExe.stop();
+				pool.checkOut(this);
 			}
 		};
 	}

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/MongoRestxSpecTestsListener.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/MongoRestxSpecTestsListener.java
@@ -24,7 +24,7 @@ public final class MongoRestxSpecTestsListener extends RunListener implements Cl
     }
 
     @Override
-    public void testRunStarted(Description description) throws Exception {
+    public void testRunStarted(Description description) {
         Version.Main version = Version.Main.PRODUCTION;
         PoolKey key = factory.getPoolKey(version);
         System.setProperty(MongoModule.MONGO_URI, key.getUri().getURI());

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/MongoRestxSpecTestsListener.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/MongoRestxSpecTestsListener.java
@@ -1,0 +1,48 @@
+package restx.jongo.specs.tests;
+
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
+import restx.mongo.MongoModule;
+
+import java.io.Closeable;
+import java.util.Objects;
+
+public final class MongoRestxSpecTestsListener extends RunListener implements Closeable {
+
+    private final EmbedMongoFactory factory;
+    private EmbedMongoClientPool pool;
+
+    public MongoRestxSpecTestsListener() {
+        this.factory = new EmbedMongoFactory();
+    }
+
+    MongoRestxSpecTestsListener(EmbedMongoFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public void testRunStarted(Description description) throws Exception {
+        Version.Main version = Version.Main.PRODUCTION;
+        PoolKey key = factory.getPoolKey(version);
+        System.setProperty(MongoModule.MONGO_URI, key.getUri().getURI());
+        MongodStarter starter = MongodStarter.getDefaultInstance();
+        pool = factory.getEmbedMongoClientPool(starter, key);
+        pool.checkIn(this);
+    }
+
+    @Override
+    public void testRunFinished(Result result) {
+        close();
+    }
+
+    @Override
+    public void close() {
+        System.clearProperty(MongoModule.MONGO_URI);
+        if (Objects.nonNull(pool)) {
+            pool.checkOut(this);
+        }
+    }
+}

--- a/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/PoolKey.java
+++ b/restx-jongo-specs-tests/src/main/java/restx/jongo/specs/tests/PoolKey.java
@@ -1,0 +1,39 @@
+package restx.jongo.specs.tests;
+
+import com.mongodb.MongoClientURI;
+import de.flapdoodle.embed.mongo.distribution.Version;
+
+import java.util.Objects;
+
+class PoolKey {
+
+    private final Version.Main version;
+    private final MongoClientURI uri;
+
+    PoolKey(Version.Main version, MongoClientURI uri) {
+        this.version = version;
+        this.uri = uri;
+    }
+
+    public Version.Main getVersion() {
+        return version;
+    }
+
+    public MongoClientURI getUri() {
+        return uri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PoolKey poolKey = (PoolKey) o;
+        return version == poolKey.version &&
+                Objects.equals(uri, poolKey.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, uri);
+    }
+}

--- a/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/EmbedMongoClientPoolTest.java
+++ b/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/EmbedMongoClientPoolTest.java
@@ -1,0 +1,158 @@
+package restx.jongo.specs.tests;
+
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodProcess;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class EmbedMongoClientPoolTest {
+
+    @Test
+    public void should_checkIn_subscribe_object_reference_in_client_pool() {
+        // Given
+        MongodExecutable executable = mock(MongodExecutable.class);
+        EmbedMongoClientPool pool = new EmbedMongoClientPool(executable);
+
+        Object client = new Object();
+
+        // When
+        pool.checkIn(client);
+
+        // Then
+        boolean output = pool.isCheckedIn(client);
+        assertThat(output).isTrue();
+    }
+
+    @Test
+    public void should_checkIn_start_mongo_executable_after_first_checkIn() throws IOException {
+        // Given
+        MongodExecutable executable = mock(MongodExecutable.class);
+        EmbedMongoClientPool pool = new EmbedMongoClientPool(executable);
+
+        Object client = new Object();
+
+        // When
+        pool.checkIn(client);
+
+        // Then
+        verify(executable).start();
+    }
+
+    @Test
+    public void should_checkIn_not_start_mongo_executable_after_second_checkIn() throws IOException {
+        // Given
+        MongodExecutable executable = mock(MongodExecutable.class);
+        EmbedMongoClientPool pool = new EmbedMongoClientPool(executable);
+
+        Object firstClient = new Object();
+        Object secondClient = new Object();
+
+        // When
+        pool.checkIn(firstClient);
+        pool.checkIn(secondClient);
+
+        // Then
+        verify(executable).start();
+    }
+
+    @Test
+    public void should_checkOut_remove_client_from_pool() throws IOException {
+        // Given
+        MongodExecutable executable = newMongodExecutable();
+        EmbedMongoClientPool pool = new EmbedMongoClientPool(executable);
+
+        Object client = new Object();
+        pool.checkIn(client);
+
+        // When
+        pool.checkOut(client);
+
+        // Then
+        boolean output = pool.isCheckedIn(client);
+        assertThat(output).isFalse();
+    }
+
+    @Test
+    public void should_checkOut_stop_mongo_executable_after_last_checkout() throws IOException {
+        // Given
+        MongodExecutable executable = newMongodExecutable();
+        EmbedMongoClientPool pool = new EmbedMongoClientPool(executable);
+
+        Object client = new Object();
+        pool.checkIn(client);
+
+        // When
+        pool.checkOut(client);
+
+        // Then
+        verify(executable).stop();
+    }
+
+    @Test
+    public void should_checkOut_not_stop_mongo_executable_when_other_clients_are_in_the_pool() throws IOException {
+        // Given
+        MongodExecutable executable = newMongodExecutable();
+        EmbedMongoClientPool pool = new EmbedMongoClientPool(executable);
+
+        Object firstClient = new Object();
+        pool.checkIn(firstClient);
+
+        Object secondClient = new Object();
+        pool.checkIn(secondClient);
+
+        int expectedNumberOfInvocations = 0;
+
+        // When
+        pool.checkOut(firstClient);
+
+        // Then
+        verify(executable, times(expectedNumberOfInvocations)).stop();
+    }
+
+    private MongodExecutable newMongodExecutable() throws IOException {
+        MongodExecutable executable = mock(MongodExecutable.class);
+        when(executable.start()).thenReturn(mock(MongodProcess.class));
+        return executable;
+    }
+
+    @Test
+    public void should_checkOut_stop_mongo_process_after_last_checkout() throws IOException {
+        // Given
+        MongodProcess process = mock(MongodProcess.class);
+
+        MongodExecutable executable = mock(MongodExecutable.class);
+        when(executable.start()).thenReturn(process);
+
+        EmbedMongoClientPool pool = new EmbedMongoClientPool(executable);
+
+        Object client = new Object();
+        pool.checkIn(client);
+
+        // When
+        pool.checkOut(client);
+
+        // Then
+        verify(process).stop();
+    }
+
+    @Test
+    public void should_checkIn_start_again_database_when_stopped_after_checkOut() throws IOException {
+        // Given
+        MongodExecutable executable = newMongodExecutable();
+        EmbedMongoClientPool pool = new EmbedMongoClientPool(executable);
+
+        Object client = new Object();
+
+        // When
+        pool.checkIn(client);
+        pool.checkOut(client);
+        pool.checkIn(client);
+
+        // Then
+        verify(executable, times(2)).start();
+    }
+}

--- a/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/EmbedMongoFactoryTest.java
+++ b/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/EmbedMongoFactoryTest.java
@@ -1,0 +1,93 @@
+package restx.jongo.specs.tests;
+
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EmbedMongoFactoryTest {
+
+    @Test
+    public void should_getPoolKey_return_the_same_instance_when_called_twice_with_same_version() throws IOException {
+        // Given
+        Version.Main version = Version.Main.PRODUCTION;
+
+        EmbedMongoFactory factory = new EmbedMongoFactory();
+        PoolKey expectedOutput = factory.getPoolKey(version);
+
+        EmbedMongoFactory anotherFactory = new EmbedMongoFactory();
+
+        // When
+        PoolKey output = anotherFactory.getPoolKey(version);
+
+        // Then
+        assertThat(output).isSameAs(expectedOutput);
+    }
+
+    @Test
+    public void should_getPoolKey_return_the_different_uri_when_called_twice_with_different_version() throws IOException {
+        // Given
+        Version.Main production = Version.Main.PRODUCTION;
+
+        EmbedMongoFactory factory = new EmbedMongoFactory();
+        PoolKey unexpectedOutput = factory.getPoolKey(production);
+
+        Version.Main olderVersion = Version.Main.V3_4;
+        EmbedMongoFactory anotherFactory = new EmbedMongoFactory();
+
+        // When
+        PoolKey output = anotherFactory.getPoolKey(olderVersion);
+
+        // Then
+        assertThat(output).isNotSameAs(unexpectedOutput);
+    }
+
+    @Test
+    public void should_getEmbedMongoClientPool_return_the_same_instance_when_called_with_same_param_MongodExecutable()
+            throws IOException {
+
+        // Given
+        EmbedMongoFactory factory = new EmbedMongoFactory();
+
+        MongodStarter starter = MongodStarter.getDefaultInstance();
+        Version.Main version = Version.Main.PRODUCTION;
+        PoolKey key = factory.getPoolKey(version);
+
+        EmbedMongoClientPool expectedOutput = factory.getEmbedMongoClientPool(starter, key);
+
+        EmbedMongoFactory anotherFactory = new EmbedMongoFactory();
+
+        // When
+        EmbedMongoClientPool output = anotherFactory.getEmbedMongoClientPool(starter, key);
+
+        // Then
+        assertThat(output).isSameAs(expectedOutput);
+    }
+
+    @Test
+    public void should_getEmbedMongoClientPool_return_the_different_instance_when_called_with_different_key()
+            throws IOException {
+
+        // Given
+        EmbedMongoFactory factory = new EmbedMongoFactory();
+
+        MongodStarter starter = MongodStarter.getDefaultInstance();
+        Version.Main version = Version.Main.PRODUCTION;
+        PoolKey key = factory.getPoolKey(version);
+
+        EmbedMongoClientPool unexpectedOutput = factory.getEmbedMongoClientPool(starter, key);
+
+        EmbedMongoFactory anotherFactory = new EmbedMongoFactory();
+        Version.Main anotherVersion = Version.Main.V3_4;
+        PoolKey anotherKey = factory.getPoolKey(anotherVersion);
+
+        // When
+        EmbedMongoClientPool output = anotherFactory.getEmbedMongoClientPool(starter, anotherKey);
+
+        // Then
+        assertThat(output).isNotSameAs(unexpectedOutput);
+    }
+}

--- a/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/EmbedMongoFactoryTest.java
+++ b/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/EmbedMongoFactoryTest.java
@@ -4,14 +4,12 @@ import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import org.junit.Test;
 
-import java.io.IOException;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EmbedMongoFactoryTest {
 
     @Test
-    public void should_getPoolKey_return_the_same_instance_when_called_twice_with_same_version() throws IOException {
+    public void should_getPoolKey_return_the_same_instance_when_called_twice_with_same_version() {
         // Given
         Version.Main version = Version.Main.PRODUCTION;
 
@@ -28,7 +26,7 @@ public class EmbedMongoFactoryTest {
     }
 
     @Test
-    public void should_getPoolKey_return_the_different_uri_when_called_twice_with_different_version() throws IOException {
+    public void should_getPoolKey_return_the_different_uri_when_called_twice_with_different_version() {
         // Given
         Version.Main production = Version.Main.PRODUCTION;
 
@@ -46,8 +44,7 @@ public class EmbedMongoFactoryTest {
     }
 
     @Test
-    public void should_getEmbedMongoClientPool_return_the_same_instance_when_called_with_same_param_MongodExecutable()
-            throws IOException {
+    public void should_getEmbedMongoClientPool_return_the_same_instance_when_called_with_same_param_MongodExecutable() {
 
         // Given
         EmbedMongoFactory factory = new EmbedMongoFactory();
@@ -68,8 +65,7 @@ public class EmbedMongoFactoryTest {
     }
 
     @Test
-    public void should_getEmbedMongoClientPool_return_the_different_instance_when_called_with_different_key()
-            throws IOException {
+    public void should_getEmbedMongoClientPool_return_the_different_instance_when_called_with_different_key() {
 
         // Given
         EmbedMongoFactory factory = new EmbedMongoFactory();

--- a/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/MongoRestxSpecTestsListenerTest.java
+++ b/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/MongoRestxSpecTestsListenerTest.java
@@ -1,0 +1,144 @@
+package restx.jongo.specs.tests;
+
+import com.mongodb.MongoClientURI;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
+import restx.mongo.MongoModule;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class MongoRestxSpecTestsListenerTest {
+
+    @Test
+    public void should_testRunStarted_be_instance_of_RunListener() {
+        // Given
+        // When
+        try (MongoRestxSpecTestsListener output = new MongoRestxSpecTestsListener()) {
+            // Then
+            assertThat(output).isInstanceOf(RunListener.class);
+        }
+    }
+
+    @Test
+    public void should_testRunStarted_set_mongo_uri_property() throws Exception {
+        // Given
+        try (MongoRestxSpecTestsListener listener = new MongoRestxSpecTestsListener()) {
+            Description description = mock(Description.class);
+            String mongoUriKey = MongoModule.MONGO_URI;
+
+            // When
+            listener.testRunStarted(description);
+
+            // Then
+            String output = System.getProperty(mongoUriKey);
+            assertThat(output).isNotNull();
+        }
+    }
+
+    @Test
+    public void should_testRunStarted_prepare_a_mongod_executable() throws Exception {
+        // Given
+        EmbedMongoClientPool pool = mock(EmbedMongoClientPool.class);
+        EmbedMongoFactory factory = newEmbedMongoFactory(pool);
+        try (MongoRestxSpecTestsListener listener = new MongoRestxSpecTestsListener(factory)) {
+            Description description = mock(Description.class);
+
+            // When
+            listener.testRunStarted(description);
+
+            // Then
+            verify(factory).getEmbedMongoClientPool(any(MongodStarter.class), any(PoolKey.class));
+        }
+    }
+
+    @Test
+    public void should_testRunStarted_checkin_the_pool() throws Exception {
+        // Given
+        EmbedMongoClientPool pool = mock(EmbedMongoClientPool.class);
+
+        EmbedMongoFactory factory = newEmbedMongoFactory(pool);
+
+        try (MongoRestxSpecTestsListener listener = new MongoRestxSpecTestsListener(factory)) {
+            Description description = mock(Description.class);
+
+            // When
+            listener.testRunStarted(description);
+
+            // Then
+            verify(pool).checkIn(listener);
+        }
+    }
+
+    private EmbedMongoFactory newEmbedMongoFactory(EmbedMongoClientPool pool) throws IOException {
+        MongoClientURI mongoClientURI = mock(MongoClientURI.class);
+        when(mongoClientURI.getURI()).thenReturn("mongodb://localhost:21017");
+
+        PoolKey key = mock(PoolKey.class);
+        when(key.getUri()).thenReturn(mongoClientURI);
+        when(key.getVersion()).thenReturn(Version.Main.PRODUCTION);
+
+        EmbedMongoFactory factory = mock(EmbedMongoFactory.class);
+        when(factory.getPoolKey(Version.Main.PRODUCTION)).thenReturn(key);
+        when(factory.getEmbedMongoClientPool(any(MongodStarter.class), eq(key))).thenReturn(pool);
+        return factory;
+    }
+
+    @Test
+    public void should_close_unset_mongo_uri_property() {
+        // Given
+        MongoRestxSpecTestsListener listener = new MongoRestxSpecTestsListener();
+
+        String mongoUriKey = MongoModule.MONGO_URI;
+        System.setProperty(mongoUriKey, "a_mongo_uri");
+
+        // When
+        listener.close();
+
+        // Then
+        String output = System.getProperty(mongoUriKey);
+        assertThat(output).isNull();
+    }
+
+    @Test
+    public void should_close_checkout_from_pool() throws Exception {
+        // Given
+        EmbedMongoClientPool pool = mock(EmbedMongoClientPool.class);
+
+        EmbedMongoFactory factory = newEmbedMongoFactory(pool);
+
+        MongoRestxSpecTestsListener listener = new MongoRestxSpecTestsListener(factory);
+        listener.testRunStarted(mock(Description.class));
+
+        // When
+        listener.close();
+
+        // Then
+        verify(pool).checkOut(listener);
+    }
+
+    @Test
+    public void should_testRunFinished_checkout_from_pool() throws Exception {
+        // Given
+        EmbedMongoClientPool pool = mock(EmbedMongoClientPool.class);
+
+        EmbedMongoFactory factory = newEmbedMongoFactory(pool);
+
+        MongoRestxSpecTestsListener listener = new MongoRestxSpecTestsListener(factory);
+        listener.testRunStarted(mock(Description.class));
+
+        Result result = mock(Result.class);
+
+        // When
+        listener.testRunFinished(result);
+
+        // Then
+        verify(pool).checkOut(listener);
+    }
+}

--- a/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/MongoRestxSpecTestsListenerTest.java
+++ b/restx-jongo-specs-tests/src/test/java/restx/jongo/specs/tests/MongoRestxSpecTestsListenerTest.java
@@ -9,8 +9,6 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.RunListener;
 import restx.mongo.MongoModule;
 
-import java.io.IOException;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -27,7 +25,7 @@ public class MongoRestxSpecTestsListenerTest {
     }
 
     @Test
-    public void should_testRunStarted_set_mongo_uri_property() throws Exception {
+    public void should_testRunStarted_set_mongo_uri_property() {
         // Given
         try (MongoRestxSpecTestsListener listener = new MongoRestxSpecTestsListener()) {
             Description description = mock(Description.class);
@@ -43,7 +41,7 @@ public class MongoRestxSpecTestsListenerTest {
     }
 
     @Test
-    public void should_testRunStarted_prepare_a_mongod_executable() throws Exception {
+    public void should_testRunStarted_prepare_a_mongod_executable() {
         // Given
         EmbedMongoClientPool pool = mock(EmbedMongoClientPool.class);
         EmbedMongoFactory factory = newEmbedMongoFactory(pool);
@@ -59,7 +57,7 @@ public class MongoRestxSpecTestsListenerTest {
     }
 
     @Test
-    public void should_testRunStarted_checkin_the_pool() throws Exception {
+    public void should_testRunStarted_checkin_the_pool() {
         // Given
         EmbedMongoClientPool pool = mock(EmbedMongoClientPool.class);
 
@@ -76,7 +74,7 @@ public class MongoRestxSpecTestsListenerTest {
         }
     }
 
-    private EmbedMongoFactory newEmbedMongoFactory(EmbedMongoClientPool pool) throws IOException {
+    private EmbedMongoFactory newEmbedMongoFactory(EmbedMongoClientPool pool) {
         MongoClientURI mongoClientURI = mock(MongoClientURI.class);
         when(mongoClientURI.getURI()).thenReturn("mongodb://localhost:21017");
 
@@ -107,7 +105,7 @@ public class MongoRestxSpecTestsListenerTest {
     }
 
     @Test
-    public void should_close_checkout_from_pool() throws Exception {
+    public void should_close_checkout_from_pool() {
         // Given
         EmbedMongoClientPool pool = mock(EmbedMongoClientPool.class);
 
@@ -124,7 +122,7 @@ public class MongoRestxSpecTestsListenerTest {
     }
 
     @Test
-    public void should_testRunFinished_checkout_from_pool() throws Exception {
+    public void should_testRunFinished_checkout_from_pool() {
         // Given
         EmbedMongoClientPool pool = mock(EmbedMongoClientPool.class);
 

--- a/restx-jongo-specs-tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/restx-jongo-specs-tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+

--- a/restx-samplest/pom.xml
+++ b/restx-samplest/pom.xml
@@ -134,6 +134,18 @@
                     <additionalparam>-restx-target-dir ${project.basedir}/target/classes</additionalparam>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>restx.jongo.specs.tests.MongoRestxSpecTestsListener</value>
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
             <!-- Uncomment to debug annotation processing on samplest...
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/restx-samplest/src/test/java/samplest/autostartable/AutoStartableTest.java
+++ b/restx-samplest/src/test/java/samplest/autostartable/AutoStartableTest.java
@@ -17,6 +17,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AutoStartableTest {
     @Test
     public void should_handle_auto_startable_in_dev_mode() throws Exception {
+        int started = AutoStartableTestComponent.getStarted() + 1;
+        int closed = AutoStartableTestComponent.getClosed();
+        int instantiated = AutoStartableTestComponent.getInstanciated() + 1;
+
         Factory.LocalMachines.threadLocal().addMachine(
                 new SingletonFactoryMachine<>(-1000, NamedComponent.of(String.class, "restx.mode", "dev")));
 
@@ -29,16 +33,18 @@ public class AutoStartableTest {
                 HttpRequest httpRequest = client.GET("/api/autostartable/test");
                 assertThat(httpRequest.code()).isEqualTo(200);
                 assertThat(httpRequest.body().trim()).isEqualTo(
-                        "called: 1 - autostartable: called: 1 started: 1 closed: 0 instanciated: 1" +
-                                " serverId: "+server.getServerId()+" baseUrl: "+server.baseUrl()+" routerPresent: true");
+                        "called: 1 - autostartable: called: 1 started: " + started + " closed: " + closed +
+                                " instanciated: " + instantiated + " serverId: " + server.getServerId() + " baseUrl: " +
+                                server.baseUrl() + " routerPresent: true");
 
                 httpRequest = client.GET("/api/autostartable/test");
                 assertThat(httpRequest.code()).isEqualTo(200);
                 // called should be only one in test mode, components are dropped at each request
                 // but autostartable should be reused
                 assertThat(httpRequest.body().trim()).isEqualTo(
-                        "called: 1 - autostartable: called: 2 started: 1 closed: 0 instanciated: 1" +
-                                " serverId: "+server.getServerId()+" baseUrl: "+server.baseUrl()+" routerPresent: true");
+                        "called: 1 - autostartable: called: 2 started: " + started + " closed: " + closed +
+                                " instanciated: " + instantiated + " serverId: " + server.getServerId() + " baseUrl: " +
+                                server.baseUrl() + " routerPresent: true");
             } finally {
                 server.stop();
             }

--- a/restx-server-simple/pom.xml
+++ b/restx-server-simple/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix #312 

These changes fix an `mvn verify` failure on `restx-parent`. Moving some tests under `MongoRestxSpecTestsRunner.class` is not the most efficient thing but it has the advantage to make tests pass and allow contributors to focus on other issues. Should an issue be created regarding this `RestxSpecTestsRunner` & `MongoRestxSpecTestsRunner` thing ?