### PR TITLE
#322 Implementing a continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk8
+  - openjdk11
+install:
+  - /bin/true
+script:
+  - mvn clean verify -B

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RESTX - the lightweight Java REST framework
 
-[![Build Status](https://drone.io/github.com/restx/restx/status.png)](https://drone.io/github.com/restx/restx/latest)
+[![Build Status](https://travis-ci.org/restx/restx.svg?branch=master)](https://travis-ci.org/restx/restx)
 
 RESTX is a full lightweight disrupting stack, which includes Swagger-like ui & considers REST specs tests as docs.
 


### PR DESCRIPTION
Fix #322 

Add a continuous integration executing a `mvn verify` (validates compilation, unit tests, integration tests) for java 8 (passing at this point) and java 11 (failing at this point).

Build is launched after each pushed commit and each pull request.

The build badge and link has been changed to point on Travis CI.