### PR TITLE
Specify Target to use FixedPrecision in fields and records

### DIFF
--- a/restx-jongo/src/main/java/restx/jackson/FixedPrecision.java
+++ b/restx-jongo/src/main/java/restx/jackson/FixedPrecision.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -15,7 +17,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Retention(RUNTIME)
 @JacksonAnnotationsInside
-
+@Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
 @JsonSerialize(using = FixedPrecisionSerializer.class)
 @JsonDeserialize(using = FixedPrecisionDeserializer.class)
 public @interface FixedPrecision {


### PR DESCRIPTION
I have tried to use the FixedPrecision annotation on records fields but Jackson would not allow it, because the annotation is not specified to target records. In this PR, Target is added to keep allowing the annotation on fields and to allow it in records.